### PR TITLE
Allow pango markup for the binding indicator.

### DIFF
--- a/i3bar/src/mode.c
+++ b/i3bar/src/mode.c
@@ -32,7 +32,7 @@ static int mode_string_cb(void *params_, const unsigned char *val, size_t len) {
 
     if (!strcmp(params->cur_key, "change")) {
         /* Save the name */
-        params->mode->name = i3string_from_utf8_with_length((const char *)val, len);
+        params->mode->name = i3string_from_markup_with_length((const char *)val, len);
         /* Save its rendered width */
         params->mode->width = predict_text_width(params->mode->name);
 


### PR DESCRIPTION
The binding indicator is currently the only place in i3bar where pango markup is not supported (afaik).

Since workspace buttons are unconditionally parsed with markup, I think doing the same in the indicator is fine, too (a config directive is definitely overkill for this).