### PR TITLE
Fix incorrect y-offset for text in i3bar

### DIFF
--- a/libi3/font.c
+++ b/libi3/font.c
@@ -122,7 +122,7 @@ static void draw_text_pango(const char *text, size_t text_len,
     cairo_set_source_rgb(cr, pango_font_red, pango_font_green, pango_font_blue);
     pango_cairo_update_layout(cr, layout);
     pango_layout_get_pixel_size(layout, NULL, &height);
-    cairo_move_to(cr, x, y - (height - savedFont->height));
+    cairo_move_to(cr, x, y - 0.5 * (height - savedFont->height));
     pango_cairo_show_layout(cr, layout);
 
     /* Free resources */


### PR DESCRIPTION
When using Pango to draw text in i3bar, the y-offset of the text is
incorrectly calculated in case all characters in the string to draw are
smaller than the cached font height. Fixes #1494.