### PR TITLE
Make click events on status blocks work if 'workspace_buttons no' is set...

### DIFF
--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -520,33 +520,35 @@ void child_click_events_key(const char *key) {
  *
  */
 void send_block_clicked(int button, const char *name, const char *instance, int x, int y) {
-    if (child.click_events) {
-        child_click_events_initialize();
-
-        yajl_gen_map_open(gen);
-
-        if (name) {
-            child_click_events_key("name");
-            yajl_gen_string(gen, (const unsigned char *)name, strlen(name));
-        }
-
-        if (instance) {
-            child_click_events_key("instance");
-            yajl_gen_string(gen, (const unsigned char *)instance, strlen(instance));
-        }
-
-        child_click_events_key("button");
-        yajl_gen_integer(gen, button);
-
-        child_click_events_key("x");
-        yajl_gen_integer(gen, x);
-
-        child_click_events_key("y");
-        yajl_gen_integer(gen, y);
-
-        yajl_gen_map_close(gen);
-        child_write_output();
+    if (!child.click_events) {
+        return;
     }
+
+    child_click_events_initialize();
+
+    yajl_gen_map_open(gen);
+
+    if (name) {
+        child_click_events_key("name");
+        yajl_gen_string(gen, (const unsigned char *)name, strlen(name));
+    }
+
+    if (instance) {
+        child_click_events_key("instance");
+        yajl_gen_string(gen, (const unsigned char *)instance, strlen(instance));
+    }
+
+    child_click_events_key("button");
+    yajl_gen_integer(gen, button);
+
+    child_click_events_key("x");
+    yajl_gen_integer(gen, x);
+
+    child_click_events_key("y");
+    yajl_gen_integer(gen, y);
+
+    yajl_gen_map_close(gen);
+    child_write_output();
 }
 
 /*

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -314,18 +314,6 @@ void handle_button(xcb_button_press_event_t *event) {
         return;
     }
 
-    /* TODO: Move this to extern get_ws_for_output() */
-    TAILQ_FOREACH (cur_ws, walk->workspaces, tailq) {
-        if (cur_ws->visible) {
-            break;
-        }
-    }
-
-    if (cur_ws == NULL) {
-        DLOG("No Workspace active?\n");
-        return;
-    }
-
     int32_t x = event->event_x >= 0 ? event->event_x : 0;
     int32_t original_x = x;
 
@@ -362,6 +350,18 @@ void handle_button(xcb_button_press_event_t *event) {
             }
         }
         x = original_x;
+    }
+
+    /* TODO: Move this to extern get_ws_for_output() */
+    TAILQ_FOREACH (cur_ws, walk->workspaces, tailq) {
+        if (cur_ws->visible) {
+            break;
+        }
+    }
+
+    if (cur_ws == NULL) {
+        DLOG("No Workspace active?\n");
+        return;
     }
 
     switch (event->detail) {
@@ -1460,10 +1460,8 @@ void reconfig_windows(bool redraw_bars) {
              * BUTTON_PRESS, to handle clicks on the workspace buttons
              * */
             values[2] = XCB_EVENT_MASK_EXPOSURE |
-                        XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT;
-            if (!config.disable_ws) {
-                values[2] |= XCB_EVENT_MASK_BUTTON_PRESS;
-            }
+                        XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT |
+                        XCB_EVENT_MASK_BUTTON_PRESS;
             xcb_void_cookie_t win_cookie = xcb_create_window_checked(xcb_connection,
                                                                      root_screen->root_depth,
                                                                      walk->bar,


### PR DESCRIPTION
....

1. Always subscribe to click events for i3bar.
2. Exit the click event handler if no current workspace was found only after clicks on status blocks have been handled.

fixes #1430