### PR TITLE
Implement "title_format"

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -564,6 +564,8 @@ hide_edge_borders vertical
 
 === Arbitrary commands for specific windows (for_window)
 
+[[for_window]]
+
 With the +for_window+ command, you can let i3 execute any command when it
 encounters a specific window. This can be used to set windows to floating or to
 change their border style, for example.
@@ -2065,6 +2067,37 @@ bindsym $mod+g exec i3-input -p 'goto ' -l 1 -P 'Goto: '
 Alternatively, if you do not want to mess with +i3-input+, you could create
 seperate bindings for a specific set of labels and then only use those labels.
 ///////////////////////////////////////////////////////////////////
+
+=== Window title format
+
+By default, i3 will simply print the X11 window title. Using +title_format+,
+this can be customized by setting the format to the desired output. This
+directive supports
+https://developer.gnome.org/pango/stable/PangoMarkupFormat.html[Pango markup]
+and the following placeholders which will be replaced:
+
++%title+::
+    The X11 window title (_NET_WM_NAME or WM_NAME as fallback).
+
+Using the <<for_window>> directive, you can set the title format for any window
+based on <<command_criteria>>.
+
+*Syntax*:
+---------------------
+title_format <format>
+---------------------
+
+*Examples*:
+-------------------------------------------------------------------------------------
+# give the focused window a prefix
+bindsym $mod+p title_format "Important | %title"
+
+# print all window titles bold
+for_window [class=".*"] title_format "<b>%title</b>"
+
+# print window titles of firefox windows red
+for_window [class="(?i)firefox"] title_format "<span foreground='red'>%title</span>"
+-------------------------------------------------------------------------------------
 
 === Changing border style
 

--- a/include/commands.h
+++ b/include/commands.h
@@ -277,6 +277,12 @@ void cmd_move_scratchpad(I3_CMD);
 void cmd_scratchpad_show(I3_CMD);
 
 /**
+ * Implementation of 'title_format <format>'
+ *
+ */
+void cmd_title_format(I3_CMD, char *format);
+
+/**
  * Implementation of 'rename workspace <name> to <name>'
  *
  */

