### PR TITLE
Fix scrolling in window decoration with hidden cursor.

### DIFF
--- a/src/click.c
+++ b/src/click.c
@@ -380,11 +380,6 @@ int handle_button_press(xcb_button_press_event_t *event) {
         return 0;
     }
 
-    if (event->child != XCB_NONE) {
-        DLOG("event->child not XCB_NONE, so this is an event which originated from a click into the application, but the application did not handle it.\n");
-        return route_click(con, event, mod_pressed, CLICK_INSIDE);
-    }
-
     /* Check if the click was on the decoration of a child */
     Con *child;
     TAILQ_FOREACH(child, &(con->nodes_head), nodes) {
@@ -392,6 +387,11 @@ int handle_button_press(xcb_button_press_event_t *event) {
             continue;
 
         return route_click(child, event, mod_pressed, CLICK_DECORATION);
+    }
+
+    if (event->child != XCB_NONE) {
+        DLOG("event->child not XCB_NONE, so this is an event which originated from a click into the application, but the application did not handle it.\n");
+        return route_click(con, event, mod_pressed, CLICK_INSIDE);
     }
 
     return route_click(con, event, mod_pressed, CLICK_BORDER);


### PR DESCRIPTION
If the mouse cursor is hidden (by unclutter, for example), then scrolling
in the window decoration creates an event with a child
(i.e. event->child != XCB_NONE). This causes route_click() to be called
with dest=CLICK_INSIDE, which prevents scrolling through a stacked layout.

To fix this, check if a click is in the window decoration _before_
checking if the event has a child.

Fixes #1511 
