### PR TITLE
Fix warning about potentially uninitialized variable.

### DIFF
--- a/src/startup.c
+++ b/src/startup.c
@@ -131,7 +131,7 @@ void startup_sequence_delete(struct Startup_Sequence *sequence) {
  *
  */
 void start_application(const char *command, bool no_startup_id) {
-    SnLauncherContext *context;
+    SnLauncherContext *context = NULL;
 
     if (!no_startup_id) {
         /* Create a startup notification context to monitor the progress of this


### PR DESCRIPTION
fixes one of the last two warnings as discussed in #1538.