### PR TITLE
Added cmd_size

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1818,6 +1818,23 @@ mode "resize" {
 bindsym $mod+r mode "resize"
 ----------------------------------------------------------------------
 
+=== Resizing containers/windows
+
+If you want to give a window a specific size, you can use the +resize+ command,
+which takes the desired size as its argument. This command will only work on
+floating containers.
+
+*Syntax*:
+---------------------------------------------------------
+resize <width> [px] <height> [px]
+---------------------------------------------------------
+
+*Examples*:
+------------------------------------------------
+# Set urxvt size to 640x480
+for_window [class="urxvt"] resize 640 480
+------------------------------------------------
+
 === Jumping to specific windows
 
 Often when in a multi-monitor environment, you want to quickly jump to a

--- a/include/commands.h
+++ b/include/commands.h
@@ -61,6 +61,12 @@ void cmd_move_con_to_workspace_name(I3_CMD, char *name);
 void cmd_move_con_to_workspace_number(I3_CMD, char *which);
 
 /**
+ * Implementation of 'resize <px> [px] <px> [px]'.
+ *
+ */
+void cmd_size(I3_CMD, char *cwidth, char *cheight);
+
+/**
  * Implementation of 'resize grow|shrink <direction> [<px> px] [or <ppt> ppt]'.
  *
  */

--- a/include/floating.h
+++ b/include/floating.h
@@ -177,6 +177,15 @@ drag_result_t drag_pointer(Con *con, const xcb_button_press_event_t *event,
 void floating_reposition(Con *con, Rect newrect);
 
 /**
+ * Sets size of the CT_FLOATING_CON to specified dimensions. Might limit the
+ * actual size with regard to size constraints taken from user settings.
+ * Additionally, the dimensions may be upscaled until they're divisible by the
+ * window's size hints.
+ *
+ */
+void floating_resize(Con *floating_con, int x, int y);
+
+/**
  * Fixes the coordinates of the floating window whenever the window gets
  * reassigned to a different output (or when the output’s rect changes).
  *

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -205,6 +205,8 @@ state UNMARK:
 state RESIZE:
   way = 'grow', 'shrink'
       -> RESIZE_DIRECTION
+  width = word
+      -> RESIZE_WIDTH
 
 state RESIZE_DIRECTION:
   direction = 'up', 'down', 'left', 'right', 'width', 'height'
@@ -231,6 +233,16 @@ state RESIZE_TILING_OR:
 state RESIZE_TILING_FINAL:
   'ppt', end
       -> call cmd_resize($way, $direction, $resize_px, $resize_ppt)
+
+state RESIZE_WIDTH:
+  'px'
+      ->
+  height = word
+      -> RESIZE_HEIGHT
+
+state RESIZE_HEIGHT:
+  'px', end
+      -> call cmd_size($width, $height)
 
 # rename workspace <name> to <name>
 # rename workspace to <name>

--- a/src/commands.c
+++ b/src/commands.c
@@ -791,6 +791,35 @@ void cmd_resize(I3_CMD, char *way, char *direction, char *resize_px, char *resiz
 }
 
 /*
+ * Implementation of 'resize <px> [px] <px> [px]'.
+ *
+ */
+void cmd_size(I3_CMD, char *cwidth, char *cheight) {
+    DLOG("resizing to %sx%s px\n", cwidth, cheight);
+    // TODO: We could either handle this in the parser itself as a separate token (and make the stack typed) or we need a better way to convert a string to a number with error checking
+    int x = atoi(cwidth);
+    int y = atoi(cheight);
+    if (x <= 0 || y <= 0) {
+        ELOG("Resize failed: dimensions cannot be negative (was %sx%s)\n", cwidth, cheight);
+        return;
+    }
+
+    HANDLE_EMPTY_MATCH;
+
+    owindow *current;
+    TAILQ_FOREACH(current, &owindows, owindows) {
+        Con *floating_con;
+        if ((floating_con = con_inside_floating(current->con))) {
+            floating_resize(floating_con, x, y);
+        }
+    }
+
+    cmd_output->needs_tree_render = true;
+    // XXX: default reply for now, make this a better reply
+    ysuccess(true);
+}
+
+/*
  * Implementation of 'border normal|none|1pixel|toggle|pixel'.
  *
  */

--- a/src/floating.c
+++ b/src/floating.c
@@ -784,6 +784,33 @@ void floating_reposition(Con *con, Rect newrect) {
 }
 
 /*
+ * Sets size of the CT_FLOATING_CON to specified dimensions. Might limit the
+ * actual size with regard to size constraints taken from user settings.
+ * Additionally, the dimensions may be upscaled until they're divisible by the
+ * window's size hints.
+ *
+ */
+void floating_resize(Con *floating_con, int x, int y) {
+    DLOG("floating resize to %dx%d px\n", x, y);
+    Rect *rect = &floating_con->rect;
+    Con *focused_con = con_descend_focused(floating_con);
+    int wi = focused_con->width_increment;
+    int hi = focused_con->height_increment;
+    rect->width = x;
+    rect->height = y;
+    if (wi)
+        rect->width += (wi - 1 - rect->width) % wi;
+    if (hi)
+        rect->height += (hi - 1 - rect->height) % hi;
+
+    floating_check_size(floating_con);
+
+    /* If this is a scratchpad window, don't auto center it from now on. */
+    if (floating_con->scratchpad_state == SCRATCHPAD_FRESH)
+        floating_con->scratchpad_state = SCRATCHPAD_CHANGED;
+}
+
+/*
  * Fixes the coordinates of the floating window whenever the window gets
  * reassigned to a different output (or when the output’s rect changes).
  *

--- a/testcases/t/189-floating-constraints.t
+++ b/testcases/t/189-floating-constraints.t
@@ -186,4 +186,36 @@ is($rect->{y}, $old_y, 'window did not move when trying to resize');
 
 exit_gracefully($pid);
 
+################################################################################
+# 7: check floating_maximum_size with cmd_size
+################################################################################
+
+my $config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+# Test with different dimensions than the i3 default.
+floating_minimum_size 80 x 70
+floating_maximum_size 100 x 90
+EOT
+
+$pid = launch_with_config($config);
+
+my $window = open_floating_window(rect => [ 0, 0, 90, 80 ]);
+cmd 'border none';
+
+cmd 'resize 101 91';
+sync_with_i3;
+my $rect = $window->rect;
+is($rect->{width}, 100, 'width did not exceed maximum width');
+is($rect->{height}, 90, 'height did not exceed maximum height');
+
+cmd 'resize 79 69';
+sync_with_i3;
+$rect = $window->rect;
+is($rect->{width}, 80, 'width did not exceed minimum width');
+is($rect->{height}, 70, 'height did not exceed minimum height');
+
+exit_gracefully($pid);
+
 done_testing;

--- a/testcases/t/240-floating-size.t
+++ b/testcases/t/240-floating-size.t
@@ -1,0 +1,45 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Test behavior of "resize <width> <height>" command.
+# Ticket: #1727
+# Bug still in: 4.10.2-1-gc0dbc5d
+use i3test;
+
+################################################################################
+# Check that setting floating windows size works
+################################################################################
+
+my $tmp = fresh_workspace;
+
+open_floating_window;
+
+my @content = @{get_ws($tmp)->{floating_nodes}};
+is(@content, 1, 'one floating node on this ws');
+
+my $oldrect = $content[0]->{rect};
+
+cmd 'resize 100 px 250 px';
+
+@content = @{get_ws($tmp)->{floating_nodes}};
+cmp_ok($content[0]->{rect}->{x}, '==', $oldrect->{x}, 'x untouched');
+cmp_ok($content[0]->{rect}->{y}, '==', $oldrect->{y}, 'y untouched');
+cmp_ok($content[0]->{rect}->{width}, '!=', $oldrect->{width}, 'width changed');
+cmp_ok($content[0]->{rect}->{height}, '!=', $oldrect->{width}, 'height changed');
+cmp_ok($content[0]->{rect}->{width}, '==', 100, 'width changed to 100 px');
+cmp_ok($content[0]->{rect}->{height}, '==', 250, 'height changed to 250 px');
+
+done_testing;


### PR DESCRIPTION
Implements #1727.

- Doesn't move window, for this one should use `move direction` or `move position`.
- Size hints are untested, since I had no idea how to test them.
- Doesn't do anything for containers. IMO resizing containers to specific sizes is different enough to deserve a separate feature/pull request.