--- a/include/data.h
+++ b/include/data.h
@@ -363,6 +363,8 @@ struct Window {
 
     /** The name of the window. */
     i3String *name;
+    /** The format with which the window's name should be displayed. */
+    char *title_format;
 
     /** The WM_WINDOW_ROLE of this window (for example, the pidgin buddy window
      * sets "buddy list"). Useful to match specific windows in assignments or

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -244,6 +244,11 @@ bool i3string_is_markup(i3String *str);
 void i3string_set_markup(i3String *str, bool is_markup);
 
 /**
+ * Escape pango markup characters in the given string.
+ */
+i3String *i3string_escape_markup(i3String *str);
+
+/**
  * Returns the number of glyphs in an i3String.
  *
  */
@@ -380,6 +385,12 @@ xcb_char2b_t *convert_utf8_to_ucs2(char *input, size_t *real_strlen);
  *
  */
 void set_font_colors(xcb_gcontext_t gc, uint32_t foreground, uint32_t background);
+
+/**
+ * Returns true if and only if the current font is a pango font.
+ *
+ */
+bool font_is_pango(void);
 
 /**
  * Draws text onto the specified X drawable (normally a pixmap) at the

--- a/libi3/font.c
+++ b/libi3/font.c
@@ -340,6 +340,18 @@ void set_font_colors(xcb_gcontext_t gc, uint32_t foreground, uint32_t background
     }
 }
 
+/*
+ * Returns true if and only if the current font is a pango font.
+ *
+ */
+bool font_is_pango(void) {
+#if PANGO_SUPPORT
+    return savedFont->type == FONT_TYPE_PANGO;
+#else
+    return false;
+#endif
+}
+
 static int predict_text_width_xcb(const xcb_char2b_t *text, size_t text_len);
 
 static void draw_text_xcb(const xcb_char2b_t *text, size_t text_len, xcb_drawable_t drawable,

--- a/libi3/string.c
+++ b/libi3/string.c
@@ -13,6 +13,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if PANGO_SUPPORT
+#include <glib.h>
+#endif
+
 #include "libi3.h"
 
 struct _i3String {
@@ -183,6 +187,18 @@ bool i3string_is_markup(i3String *str) {
  */
 void i3string_set_markup(i3String *str, bool is_markup) {
     str->is_markup = is_markup;
+}
+
+/*
+ * Escape pango markup characters in the given string.
+ */
+i3String *i3string_escape_markup(i3String *str) {
+#if PANGO_SUPPORT
+    const char *text = i3string_as_utf8(str);
+    return i3string_from_utf8(g_markup_escape_text(text, -1));
+#else
+    return str;
+#endif
 }
 
 /*

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -37,6 +37,7 @@ state INITIAL:
   'rename' -> RENAME
   'nop' -> NOP
   'scratchpad' -> SCRATCHPAD
+  'title_format' -> TITLE_FORMAT
   'mode' -> MODE
   'bar' -> BAR
 
@@ -373,6 +374,10 @@ state NOP:
 state SCRATCHPAD:
   'show'
       -> call cmd_scratchpad_show()
+
+state TITLE_FORMAT:
+  format = string
+      -> call cmd_title_format($format)
 
 # bar (hidden_state hide|show|toggle)|(mode dock|hide|invisible|toggle) [<bar_id>]
 state BAR:

--- a/src/commands.c
+++ b/src/commands.c
@@ -1900,6 +1900,17 @@ void cmd_scratchpad_show(I3_CMD) {
 }
 
 /*
+ * Implementation of 'title_format <format>'
+ *
+ */
+void cmd_title_format(I3_CMD, char *format) {
+    DLOG("setting title_format to %s\n", format);
+
+    cmd_output->needs_tree_render = true;
+    ysuccess(true);
+}
+
+/*
  * Implementation of 'rename workspace [<name>] to <name>'
  *
  */

--- a/src/commands.c
+++ b/src/commands.c
@@ -1904,7 +1904,25 @@ void cmd_scratchpad_show(I3_CMD) {
  *
  */
 void cmd_title_format(I3_CMD, char *format) {
-    DLOG("setting title_format to %s\n", format);
+    DLOG("setting title_format to \"%s\"\n", format);
+    HANDLE_EMPTY_MATCH;
+
+    owindow *current;
+    TAILQ_FOREACH(current, &owindows, owindows) {
+        if (current->con->window == NULL)
+            continue;
+
+        DLOG("setting title_format for %p / %s\n", current->con, current->con->name);
+        FREE(current->con->window->title_format);
+
+        /* If we only display the title without anything else, we can skip the parsing step,
+         * so we remove the title format altogether. */
+        if (strcasecmp(format, "%title") != 0)
+            current->con->window->title_format = sstrdup(format);
+
+        /* Make sure the window title is redrawn immediately. */
+        current->con->window->name_x_changed = true;
+    }
 
     cmd_output->needs_tree_render = true;
     ysuccess(true);

--- a/testcases/t/187-commands-parser.t
+++ b/testcases/t/187-commands-parser.t
@@ -144,7 +144,7 @@ is(parser_calls("\nworkspace test"),
 ################################################################################
 
 is(parser_calls('unknown_literal'),
-   "ERROR: Expected one of these tokens: <end>, '[', 'move', 'exec', 'exit', 'restart', 'reload', 'shmlog', 'debuglog', 'border', 'layout', 'append_layout', 'workspace', 'focus', 'kill', 'open', 'fullscreen', 'split', 'floating', 'mark', 'unmark', 'resize', 'rename', 'nop', 'scratchpad', 'mode', 'bar'\n" .
+   "ERROR: Expected one of these tokens: <end>, '[', 'move', 'exec', 'exit', 'restart', 'reload', 'shmlog', 'debuglog', 'border', 'layout', 'append_layout', 'workspace', 'focus', 'kill', 'open', 'fullscreen', 'split', 'floating', 'mark', 'unmark', 'resize', 'rename', 'nop', 'scratchpad', 'title_format', 'mode', 'bar'\n" .
    "ERROR: Your command: unknown_literal\n" .
    "ERROR:               ^^^^^^^^^^^^^^^",
    'error for unknown literal ok');


### PR DESCRIPTION
I verified that not using a pango font doesn't mistakenly escape the window title. I do strongly suggest we get at least someone else (@acrisci, @ambihelical being canonical candidates) to play around with this first.

One open question for me is if we need to handle other characters when escaping pango markup. The glib implementation seems to do something (see my comment in #1723 where I pasted their implementation), but I don't really understand what's happening there, so input is much appreciated.

Here are some quick screenshots:
![screenshot-2015-06-10_19-10-57](https://cloud.githubusercontent.com/assets/2392216/8089002/8d94c9c8-0fa5-11e5-99cf-e626aea2e274.png)
![screenshot-2015-06-10_19-12-37](https://cloud.githubusercontent.com/assets/2392216/8089004/8d96cf70-0fa5-11e5-9218-4ada6cca142f.png)
![screenshot-2015-06-10_19-15-20](https://cloud.githubusercontent.com/assets/2392216/8089003/8d95a546-0fa5-11e5-9a40-90f61f830d5c.png)

fixes #1723