### PR TITLE
i3bar: set markup per block

### DIFF
--- a/docs/i3bar-protocol
+++ b/docs/i3bar-protocol
@@ -172,6 +172,10 @@ separator_block_width::
 	this gap, a separator line will be drawn unless +separator+ is
 	disabled. Normally, you want to set this to an odd value (the default
 	is 9 pixels), since the separator line is drawn in the middle.
+markup::
+	A string that indicates how the text of the block should be parsed. Set to
+	+"pango"+ to use https://developer.gnome.org/pango/stable/PangoMarkupFormat.html[Pango markup]
+	(default). Set to +"none"+ to not use any markup.
 
 If you want to put in your own entries into a block, prefix the key with an
 underscore (_). i3bar will ignore all keys it doesn’t understand, and prefixing

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -38,11 +38,18 @@ struct status_block {
     i3String *short_text;
 
     char *color;
+
+    /* min_width can be specified either as a numeric value (in pixels) or as a
+     * string. For strings, we set min_width to the measured text width of
+     * min_width_str. */
     uint32_t min_width;
+    char *min_width_str;
+
     blockalign_t align;
 
     bool urgent;
     bool no_separator;
+    bool is_markup;
 
     /* The amount of pixels necessary to render a separater after the block. */
     uint32_t sep_block_width;

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -218,6 +218,11 @@ size_t i3string_get_num_bytes(i3String *str);
 bool i3string_is_markup(i3String *str);
 
 /**
+ * Set whether the i3String should use Pango markup.
+ */
+void i3string_set_markup(i3String *str, bool is_markup);
+
+/**
  * Returns the number of glyphs in an i3String.
  *
  */

--- a/libi3/string.c
+++ b/libi3/string.c
@@ -179,6 +179,13 @@ bool i3string_is_markup(i3String *str) {
 }
 
 /*
+ * Set whether the i3String should use Pango markup.
+ */
+void i3string_set_markup(i3String *str, bool is_markup) {
+    str->is_markup = is_markup;
+}
+
+/*
  * Returns the number of glyphs in an i3String.
  *
  */


### PR DESCRIPTION
Add `markup` to the i3bar protocol as a block member.

This is a string that determines how the block should be parsed as
markup. "pango" indicates the block should be parsed as Pango markup.
"none" indicates the block should not be parsed as markup.