### PR TITLE
Use a reasonable default sep_block_width if a separator_symbol is given

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1319,8 +1319,7 @@ bar {
 === Custom separator symbol
 
 Specifies a custom symbol to be used for the separator as opposed to the vertical,
-one pixel thick separator. Note that you may have to adjust the +sep_block_width+ 
-property.
+one pixel thick separator.
 
 *Syntax*:
 -------------------------

--- a/i3bar/include/xcb.h
+++ b/i3bar/include/xcb.h
@@ -44,6 +44,9 @@ struct xcb_color_strings_t {
 
 typedef struct xcb_colors_t xcb_colors_t;
 
+/* Cached width of the custom separator if one was set */
+int separator_symbol_width;
+
 /*
  * Early initialization of the connection to X11: Everything which does not
  * depend on 'config'.

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -162,7 +162,10 @@ static int stdin_start_map(void *context) {
     memset(&(ctx->block), '\0', sizeof(struct status_block));
 
     /* Default width of the separator block. */
-    ctx->block.sep_block_width = logical_px(9);
+    if (config.separator_symbol == NULL)
+        ctx->block.sep_block_width = logical_px(9);
+    else
+        ctx->block.sep_block_width = logical_px(8) + separator_symbol_width;
 
     return 1;
 }

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -63,9 +63,6 @@ static i3Font font;
 /* Overall height of the bar (based on font size) */
 int bar_height;
 
-/* Cached width of the custom separator if one was set */
-int separator_symbol_width;
-
 /* These are only relevant for XKB, which we only need for grabbing modifiers */
 int xkb_base;
 int mod_pressed = 0;


### PR DESCRIPTION
There's no reason not to provide a reasonable default; sorry for not doing this right away. I don't think it's a problem to add this now because it only means the user doesn't have to do something they would otherwise have to do. Also, it caused some confusion, see https://faq.i3wm.org/question/5727/how-to-set-separator-in-i3bar/