### PR TITLE
Docs: Update ipc library list

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -808,18 +808,10 @@ know):
 
 C::
 	* i3 includes a headerfile +i3/ipc.h+ which provides you all constants.
-	* https://github.com/acrisci/i3ipc-glib
+	* https://github.com/acrisci/i3ipc-glib - provides bindings to many languages with its https://wiki.gnome.org/Projects/GObjectIntrospection/Users[GOjbect Introspection] library.
 Go::
 	* https://github.com/proxypoke/i3ipc
-JavaScript::
-	* https://github.com/acrisci/i3ipc-gjs
-Lua::
-	* https://github.com/acrisci/i3ipc-lua
 Perl::
 	* https://metacpan.org/module/AnyEvent::I3
 Python::
 	* https://github.com/acrisci/i3ipc-python
-	* https://github.com/whitelynx/i3ipc (not maintained)
-	* https://github.com/ziberna/i3-py (not maintained)
-Ruby::
-	* http://github.com/badboy/i3-ipc


### PR DESCRIPTION
Remove unmaintained or deprecated ipc libraries from the ipc library
list and add a note about GObject introspection for i3ipc-glib.