### PR TITLE
bugfix: workspace rename focus mismatch

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1919,6 +1919,10 @@ void cmd_rename_workspace(I3_CMD, char *old_name, char *new_name) {
         }
 
         workspace_move_to_output(workspace, assignment->output);
+
+        if (previously_focused)
+            workspace_show(con_get_workspace(previously_focused));
+
         break;
     }
 


### PR DESCRIPTION
When renaming a workspace on another output that moves the workspace to
the current output, the renamed workspace would be shown even though it
does not contain the focused container.

Explicitly show the focused workspace after the move. This is necessary
because `workspace_move_to_output` will show the workspace that is
moved.