### PR TITLE
i3bar: fix freeing static strings

### DIFF
--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -107,14 +107,14 @@ __attribute__((format(printf, 1, 2))) static void set_statusline_error(const cha
 
     struct status_block *err_block = scalloc(sizeof(struct status_block));
     err_block->full_text = i3string_from_utf8("Error: ");
-    err_block->name = "error";
-    err_block->color = "red";
+    err_block->name = sstrdup("error");
+    err_block->color = sstrdup("red");
     err_block->no_separator = true;
 
     struct status_block *message_block = scalloc(sizeof(struct status_block));
     message_block->full_text = i3string_from_utf8(message);
-    message_block->name = "error_message";
-    message_block->color = "red";
+    message_block->name = sstrdup("error_message");
+    message_block->color = sstrdup("red");
     message_block->no_separator = true;
 
     TAILQ_INSERT_HEAD(&statusline_head, err_block, blocks);


### PR DESCRIPTION
This script set as a statusline command causes freeing of static memory in i3bar:
````bash
#!/usr/bin/env bash

echo '{"version": 1}'
echo '['
while true; do
    echo '[{"foobar:'
    sleep 1
done
````
````
[libi3] libi3/font.c Using Pango font Terminus, size 9
[libi3] libi3/font.c X11 root window dictates 96.455696 DPI
[i3bar] Could not parse JSON input (code = 2, message = lexical error: invalid character inside string.): 
[
[{"foobar:

[i3bar] Could not parse JSON input (code = 2, message = lexical error: invalid character inside string.): [{"foobar:

*** Error in `i3bar': double free or corruption (out): 0x0000000000411fc0 ***
````
This is my fix for that.