### PR TITLE
Fix ‘FALSE’ undeclared (first use in this function) when i3 is built w/o PANGO

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -880,7 +880,7 @@ static void handle_client_message(xcb_client_message_event_t *event) {
                 floating_drag_window(con->parent, &fake);
                 break;
             case _NET_WM_MOVERESIZE_SIZE_TOPLEFT... _NET_WM_MOVERESIZE_SIZE_LEFT:
-                floating_resize_window(con->parent, FALSE, &fake);
+                floating_resize_window(con->parent, false, &fake);
                 break;
             default:
                 DLOG("_NET_WM_MOVERESIZE direction %d not implemented\n", direction);


### PR DESCRIPTION
When trying to build without PANGO support you get:
```
../i3/src/handlers.c: In function ‘handle_client_message’:
../i3/src/handlers.c:883:53: error: ‘FALSE’ undeclared (first use in this function)
                 floating_resize_window(con->parent, FALSE, &fake);
                                                     ^
../i3/src/handlers.c:883:53: note: each undeclared identifier is reported only once for each function it appears in
```

See downstream [bug](https://bugs.gentoo.org/show_bug.cgi?id=546444) for more info.