### PR TITLE
Fix key bindings on big-endian platforms

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -159,9 +159,10 @@ static Binding *get_binding(uint16_t modifiers, bool is_release, uint16_t input_
          * need to look in the array of translated keycodes for the event’s
          * keycode */
         if (input_type == B_KEYBOARD && bind->symbol != NULL) {
+            xcb_keycode_t input_keycode = (xcb_keycode_t)input_code;
             if (memmem(bind->translated_to,
                        bind->number_keycodes * sizeof(xcb_keycode_t),
-                       &input_code, sizeof(xcb_keycode_t)) == NULL)
+                       &input_keycode, sizeof(xcb_keycode_t)) == NULL)
                 continue;
         } else {
             /* This case is easier: The user specified a keycode */


### PR DESCRIPTION
input_code is a uint16_t, but xcb_keycode_t is uint8_t, meaning that
only the first byte of input_code is inspected by memmem. On
little-endian platforms, this code would have worked by accident, since
the first byte of input_code represents the 8 least significant bits.
However, on big-endian platforms the first byte is the 8 most
significant bits, which means memmem is scanning bind->translated_to
for the wrong keycode (probably 0).

In order to work correctly on big-endian and little-endian platforms,
simply typecast input_code to an xcb_keycode_t and pass that to memmem.

The observed behaviour associated with this bug is that key bindings
don't work at all. This patch has been tested on an iBook G4 running
OpenBSD -current, and key bindings work properly with this fix applied.