### PR TITLE
Check if output is disabled in handle_output()

### DIFF
--- a/src/randr.c
+++ b/src/randr.c
@@ -555,6 +555,12 @@ static void handle_output(xcb_connection_t *conn, xcb_randr_output_t id,
         return;
     }
 
+    if (output->connection == XCB_RANDR_CONNECTION_DISCONNECTED) {
+        DLOG("Disabling output %s: it is disconnected\n", new->name);
+        new->to_be_disabled = true;
+        return;
+    }
+
     bool updated = update_if_necessary(&(new->rect.x), crtc->x) |
                    update_if_necessary(&(new->rect.y), crtc->y) |
                    update_if_necessary(&(new->rect.width), crtc->width) |


### PR DESCRIPTION
Check if the `connection` of the randr output is
XCB_RANDR_CONNECTION_DISONNECTED and disable the output if it is.

This fixes an issue where the output would not be disabled if the output was
physically unplugged from the machine.