### PR TITLE
Rename workspaces in startup sequences

### DIFF
--- a/include/startup.h
+++ b/include/startup.h
@@ -45,6 +45,12 @@ void startup_sequence_delete(struct Startup_Sequence *sequence);
 void startup_monitor_event(SnMonitorEvent *event, void *userdata);
 
 /**
+ * Renames workspaces that are mentioned in the startup sequences.
+ *
+ */
+void startup_sequence_rename_workspace(char *old_name, char *new_name);
+
+/**
  * Gets the stored startup sequence for the _NET_STARTUP_ID of a given window.
  *
  */

--- a/src/commands.c
+++ b/src/commands.c
@@ -2044,6 +2044,8 @@ void cmd_rename_workspace(I3_CMD, char *old_name, char *new_name) {
     ewmh_update_desktop_names();
     ewmh_update_desktop_viewport();
     ewmh_update_current_desktop();
+
+    startup_sequence_rename_workspace(old_name, new_name);
 }
 
 /*

--- a/src/startup.c
+++ b/src/startup.c
@@ -258,6 +258,22 @@ void startup_monitor_event(SnMonitorEvent *event, void *userdata) {
 }
 
 /**
+ * Renames workspaces that are mentioned in the startup sequences.
+ *
+ */
+void startup_sequence_rename_workspace(char *old_name, char *new_name) {
+    struct Startup_Sequence *current;
+    TAILQ_FOREACH(current, &startup_sequences, sequences) {
+        if (strcmp(current->workspace, old_name) != 0)
+            continue;
+        DLOG("Renaming workspace \"%s\" to \"%s\" in startup sequence %s.\n",
+             old_name, new_name, current->id);
+        free(current->workspace);
+        current->workspace = sstrdup(new_name);
+    }
+}
+
+/**
  * Gets the stored startup sequence for the _NET_STARTUP_ID of a given window.
  *
  */

--- a/testcases/t/175-startup-notification.t
+++ b/testcases/t/175-startup-notification.t
@@ -142,11 +142,16 @@ is_num_children($first_ws, 2, 'two containers on the first workspace');
 complete_startup();
 sync_with_i3;
 
+# even when renaming the workspace, windows should end up on the correct one
+cmd "rename workspace $first_ws to temp";
+
 # Startup has completed but the 30-second deletion time hasn't elapsed,
 # so this window should still go on the leader's initial workspace.
 $win = open_window({ dont_map => 1, client_leader => $leader });
 $win->map;
 sync_with_i3;
+
+cmd "rename workspace temp to $first_ws";
 
 is_num_children($first_ws, 3, 'three containers on the first workspace');
 


### PR DESCRIPTION
When renaming workspaces with `rename workspace`, workspaces that are mentioned in startup sequences are not renamed (issue #1527).

First commit is a test case that fails in `next`.

I'm not really sure where `startup_sequence_rename_workspace(old_name, new_name)` should go exactly in `cmd_rename_workspace`.