### PR TITLE
Use WM_SIZE_HINTS when available to set the geometry of floating windows

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -428,6 +428,17 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
     if (cwindow->dock)
         want_floating = false;
 
+    /* Plasma windows set their geometry in WM_SIZE_HINTS. */
+    if ((wm_size_hints.width > 0) && (wm_size_hints.height > 0))
+    {
+      DLOG("We are setting geometry according to wm_size_hints x=%d y=%d w=%d h=%d\n",
+           wm_size_hints.x, wm_size_hints.y, wm_size_hints.width, wm_size_hints.height);
+      geom->x = wm_size_hints.x;
+      geom->y = wm_size_hints.y;
+      geom->width = wm_size_hints.width;
+      geom->height = wm_size_hints.height;
+    }
+
     /* Store the requested geometry. The width/height gets raised to at least
      * 75x50 when entering floating mode, which is the minimum size for a
      * window to be useful (smaller windows are usually overlays/toolbars/…


### PR DESCRIPTION
This helps a lot when using i3 with KDE/Plasma 5.2 since the intended location of the panel windows is stored in WM_SIZE_HINTS. Without it, the panel windows end up centered in the screen.