### PR TITLE
Allow referencing the workspace by number.

### DIFF
--- a/i3-save-tree
+++ b/i3-save-tree
@@ -222,7 +222,7 @@ my $tree = $i3->get_tree->recv;
 my $dump;
 if (defined($workspace)) {
     $dump = filter_containers($tree, sub {
-        $_->{type} eq 'workspace' && $_->{name} eq $workspace
+        $_->{type} eq 'workspace' && ($_->{name} eq $workspace || ($workspace =~ /^\d+$/ && $_->{num} eq $workspace))
     });
 } else {
     $dump = filter_containers($tree, sub {
@@ -252,7 +252,7 @@ for my $key (qw(nodes floating_nodes)) {
 
 =head1 SYNOPSIS
 
-    i3-save-tree [--workspace=name] [--output=name]
+    i3-save-tree [--workspace=name|number] [--output=name]
 
 =head1 DESCRIPTION
 
@@ -271,9 +271,10 @@ If neither argument is specified, the currently focused workspace will be used.
 
 =over
 
-=item B<--workspace=name>
+=item B<--workspace=name|number>
 
-Specifies the workspace that should be dumped, e.g. 1.
+Specifies the workspace that should be dumped, e.g. 1. This can either be a
+name or the number of a workspace.
 
 =item B<--output=name>
 


### PR DESCRIPTION
This allows "--workspace 3" for numbered workspaces, e.g., if the name is
actually "3:foo". This introduces the same functionality the IPC already
offers in many places.