### PR TITLE
Bump testsuite dependencies versions

### DIFF
--- a/testcases/Makefile.PL
+++ b/testcases/Makefile.PL
@@ -8,8 +8,8 @@ WriteMakefile(
     MIN_PERL_VERSION => '5.010000', # 5.10.0
     PREREQ_PM => {
         'AnyEvent'     => 0,
-        'AnyEvent::I3' => '0.15',
-        'X11::XCB'     => '0.09',
+        'AnyEvent::I3' => '0.16',
+        'X11::XCB'     => '0.12',
         'Inline'       => 0,
         'Inline::C'    => 0,
         'ExtUtils::PkgConfig' => 0,


### PR DESCRIPTION
~265 test fail with x11:xcb 0.11 
and ~13 with anyevent:i3 0.15 (thought I am not sure about this one)