### PR TITLE
Only detect clicks within the statusline width.

### DIFF
--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -420,7 +420,7 @@ void handle_button(xcb_button_press_event_t *event) {
         int offset = walk->rect.w - statusline_width - tray_width - logical_px(sb_hoff_px);
 
         x = original_x - offset;
-        if (x >= 0) {
+        if (x >= 0 && (size_t)x < statusline_width) {
             struct status_block *block;
             int sep_offset_remainder = 0;
 


### PR DESCRIPTION
If the user clicks on the very top of i3bar above a tray icon, i3bar might
mistakenly trigger the click event for the last status block. This is due to
the fact that the click detection considers the separator width of the block
even though on the last block this is ignored, incorrectly spanning the block's
width partially (or entirely) across the tray area.