### PR TITLE
Change iconify request to move window to scratchpad.

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -799,8 +799,8 @@ static void handle_client_message(xcb_client_message_event_t *event) {
             /* this request is so we can play some animiation showing the
              * window physically moving to the tray before we close it (I
              * think) */
-            DLOG("Client has requested iconic state. Closing this con. (con = %p)\n", con);
-            tree_close(con, DONT_KILL_WINDOW, false, false);
+            DLOG("Client has requested iconic state. Moving this con to scratchpad. (con = %p)\n", con);
+            scratchpad_move(con);
             tree_render();
         } else {
             DLOG("Not handling WM_CHANGE_STATE request. (window = %d, state = %d)\n", event->window, event->data.data32[0]);


### PR DESCRIPTION
By default the X11 version of Emacs maps key press Ctrl-z (suspend-frame) to iconify the window. In i3 it can be rather destructive pressing this by accident. Sending the window to the scratchpad on the other hand is extremely useful and consistent with the intent. In this case it can be scripted within Emacs lisp too. Presumably this functionality may be equally useful in other applications.