### PR TITLE
feature: focus previous

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -175,6 +175,12 @@ void cmd_focus_direction(I3_CMD, char *direction);
 void cmd_focus_window_mode(I3_CMD, char *window_mode);
 
 /**
+ * Implementation of 'focus previous'.
+ *
+ */
+void cmd_focus_previous(I3_CMD);
+	
+/**
  * Implementation of 'focus parent|child'.
  *
  */

--- a/include/tree.h
+++ b/include/tree.h
@@ -13,6 +13,8 @@ extern Con *croot;
 /* TODO: i am not sure yet how much access to the focused container should
  * be permitted to source files */
 extern Con *focused;
+extern Con *previous_focused;
+extern bool infocusloop;
 TAILQ_HEAD(all_cons_head, Con);
 extern struct all_cons_head all_cons;
 

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -138,6 +138,8 @@ state FOCUS:
       -> call cmd_focus_direction($direction)
   'output'
       -> FOCUS_OUTPUT
+  'previous'
+      -> call cmd_focus_previous()
   window_mode = 'tiling', 'floating', 'mode_toggle'
       -> call cmd_focus_window_mode($window_mode)
   level = 'parent', 'child'

--- a/src/commands.c
+++ b/src/commands.c
@@ -1494,6 +1494,19 @@ void cmd_focus_window_mode(I3_CMD, char *window_mode) {
 }
 
 /*
+ * Implementation of 'focus previous'.
+ *
+ */
+void cmd_focus_previous(I3_CMD) {
+	if (focused != previous_focused)
+		con_focus(previous_focused);
+
+    cmd_output->needs_tree_render = true;
+    // XXX: default reply for now, make this a better reply
+    ysuccess(true);
+}
+
+/*
  * Implementation of 'focus parent|child'.
  *
  */

--- a/src/con.c
+++ b/src/con.c
@@ -194,13 +194,19 @@ void con_focus(Con *con) {
     assert(con != NULL);
     DLOG("con_focus = %p\n", con);
 
+	if (!infocusloop)
+		previous_focused = focused;
+
     /* 1: set focused-pointer to the new con */
     /* 2: exchange the position of the container in focus stack of the parent all the way up */
     TAILQ_REMOVE(&(con->parent->focus_head), con, focused);
     TAILQ_INSERT_HEAD(&(con->parent->focus_head), con, focused);
-    if (con->parent->parent != NULL)
+    if (con->parent->parent != NULL) {
+		infocusloop = true;
         con_focus(con->parent);
-
+	}
+	
+	infocusloop = false;
     focused = con;
     /* We can't blindly reset non-leaf containers since they might have
      * other urgent children. Therefore we only reset leafs and propagate

--- a/src/tree.c
+++ b/src/tree.c
@@ -13,6 +13,8 @@
 
 struct Con *croot;
 struct Con *focused;
+struct Con *previous_focused;
+bool infocusloop = false;
 
 struct all_cons_head all_cons = TAILQ_HEAD_INITIALIZER(all_cons);
 


### PR DESCRIPTION
allows quick switching to the previous focused window on the current workspace

see also: https://github.com/i3/i3/issues/838