### PR TITLE
Focus containers by number

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1648,6 +1648,13 @@ mode_toggle::
 output::
 	Followed by a direction or an output name, this will focus the
 	corresponding output.
+local::
+        Followed by a number, this will focus the n-th child of the currently
+        focused container's parent.
+global::
+        Followed by a number, this works similarly to +local+, but instead of
+        focusing the n-th child of the parent, it focuses the n-th child of the
+        currently focused container's workspace.
 
 For moving, use +move left+, +move right+, +move down+ and +move up+.
 
@@ -1656,6 +1663,7 @@ For moving, use +move left+, +move right+, +move down+ and +move up+.
 focus <left|right|down|up>
 focus <parent|child|floating|tiling|mode_toggle>
 focus output <<left|right|down|up>|output>
+focus local|global <number>
 move <left|right|down|up> [<px> px]
 move [absolute] position [[<px> px] [<px> px]|center]
 -----------------------------------

--- a/include/commands.h
+++ b/include/commands.h
@@ -187,6 +187,12 @@ void cmd_focus_window_mode(I3_CMD, char *window_mode);
 void cmd_focus_level(I3_CMD, char *level);
 
 /**
+ * Implementation of 'focus local|global <n>'
+ *
+ */
+void cmd_focus_number(I3_CMD, char *context, char *_n);
+
+/**
  * Implementation of 'focus'.
  *
  */

--- a/include/con.h
+++ b/include/con.h
@@ -382,3 +382,11 @@ char *con_get_tree_representation(Con *con);
  *
  */
 void con_force_split_parents_redraw(Con *con);
+
+/**
+ * Returns the n-th child window of con.
+ * Tabbed and stacked containers are considered one window
+ * while for all other split containers, it will descend recursively.
+ *
+ */
+Con *con_get_nth(Con *con, int n);

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -133,6 +133,7 @@ state WORKSPACE_NUMBER:
 # focus output <output>
 # focus tiling|floating|mode_toggle
 # focus parent|child
+# focus local|global <n>
 # focus
 state FOCUS:
   direction = 'left', 'right', 'up', 'down'
@@ -143,12 +144,18 @@ state FOCUS:
       -> call cmd_focus_window_mode($window_mode)
   level = 'parent', 'child'
       -> call cmd_focus_level($level)
+  context = 'local', 'global'
+      -> FOCUS_NUMBER
   end
       -> call cmd_focus()
 
 state FOCUS_OUTPUT:
   output = string
       -> call cmd_focus_output($output)
+
+state FOCUS_NUMBER:
+  n = word
+      -> call cmd_focus_number($context, $n)
 
 # kill [window|client]
 state KILL:

--- a/src/con.c
+++ b/src/con.c
@@ -1819,3 +1819,37 @@ char *con_get_tree_representation(Con *con) {
 
     return complete_buf;
 }
+
+static Con *_con_get_nth(Con *con, int *n) {
+    Con *current;
+    TAILQ_FOREACH(current, &(con->nodes_head), nodes) {
+        /* We consider leaf containers and tabbed / stacked containers to be
+         * actual window like containers since this is how it appears to the user. */
+        if (con_is_leaf(current) ||
+                current->layout == L_STACKED || current->layout == L_TABBED) {
+            if (*n == 1)
+                return current;
+
+            (*n)--;
+            continue;
+        }
+
+        /* For other split containers, we don't consider the split container itself,
+         * but instead go through its children. */
+        Con *recursed = _con_get_nth(current, n);
+        if (recursed != NULL)
+            return recursed;
+    }
+
+    return NULL;
+}
+
+/**
+ * Returns the n-th child window of con.
+ * Tabbed and stacked containers are considered one window
+ * while for all other split containers, it will descend recursively.
+ *
+ */
+Con *con_get_nth(Con *con, int n) {
+    return _con_get_nth(con, &n);
+}

