### PR TITLE
Add "move relative position" support

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1728,10 +1728,11 @@ Use the +move+ command to move a container.
 # defaults to 10 pixels.
 move <left|right|down|up> [<px> px]
 
-# Moves the container either to a specific location
-# or to the center of the screen. If 'absolute' is
-# used, it is moved to the center of all outputs.
-move [absolute] position [[<px> px] [<px> px]|center]
+# Moves the container either to a specific location,
+# by a specific offset or to the center of the screen.
+# If 'absolute' is used, it is moved to the center
+# of all outputs.
+move [absolute|relative] position [[<px> px] [<px> px]|center]
 
 # Moves the container to the current position of the
 # mouse cursor. Only affects floating containers.

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -270,7 +270,7 @@ state RENAME_WORKSPACE_NEW_NAME:
 # move [window|container] [to] scratchpad
 # move workspace to [output] <str>
 # move scratchpad
-# move [window|container] [to] [absolute] position [ [<pixels> [px] <pixels> [px]] | center ]
+# move [window|container] [to] [absolute|relative] position [ [<pixels> [px] <pixels> [px]] | center ]
 # move [window|container] [to] position mouse|cursor|pointer
 state MOVE:
   'window'
@@ -293,6 +293,8 @@ state MOVE:
       -> MOVE_TO_POSITION
   method = 'absolute'
       -> MOVE_TO_ABSOLUTE_POSITION
+  method = 'relative'
+      -> MOVE_TO_RELATIVE_POSITION
 
 state MOVE_DIRECTION:
   pixels = word
@@ -337,6 +339,10 @@ state MOVE_WORKSPACE_TO_OUTPUT:
       -> call cmd_move_workspace_to_output($output)
 
 state MOVE_TO_ABSOLUTE_POSITION:
+  'position'
+      -> MOVE_TO_POSITION
+
+state MOVE_TO_RELATIVE_POSITION:
   'position'
       -> MOVE_TO_POSITION
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -1755,7 +1755,7 @@ void cmd_focus_output(I3_CMD, char *name) {
 }
 
 /*
- * Implementation of 'move [window|container] [to] [absolute] position <px> [px] <px> [px]
+ * Implementation of 'move [window|container] [to] [absolute|relative] position <px> [px] <px> [px]
  *
  */
 void cmd_move_window_to_position(I3_CMD, char *method, char *cx, char *cy) {
@@ -1783,6 +1783,15 @@ void cmd_move_window_to_position(I3_CMD, char *method, char *cx, char *cy) {
             current->con->parent->rect.y = y;
 
             DLOG("moving to absolute position %d %d\n", x, y);
+            floating_maybe_reassign_ws(current->con->parent);
+            cmd_output->needs_tree_render = true;
+        }
+
+        if (strcmp(method, "relative") == 0) {
+            current->con->parent->rect.x += x;
+            current->con->parent->rect.y += y;
+
+            DLOG("moving by relative offset %d %d\n", x, y);
             floating_maybe_reassign_ws(current->con->parent);
             cmd_output->needs_tree_render = true;
         }

--- a/testcases/t/124-move.t
+++ b/testcases/t/124-move.t
@@ -235,6 +235,13 @@ cmd 'move position 5 px 15 px';
 is($floatcon[0]->{rect}->{x}, 5, 'moved to position 5 x');
 is($floatcon[0]->{rect}->{y}, 15, 'moved to position 15 y');
 
+cmd 'move relative position +3 px -12 px';
+
+@floatcon = @{get_ws($tmp)->{floating_nodes}};
+
+is($floatcon[0]->{rect}->{x}, 8, 'moved by offset 3 x');
+is($floatcon[0]->{rect}->{y}, 3, 'moved by offset -12 y');
+
 cmd 'move absolute position center';
 
 @floatcon = @{get_ws($tmp)->{floating_nodes}};

--- a/testcases/t/187-commands-parser.t
+++ b/testcases/t/187-commands-parser.t
@@ -150,7 +150,7 @@ is(parser_calls('unknown_literal'),
    'error for unknown literal ok');
 
 is(parser_calls('move something to somewhere'),
-   "ERROR: Expected one of these tokens: 'window', 'container', 'to', 'workspace', 'output', 'mark', 'scratchpad', 'left', 'right', 'up', 'down', 'position', 'absolute'\n" .
+   "ERROR: Expected one of these tokens: 'window', 'container', 'to', 'workspace', 'output', 'mark', 'scratchpad', 'left', 'right', 'up', 'down', 'position', 'absolute', 'relative'\n" .
    "ERROR: Your command: move something to somewhere\n" .
    "ERROR:                    ^^^^^^^^^^^^^^^^^^^^^^",
    'error for unknown literal ok');


### PR DESCRIPTION
Right now we can move floating windows in following fashion:

- to an absolute position
- to the center of the screen
- to the center of all screens
- in the specified direction

The last one might be sufficient for simple key bindings, but it's rather cumbersome to use in scripts. This proposal adds `move relative position X Y` command, that offsets current window position by X value in horizontal axis and Y value in vertical axis.

This makes it complementary with `resize grow X Y` and `resize shrink X Y` commands.