### PR TITLE
i3bar: check block text for NULL

### DIFF
--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -286,7 +286,7 @@ static int stdin_end_array(void *context) {
     struct status_block *current;
     TAILQ_FOREACH(current, &statusline_head, blocks) {
         DLOG("full_text = %s\n", i3string_as_utf8(current->full_text));
-        DLOG("short_text = %s\n", i3string_as_utf8(current->short_text));
+        DLOG("short_text = %s\n", (current->short_text == NULL ? NULL : i3string_as_utf8(current->short_text)));
         DLOG("color = %s\n", current->color);
     }
     DLOG("end of dump\n");

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -265,7 +265,9 @@ static int stdin_end_map(void *context) {
     }
 
     i3string_set_markup(new_block->full_text, new_block->is_markup);
-    i3string_set_markup(new_block->short_text, new_block->is_markup);
+
+    if (new_block->short_text != NULL)
+        i3string_set_markup(new_block->short_text, new_block->is_markup);
 
     TAILQ_INSERT_TAIL(&statusline_buffer, new_block, blocks);
     return 1;


### PR DESCRIPTION
Add a null check to `full_text` and `short_text` for a block before
setting the markup property to avoid a segfault.