--- a/testcases/t/244-focus-local-global.t
+++ b/testcases/t/244-focus-local-global.t
@@ -1,0 +1,169 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests the 'focus local|global <n>' directives.
+# Ticket: #1214
+use i3test;
+
+sub cmd_focus {
+    my ($type, $n) = @_;
+    my $command = cmd "focus $type $n";
+    sync_with_i3;
+    return $command->[0];
+}
+
+my ($A, $B, $C, $D, $command);
+my @types = ('local', 'global');
+
+###############################################################################
+# Given three containers A, B and C in horizontal|vertical layout, when
+# focusing local|global, then the correct container is selected.
+###############################################################################
+
+for my $layout (('horizontal', 'vertical')) {
+
+    fresh_workspace;
+    cmd "layout $layout";
+    $A = open_window;
+    $B = open_window;
+    $C = open_window;
+
+    for my $type (@types) {
+
+        cmd_focus('local', 1);
+        is($x->input_focus, $A->{id}, 'A is focused');
+        cmd_focus('local', 2);
+        is($x->input_focus, $B->{id}, 'B is focused');
+        cmd_focus('local', 3);
+        is($x->input_focus, $C->{id}, 'C is focused');
+
+    }
+
+}
+
+###############################################################################
+# Given a tabbed container with tabs A, B and C, when focusing local, then
+# the correct tab is selected.
+# Given the same tabbed container, when focusing global, then only '1' works.
+###############################################################################
+
+fresh_workspace;
+$A = open_window;
+cmd 'layout tabbed';
+$B = open_window;
+$C = open_window;
+
+cmd_focus('local', 1);
+is($x->input_focus, $A->{id}, 'A is focused when selecting 1 locally');
+cmd_focus('local', 2);
+is($x->input_focus, $B->{id}, 'B is focused when selecting 2 locally');
+
+cmd_focus('global', 1);
+is($x->input_focus, $B->{id}, 'B is focused when selecting 1 globally');
+
+$command = cmd_focus('global', 2);
+ok(!$command->{success}, 'command fails when selecting 2 globally');
+is($x->input_focus, $B->{id}, 'B is still focused');
+
+###############################################################################
+# Given H[A V[B C]] as a layout, when selecting globally, then the correct
+# window is focused.
+###############################################################################
+
+fresh_workspace;
+$A = open_window;
+$B = open_window;
+cmd 'split v';
+$C = open_window;
+
+cmd_focus('global', 1);
+is($x->input_focus, $A->{id}, 'A is focused when selecting 1 globally');
+cmd_focus('global', 2);
+is($x->input_focus, $B->{id}, 'B is focused when selecting 2 globally');
+cmd_focus('global', 3);
+is($x->input_focus, $C->{id}, 'C is focused when selecting 3 globally');
+
+###############################################################################
+# Given H[A V[B C]] as a layout, when selecting locally, then the correct
+# window is focused.
+###############################################################################
+
+fresh_workspace;
+$A = open_window;
+$B = open_window;
+cmd 'split v';
+$C = open_window;
+
+cmd_focus('local', 1);
+is($x->input_focus, $B->{id}, 'B is focused when selecting 1 locally');
+cmd_focus('local', 2);
+is($x->input_focus, $C->{id}, 'C is focused when selecting 2 locally');
+$command = cmd_focus('local', 3);
+ok(!$command->{success}, 'command fails when selecting 3 locally');
+
+###############################################################################
+# Given H[A V[B S[C D]]], when focusing locally, then the correct focus is
+# set.
+# Given the same layout, when focusing the stacked container globally, then
+# the focus head is selected.
+###############################################################################
+
+fresh_workspace;
+$A = open_window;
+$B = open_window;
+cmd 'split v';
+$C = open_window;
+cmd 'split v';
+$D = open_window;
+cmd 'layout stacked';
+
+cmd_focus('local', 1);
+is($x->input_focus, $C->{id}, 'C is focused when selecting 1 locally');
+
+cmd 'focus parent';
+cmd_focus('local', 1);
+is($x->input_focus, $B->{id}, 'B is focused when selecting 1 locally');
+
+cmd 'focus left';
+cmd_focus('global', 3);
+is($x->input_focus, $C->{id}, 'C is focused when selecting 3 globally');
+
+###############################################################################
+# Given nested tabbed containers, when selecting locally, then the correct
+# tab is selected.
+# Given the same layout, when focusing parents, then the correct tabbed
+# container is used and the focus head of its tab is selected.
+###############################################################################
+
+fresh_workspace;
+$A = open_window;
+cmd 'layout tabbed';
+$B = open_window;
+cmd 'split v';
+$C = open_window;
+cmd 'layout stacked';
+$D = open_window;
+
+cmd_focus('local', 2);
+is($x->input_focus, $C->{id}, 'C is focused when selecting 2 locally');
+
+cmd 'focus parent';
+cmd_focus('local', 1);
+is($x->input_focus, $A->{id}, 'A is focused when selecting 1 locally');
+
+###############################################################################
+
+done_testing;


### PR DESCRIPTION
I'd like to get input first. As mentioned in the issue:
* Do we want both "concepts" (local, global)? The global concept can be emulated by focusing the workspace first, but the extra implementation effort is almost none and I think it's a valid usecase.
* I'm not happy with the current syntax. For the "local" mode, I could imagine using `focus container <n>`, but I'd a) like feedback on this and b) still need a good way for the "global" concept (if we want to keep it).