### PR TITLE
Display long status lines correctly

### DIFF
--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -174,7 +174,7 @@ void refresh_statusline(void) {
         realloc_sl_buffer();
 
     /* Clear the statusline pixmap. */
-    xcb_rectangle_t rect = {0, 0, root_screen->width_in_pixels, bar_height};
+    xcb_rectangle_t rect = {0, 0, statusline_width, bar_height};
     xcb_poly_fill_rectangle(xcb_connection, statusline_pm, statusline_clear, 1, &rect);
 
     /* Draw the text of each block. */
@@ -1786,7 +1786,7 @@ void draw_bars(bool unhide) {
                           statusline_pm,
                           outputs_walk->buffer,
                           outputs_walk->bargc,
-                          MAX(0, (int16_t)(statusline_width - outputs_walk->rect.w + logical_px(4))), 0,
+                          MAX(0, (int16_t)(statusline_width - outputs_walk->rect.w + traypx + logical_px(4))), 0,
                           MAX(0, (int16_t)(outputs_walk->rect.w - statusline_width - traypx - logical_px(4))), 0,
                           MIN(outputs_walk->rect.w - traypx - logical_px(4), (int)statusline_width), bar_height);
         }


### PR DESCRIPTION
Clear the entire width of the status line pixmap, not just the root
screen width.
Also include the tray width in calculating the source width that needs
to be copied for long status lines.

This fixes #1531. I'm having trouble with CPAN and some modules the tests need, so I couldn't run them yet. I would expect the changes to pass, tho.