### PR TITLE
Fix warnings

### DIFF
--- a/i3-msg/main.c
+++ b/i3-msg/main.c
@@ -187,8 +187,7 @@ int main(int argc, char *argv[]) {
             payload = sstrdup(argv[optind]);
         } else {
             char *both;
-            if (asprintf(&both, "%s %s", payload, argv[optind]) == -1)
-                err(EXIT_FAILURE, "asprintf");
+            sasprintf(&both, "%s %s", payload, argv[optind]);
             free(payload);
             payload = both;
         }

--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -164,7 +164,7 @@ static void handle_button_release(xcb_connection_t *conn, xcb_button_release_eve
     char *link_path;
     char *exe_path = get_exe_path(argv0);
     sasprintf(&link_path, "%s.nagbar_cmd", script_path);
-    symlink(exe_path, link_path);
+    ssymlink(exe_path, link_path);
 
     char *terminal_cmd;
     sasprintf(&terminal_cmd, "i3-sensible-terminal -e %s", link_path);

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -101,7 +101,7 @@ __attribute__((format(printf, 1, 2))) static void set_statusline_error(const cha
     char *message;
     va_list args;
     va_start(args, format);
-    vasprintf(&message, format, args);
+    svasprintf(&message, format, args);
 
     struct status_block *err_block = scalloc(sizeof(struct status_block));
     err_block->full_text = i3string_from_utf8("Error: ");
@@ -168,7 +168,7 @@ static int stdin_start_map(void *context) {
 static int stdin_map_key(void *context, const unsigned char *key, size_t len) {
     parser_ctx *ctx = context;
     FREE(ctx->last_map_key);
-    sasprintf(&(ctx->last_map_key), "%.*s", len, key);
+    sasprintf(&(ctx->last_map_key), "%.*s", (int)len, key);
     return 1;
 }
 
@@ -189,7 +189,7 @@ static int stdin_string(void *context, const unsigned char *val, size_t len) {
         ctx->block.full_text = i3string_from_markup_with_length((const char *)val, len);
     }
     if (strcasecmp(ctx->last_map_key, "color") == 0) {
-        sasprintf(&(ctx->block.color), "%.*s", len, val);
+        sasprintf(&(ctx->block.color), "%.*s", (int)len, val);
     }
     if (strcasecmp(ctx->last_map_key, "align") == 0) {
         if (len == strlen("center") && !strncmp((const char *)val, "center", strlen("center"))) {

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -433,8 +433,8 @@ void child_write_output(void) {
         size_t size;
 
         yajl_gen_get_buf(gen, &output, &size);
-        write(child_stdin, output, size);
-        write(child_stdin, "\n", 1);
+        swrite(child_stdin, output, size);
+        swrite(child_stdin, "\n", 1);
         yajl_gen_clear(gen);
     }
 }

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -1551,8 +1551,7 @@ void reconfig_windows(bool redraw_bars) {
                                                "i3bar\0i3bar\0");
 
             char *name;
-            if (asprintf(&name, "i3bar for output %s", walk->name) == -1)
-                err(EXIT_FAILURE, "asprintf()");
+            sasprintf(&name, "i3bar for output %s", walk->name);
             xcb_void_cookie_t name_cookie;
             name_cookie = xcb_change_property(xcb_connection,
                                               XCB_PROP_MODE_REPLACE,

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -156,6 +156,13 @@ ssize_t swrite(int fd, const void *buf, size_t count);
 int spipe(int pipefd[2]);
 
 /**
+ * Safe-wrapper around symlink which exits if it returns -1 (meaning that
+ * symlink failed)
+ *
+ */
+int ssymlink(const char *target, const char *linkpath);
+
+/**
  * Build an i3String from an UTF-8 encoded string.
  * Returns the newly-allocated i3String.
  *

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -149,6 +149,13 @@ int sasprintf(char **strp, const char *fmt, ...) __attribute__((format(printf, 2
 ssize_t swrite(int fd, const void *buf, size_t count);
 
 /**
+ * Safe-wrapper around pipe which exits if it returns -1 (meaning that
+ * pipe failed)
+ *
+ */
+int spipe(int pipefd[2]);
+
+/**
  * Build an i3String from an UTF-8 encoded string.
  * Returns the newly-allocated i3String.
  *

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -142,6 +142,13 @@ int svasprintf(char **strp, const char *fmt, va_list ap);
 int sasprintf(char **strp, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
 /**
+ * Safe-wrapper around write which exits if it returns -1 (meaning that
+ * write failed)
+ *
+ */
+ssize_t swrite(int fd, const void *buf, size_t count);
+
+/**
  * Build an i3String from an UTF-8 encoded string.
  * Returns the newly-allocated i3String.
  *

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -128,11 +128,18 @@ void *srealloc(void *ptr, size_t size);
 char *sstrdup(const char *str);
 
 /**
+ * Safe-wrapper around vasprintf which exits if it returns -1 (meaning that
+ * there is no more memory available)
+ *
+ */
+int svasprintf(char **strp, const char *fmt, va_list ap);
+
+/**
  * Safe-wrapper around asprintf which exits if it returns -1 (meaning that
  * there is no more memory available)
  *
  */
-int sasprintf(char **strp, const char *fmt, ...);
+int sasprintf(char **strp, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
 /**
  * Build an i3String from an UTF-8 encoded string.

--- a/libi3/safewrappers.c
+++ b/libi3/safewrappers.c
@@ -81,3 +81,11 @@ int spipe(int pipefd[2]) {
         err(EXIT_FAILURE, "pipe((int[]){%d,%d})", pipefd[0], pipefd[1]);
     return result;
 }
+
+int ssymlink(const char *target, const char *linkpath) {
+    ssize_t result = symlink(target, linkpath);
+
+    if (-1 == result)
+        err(EXIT_FAILURE, "symlink(\"%s\", \"%s\")", target, linkpath);
+    return result;
+}

--- a/libi3/safewrappers.c
+++ b/libi3/safewrappers.c
@@ -73,3 +73,11 @@ ssize_t swrite(int fd, const void *buf, size_t count) {
         err(EXIT_FAILURE, "write(%d,...)", fd);
     return result;
 }
+
+int spipe(int pipefd[2]) {
+    ssize_t result = pipe(pipefd);
+    
+    if (-1 == result)
+        err(EXIT_FAILURE, "pipe((int[]){%d,%d})", pipefd[0], pipefd[1]);
+    return result;
+}

--- a/libi3/safewrappers.c
+++ b/libi3/safewrappers.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <unistd.h>
 #include <stdio.h>
 #include <err.h>
 
@@ -62,5 +63,13 @@ int sasprintf(char **strp, const char *fmt, ...) {
     if ((result = vasprintf(strp, fmt, args)) == -1)
         err(EXIT_FAILURE, "asprintf(%s)", fmt);
     va_end(args);
+    return result;
+}
+
+ssize_t swrite(int fd, const void *buf, size_t count) {
+    ssize_t result = write (fd, buf, count);
+    
+    if (-1 == result)
+        err(EXIT_FAILURE, "write(%d,...)", fd);
     return result;
 }

--- a/libi3/safewrappers.c
+++ b/libi3/safewrappers.c
@@ -46,6 +46,14 @@ char *sstrdup(const char *str) {
     return result;
 }
 
+int svasprintf(char **strp, const char *fmt, va_list ap) {
+    int result = vasprintf(strp, fmt, ap);
+    
+    if (-1 == result)
+        err(EXIT_FAILURE, "vasprintf(%s)", fmt);
+    return result;
+}
+
 int sasprintf(char **strp, const char *fmt, ...) {
     va_list args;
     int result;

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -429,7 +429,7 @@ CommandResult *run_binding(Binding *bind, Con *con) {
     if (con == NULL)
         command = sstrdup(bind->command);
     else
-        sasprintf(&command, "[con_id=\"%d\"] %s", con, bind->command);
+        sasprintf(&command, "[con_id=\"%p\"] %s", con, bind->command);
 
     Binding *bind_cp = binding_copy(bind);
     CommandResult *result = parse_command(command, NULL);

--- a/src/click.c
+++ b/src/click.c
@@ -46,6 +46,8 @@ static bool tiling_resize_for_border(Con *con, border_t border, xcb_button_press
         case BORDER_BOTTOM:
             search_direction = D_DOWN;
             break;
+        default:
+            assert(false);
     }
 
     bool res = resize_find_tiling_participants(&first, &second, search_direction);

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -105,7 +105,7 @@ static int json_end_map(void *ctx) {
             int cnt = 1;
             while (workspace != NULL) {
                 FREE(json_node->name);
-                asprintf(&(json_node->name), "%s_%d", base, cnt++);
+                sasprintf(&(json_node->name), "%s_%d", base, cnt++);
                 workspace = NULL;
                 TAILQ_FOREACH(output, &(croot->nodes_head), nodes)
                 GREP_FIRST(workspace, output_get_content(output), !strcasecmp(child->name, json_node->name));
@@ -194,7 +194,7 @@ static int json_string(void *ctx, const unsigned char *val, size_t len) {
     LOG("string: %.*s for key %s\n", (int)len, val, last_key);
     if (parsing_swallows) {
         char *sval;
-        sasprintf(&sval, "%.*s", len, val);
+        sasprintf(&sval, "%.*s", (int)len, val);
         if (strcasecmp(last_key, "class") == 0) {
             current_swallow->class = regex_new(sval);
         } else if (strcasecmp(last_key, "instance") == 0) {

--- a/src/sighandler.c
+++ b/src/sighandler.c
@@ -70,8 +70,8 @@ static int backtrace(void) {
         int stdin_pipe[2],
             stdout_pipe[2];
 
-        pipe(stdin_pipe);
-        pipe(stdout_pipe);
+        spipe(stdin_pipe);
+        spipe(stdout_pipe);
 
         /* close standard streams in case i3 is started from a terminal; gdb
          * needs to run without controlling terminal for it to work properly in

--- a/src/startup.c
+++ b/src/startup.c
@@ -131,7 +131,7 @@ void startup_sequence_delete(struct Startup_Sequence *sequence) {
  *
  */
 void start_application(const char *command, bool no_startup_id) {
-    SnLauncherContext *context;
+    SnLauncherContext *context = NULL;
 
     if (!no_startup_id) {
         /* Create a startup notification context to monitor the progress of this


### PR DESCRIPTION
This fixes all the warnings from #1538 except this one:
```
../i3/src/floating.c:743:5: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
     ev_check_init(&loop.check, xcb_drag_check_cb);
     ^
../i3/src/floating.c:743:5: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
../i3/src/floating.c:743:5: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
../i3/src/click.c: In function ‘tiling_resize_for_border’:
```
I don't understand `ev` well enough to fix this.  Maybe someone else can have a look?