### PR TITLE
Docs: add hint to use xvfb-run

### DIFF
--- a/docs/testsuite
+++ b/docs/testsuite
@@ -107,6 +107,11 @@ containing the appropriate i3 logfile for each testcase. The latest folder can
 always be found under the symlink +latest/+. Unless told differently, it will
 run the tests on a separate X server instance (using Xephyr).
 
+Xephyr will open a window where you can inspect the running test. You can run
+the tests without an X session with Xvfb, such as with +xvfb-run
+./complete-run+. This will also speed up the tests signficantly especially on
+machines without a powerful video card.
+
 .Example invocation of complete-run.pl+
 ---------------------------------------
 $ cd ~/i3/testcases


### PR DESCRIPTION
Document that Xvfb can be used to run tests without an X server, and be
used to significantly speed up tests on machines with slow video cards.