### PR TITLE
[Adopted] Use WM_SIZE_HINTS when available to set the geometry of floating windows

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -428,6 +428,17 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
     if (cwindow->dock)
         want_floating = false;
 
+    /* Plasma windows set their geometry in WM_SIZE_HINTS. */
+    if ((wm_size_hints.flags & XCB_ICCCM_SIZE_HINT_US_POSITION || wm_size_hints.flags & XCB_ICCCM_SIZE_HINT_P_POSITION) &&
+        (wm_size_hints.flags & XCB_ICCCM_SIZE_HINT_US_SIZE || wm_size_hints.flags & XCB_ICCCM_SIZE_HINT_P_SIZE)) {
+        DLOG("We are setting geometry according to wm_size_hints x=%d y=%d w=%d h=%d\n",
+             wm_size_hints.x, wm_size_hints.y, wm_size_hints.width, wm_size_hints.height);
+        geom->x = wm_size_hints.x;
+        geom->y = wm_size_hints.y;
+        geom->width = wm_size_hints.width;
+        geom->height = wm_size_hints.height;
+    }
+
     /* Store the requested geometry. The width/height gets raised to at least
      * 75x50 when entering floating mode, which is the minimum size for a
      * window to be useful (smaller windows are usually overlays/toolbars/…


### PR DESCRIPTION
This is an adopted PR from #1456 by @pronobis since he seems to have abandoned the PR. I only incorporated the review comment. Since I'm not running KDE / Plasma, I cannot test it. So someone should verify this.