### PR TITLE
Focus next

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -187,6 +187,12 @@ void cmd_focus_level(I3_CMD, char *level);
 void cmd_focus(I3_CMD);
 
 /**
+ * Implementation of 'focus next'.
+ *
+ */
+void cmd_focus_next(I3_CMD);
+
+/**
  * Implementation of 'fullscreen [enable|disable|toggle] [global]'.
  *
  */

--- a/include/data.h
+++ b/include/data.h
@@ -408,6 +408,8 @@ struct Match {
     struct regex *instance;
     struct regex *mark;
     struct regex *window_role;
+    struct regex *workspace;
+    bool current_workspace;
     enum {
         U_DONTCHECK = -1,
         U_LATEST = 0,

--- a/include/match.h
+++ b/include/match.h
@@ -41,6 +41,13 @@ void match_copy(Match *dest, Match *src);
 bool match_matches_window(Match *match, i3Window *window);
 
 /**
+ * Check if a match data structure matches the workspace of the given
+ * container.
+ *
+ */
+bool match_matches_workspace(Match *match, Con *con);
+
+/**
  * Frees the given match. It must not be used afterwards!
  *
  */

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -49,6 +49,7 @@ state CRITERIA:
   ctype = 'con_mark' -> CRITERION
   ctype = 'title' -> CRITERION
   ctype = 'urgent' -> CRITERION
+  ctype = 'workspace' -> CRITERION
   ']' -> call cmd_criteria_match_windows(); INITIAL
 
 state CRITERION:

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -133,6 +133,7 @@ state WORKSPACE_NUMBER:
 # focus output <output>
 # focus tiling|floating|mode_toggle
 # focus parent|child
+# focus next
 # focus
 state FOCUS:
   direction = 'left', 'right', 'up', 'down'
@@ -143,6 +144,8 @@ state FOCUS:
       -> call cmd_focus_window_mode($window_mode)
   level = 'parent', 'child'
       -> call cmd_focus_level($level)
+  'next'
+      -> call cmd_focus_next()
   end
       -> call cmd_focus()
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -314,7 +314,9 @@ void cmd_criteria_match_windows(I3_CMD) {
             DLOG("match by mark\n");
             TAILQ_INSERT_TAIL(&owindows, current, owindows);
         } else {
-            if (current->con->window && match_matches_window(current_match, current->con->window)) {
+            if (current->con->window &&
+                match_matches_window(current_match, current->con->window) &&
+                match_matches_workspace(current_match, current->con)) {
                 DLOG("matches window!\n");
                 TAILQ_INSERT_TAIL(&owindows, current, owindows);
             } else {
@@ -403,6 +405,14 @@ void cmd_criteria_add(I3_CMD, char *ctype, char *cvalue) {
             current_match->urgent = U_OLDEST;
         }
         return;
+    }
+
+    if (strcmp(ctype, "workspace") == 0) {
+	if (strcmp(cvalue, "current") == 0)
+	    current_match->current_workspace = true;
+	else
+	    current_match->workspace = regex_new(cvalue);
+	return;
     }
 
     ELOG("Unknown criterion: %s\n", ctype);

--- a/src/match.c
+++ b/src/match.c
@@ -46,6 +46,8 @@ bool match_is_empty(Match *match) {
             match->class == NULL &&
             match->instance == NULL &&
             match->window_role == NULL &&
+            match->workspace == NULL &&
+            match->current_workspace == false &&
             match->urgent == U_DONTCHECK &&
             match->id == XCB_NONE &&
             match->con_id == NULL &&
@@ -185,6 +187,34 @@ bool match_matches_window(Match *match, i3Window *window) {
 }
 
 /*
+ * Check if a match data structure matches the workspace of the given
+ * container.
+ *
+ */
+bool match_matches_workspace(Match *match, Con *con) {
+    if (match->current_workspace) {
+	Con *current = con_get_workspace(focused);
+	Con *ws = con_get_workspace(con);
+	if (ws == current)
+            LOG("current workspace matches\n");
+	else
+	    return false;
+    }
+
+    if (match->workspace) {
+	Con *ws = con_get_workspace(con);
+	if (ws->name &&
+	    regex_matches(match->workspace, ws->name)) {
+            LOG("workspace name matches (%s)\n", ws->name);
+        } else {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/*
  * Frees the given match. It must not be used afterwards!
  *
  */
@@ -196,6 +226,7 @@ void match_free(Match *match) {
     regex_free(match->instance);
     regex_free(match->mark);
     regex_free(match->window_role);
+    regex_free(match->workspace);
 
     /* Second step: free the regex helper struct itself */
     FREE(match->title);
@@ -204,4 +235,5 @@ void match_free(Match *match) {
     FREE(match->instance);
     FREE(match->mark);
     FREE(match->window_role);
+    FREE(match->workspace);
 }


### PR DESCRIPTION
Hi,

this is a RFC, not a full-featured pull request. I consider switching to i3 and I miss some features, namely something similar to awesome's run-or-raise. There is a solution at [i3 FAQ](https://faq.i3wm.org/question/2473/run-or-focus-in-i3/?answer=2792#post-id-2792) that might work (with some changes) for me but I find it unnecessarily complex.

With these patches, my desired run-or-raise functionality can be implemented easily as:

    if i3-msg '[class="XTerm" workspace=current] focus next'|jq -e '.[0].success == false'; then
        exec xterm
    fi
