### PR TITLE
Make the --workspace optional by defaulting to the focused workspace.

### DIFF
--- a/i3-save-tree
+++ b/i3-save-tree
@@ -265,19 +265,19 @@ specification. When a window is mapped (made visible on the screen) that
 matches the specification, i3 will put it into that place and kill the
 placeholder.
 
+If neither argument is specified, the currently focused workspace will be used.
+
 =head1 OPTIONS
 
 =over
 
 =item B<--workspace=name>
 
-Specifies the workspace that should be dumped, e.g. 1. Either this or --output
-need to be specified.
+Specifies the workspace that should be dumped, e.g. 1.
 
 =item B<--output=name>
 
-Specifies the output that should be dumped, e.g. LVDS-1. Either this or
---workspace need to be specified.
+Specifies the output that should be dumped, e.g. LVDS-1.
 
 =back
 

--- a/i3-save-tree
+++ b/i3-save-tree
@@ -13,6 +13,7 @@ use POSIX qw(locale_h);
 use File::Find;
 use File::Basename qw(basename);
 use File::Temp qw(tempfile);
+use List::Util qw(first);
 use Getopt::Long;
 use Pod::Usage;
 use AnyEvent::I3;
@@ -41,11 +42,7 @@ my $result = GetOptions(
 
 die "Could not parse command line options" unless $result;
 
-if (!defined($workspace) && !defined($output)) {
-    die "One of --workspace or --output need to be specified";
-}
-
-unless (defined($workspace) ^ defined($output)) {
+if (defined($workspace) && defined($output)) {
     die "Only one of --workspace or --output can be specified";
 }
 
@@ -55,6 +52,15 @@ $output = decode('utf-8', $output);
 my $i3 = i3();
 if (!$i3->connect->recv) {
     die "Could not connect to i3";
+}
+
+sub get_current_workspace {
+    my $current = first { $_->{focused} } @{$i3->get_workspaces->recv};
+    return $current->{name};
+}
+
+if (!defined($workspace) && !defined($output)) {
+    $workspace = get_current_workspace();
 }
 
 sub filter_containers {


### PR DESCRIPTION
If no option is given, i3-save-tree should default to the currently focused workspace.
Specifying both --workspace and --output will still yield an error.