### PR TITLE
Initialize workspace rect to the output's upon creation

### DIFF
--- a/src/workspace.c
+++ b/src/workspace.c
@@ -29,6 +29,7 @@ static void _workspace_apply_default_orientation(Con *ws) {
     if (config.default_orientation == NO_ORIENTATION) {
         Con *output = con_get_output(ws);
         ws->layout = (output->rect.height > output->rect.width) ? L_SPLITV : L_SPLITH;
+        ws->rect = output->rect;
         DLOG("Auto orientation. Workspace size set to (%d,%d), setting layout to %d.\n",
              output->rect.width, output->rect.height, ws->layout);
     } else {

--- a/testcases/t/244-new-workspace-floating-enable-center.t
+++ b/testcases/t/244-new-workspace-floating-enable-center.t
@@ -1,0 +1,53 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Ensures that 'move workspace $new, floating enable' on a marked window
+# leaves the window centered on the new workspace.
+# Bug still in: 4.10.2-137-ga4f0ed6
+use i3test i3_autostart => 0;
+
+my $config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+new_window none
+new_float none
+EOT
+
+my $pid = launch_with_config($config);
+
+#####################################################################
+# Open a tiled window, and then simultaneously move it to another
+# workspace and float it, ensuring that it ends up centered.
+#####################################################################
+
+my $window = open_window;
+my $unused = get_unused_workspace();
+
+cmd "mark foo; [con_mark=\"foo\"] move workspace $unused, floating enable";
+
+sync_with_i3;
+
+my $pos = $window->rect;
+
+is(int($pos->{x} + $pos->{width} / 2), int($x->root->rect->width / 2),
+    'x coordinates match');
+is(int($pos->{y} + $pos->{height} / 2), int($x->root->rect->height / 2),
+    'y coordinates match');
+
+exit_gracefully($pid);
+
+done_testing;


### PR DESCRIPTION
The comment immediately following implied that this was the intended behaviour. Not doing so means that compound commands that both move a window to a new workspace as well as do something that depends on the workspace's geometry (e.g. 'move position center' or 'floating enable' on a tiled window) would use the workspace's calloc'd 0x0+0x0 geometry.

The issue can be reproduced by running the following on a tiled window, assuming workspace 11 is unused:
`i3-msg -t command 'mark foo; [con_mark="foo"] move workspace 11, floating enable'`