### PR TITLE
Switch the wizard's modifier choice when up or down are pressed

### DIFF
--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -592,6 +592,12 @@ static int handle_key_press(void *ignored, xcb_connection_t *conn, xcb_key_press
             finish();
     }
 
+    /* Swap between modifiers when up or down is pressed. */
+    if (sym == XK_Up || sym == XK_Down) {
+        modifier = (modifier == MOD_Mod1) ? MOD_Mod4 : MOD_Mod1;
+        handle_expose();
+    }
+
     /* cancel any time */
     if (sym == XK_Escape)
         exit(0);


### PR DESCRIPTION
A minor improvement to something most users see for a few seconds, but a user's initial experience with i3 may as well be slightly more intuitive.