### PR TITLE
bugfix: serialize con_id with %p in run_binding()

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -431,7 +431,7 @@ CommandResult *run_binding(Binding *bind, Con *con) {
     if (con == NULL)
         command = sstrdup(bind->command);
     else
-        sasprintf(&command, "[con_id=\"%d\"] %s", con, bind->command);
+        sasprintf(&command, "[con_id=\"%p\"] %s", con, bind->command);
 
     Binding *bind_cp = binding_copy(bind);
     CommandResult *result = parse_command(command, NULL);


### PR DESCRIPTION
When a con is given to run_binding() to run the command in the context
of this con such as when running a mouse binding, serialize the con_id
with %p. This seems to be more consistent across Unixes.

fixes #1668