### PR TITLE
Respect XDG config directories in i3-config-wizard

### DIFF
--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -482,17 +482,23 @@ static int handle_expose() {
         set_font_colors(pixmap_gc, get_colorpixel("#FFFFFF"), get_colorpixel("#000000"));
 
         txt(logical_px(10), 2, "You have not configured i3 yet.");
-        txt(logical_px(10), 3, "Do you want me to generate ~/.i3/config?");
-        txt(logical_px(85), 5, "Yes, generate ~/.i3/config");
-        txt(logical_px(85), 7, "No, I will use the defaults");
+        txt(logical_px(10), 3, "Do you want me to generate a config at");
+
+        char *msg;
+        sasprintf(&msg, "%s?", config_path);
+        txt(logical_px(10), 4, msg);
+        free(msg);
+
+        txt(logical_px(85), 6, "Yes, generate the config");
+        txt(logical_px(85), 8, "No, I will use the defaults");
 
         /* green */
         set_font_colors(pixmap_gc, get_colorpixel("#00FF00"), get_colorpixel("#000000"));
-        txt(logical_px(25), 5, "<Enter>");
+        txt(logical_px(25), 6, "<Enter>");
 
         /* red */
         set_font_colors(pixmap_gc, get_colorpixel("#FF0000"), get_colorpixel("#000000"));
-        txt(logical_px(31), 7, "<ESC>");
+        txt(logical_px(31), 8, "<ESC>");
     }
 
     if (current_step == STEP_GENERATE) {
@@ -502,7 +508,7 @@ static int handle_expose() {
         txt(logical_px(85), 4, "Win as default modifier");
         txt(logical_px(85), 5, "Alt as default modifier");
         txt(logical_px(10), 7, "Afterwards, press");
-        txt(logical_px(85), 9, "to write ~/.i3/config");
+        txt(logical_px(85), 9, "to write the config");
         txt(logical_px(85), 10, "to abort");
 
         /* the not-selected modifier */
@@ -740,7 +746,7 @@ static void finish() {
 }
 
 int main(int argc, char *argv[]) {
-    config_path = resolve_tilde("~/.i3/config");
+    char *xdg_config_home;
     socket_path = getenv("I3SOCK");
     char *pattern = "pango:monospace 8";
     char *patternbold = "pango:monospace bold 8";
@@ -774,20 +780,29 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    /* Check if the destination config file does not exist but the path is
-     * writable. If not, exit now, this program is not useful in that case. */
-    struct stat stbuf;
-    if (stat(config_path, &stbuf) == 0) {
-        printf("The config file \"%s\" already exists. Exiting.\n", config_path);
+    char *path = get_config_path(NULL, false);
+    if (path != NULL) {
+        printf("The config file \"%s\" already exists. Exiting.\n", path);
+        free(path);
         return 0;
     }
 
-    /* Create ~/.i3 if it does not yet exist */
-    char *config_dir = resolve_tilde("~/.i3");
+    /* Always write to $XDG_CONFIG_HOME/i3/config by default. */
+    if ((xdg_config_home = getenv("XDG_CONFIG_HOME")) == NULL)
+        xdg_config_home = "~/.config";
+
+    xdg_config_home = resolve_tilde(xdg_config_home);
+    sasprintf(&config_path, "%s/i3/config", xdg_config_home);
+
+    /* Create $XDG_CONFIG_HOME/i3 if it does not yet exist */
+    char *config_dir;
+    struct stat stbuf;
+    sasprintf(&config_dir, "%s/i3", xdg_config_home);
     if (stat(config_dir, &stbuf) != 0)
-        if (mkdir(config_dir, 0755) == -1)
-            err(1, "mkdir(%s) failed", config_dir);
+        if (!mkdirp(config_dir))
+            err(EXIT_FAILURE, "mkdirp(%s) failed", config_dir);
     free(config_dir);
+    free(xdg_config_home);
 
     int fd;
     if ((fd = open(config_path, O_CREAT | O_RDWR, 0644)) == -1) {


### PR DESCRIPTION
Should fix #1566

I've explicitly excluded two of i3's config detection mechanisms, SYSCONFDIR (usually /etc) and /etc/xdg (Normally default when $XDG_CONFIG_DIRS isn't set) because they're system- rather than user-level, and the wizard is for setting up a user-editable config.

The text changes are necessary to (hopefully) prevent overflow with long $XDG_CONFIG_HOME paths. It'd have been considerably uglier to dynamically widen the window and pixmap dependent on the longest line of text.
