### PR TITLE
i3bar: don't parse markup on statusline by default

### DIFF
--- a/docs/i3bar-protocol
+++ b/docs/i3bar-protocol
@@ -117,10 +117,8 @@ click_events::
 === Blocks in detail
 
 full_text::
-	The most simple block you can think of is one which just includes the
-	only required key, the +full_text+ key. i3bar will display the string
-	value parsed as
-	https://developer.gnome.org/pango/stable/PangoMarkupFormat.html[Pango markup].
+	The +full_text+ will be displayed by i3bar on the status line. This is the
+	only required key.
 short_text::
 	Where appropriate, the +short_text+ (string) entry should also be
 	provided. It will be used in case the status line needs to be shortened
@@ -174,8 +172,8 @@ separator_block_width::
 	is 9 pixels), since the separator line is drawn in the middle.
 markup::
 	A string that indicates how the text of the block should be parsed. Set to
-	+"pango"+ to use https://developer.gnome.org/pango/stable/PangoMarkupFormat.html[Pango markup]
-	(default). Set to +"none"+ to not use any markup.
+	+"pango"+ to use https://developer.gnome.org/pango/stable/PangoMarkupFormat.html[Pango markup].
+	Set to +"none"+ to not use any markup (default).
 
 If you want to put in your own entries into a block, prefix the key with an
 underscore (_). i3bar will ignore all keys it doesn’t understand, and prefixing

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -164,9 +164,6 @@ static int stdin_start_map(void *context) {
     /* Default width of the separator block. */
     ctx->block.sep_block_width = logical_px(9);
 
-    /* Use markup by default */
-    ctx->block.is_markup = true;
-
     return 1;
 }
 


### PR DESCRIPTION
fixes #1565
