### PR TITLE
Display which config is used in --more_version

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -582,11 +582,14 @@ human_readable (string)::
 	build date and branch name. When you need to display the i3 version to
 	your users, use the human-readable version whenever possible (since
 	this is what +i3 --version+ displays, too).
+loaded_config_file_name (string)::
+	The current config path.
 
 *Example:*
 -------------------
 {
    "human_readable" : "4.2-169-gf80b877 (2012-08-05, branch \"next\")",
+   "loaded_config_file_name" : "/home/hwangcc23/.i3/config",
    "minor" : 2,
    "patch" : 0,
    "major" : 4

--- a/src/display_version.c
+++ b/src/display_version.c
@@ -16,20 +16,25 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <fcntl.h>
+#include <time.h>
 #include "all.h"
 
-static bool human_readable_key;
-static char *human_readable_version;
+static bool human_readable_key, loaded_config_file_name_key;
+static char *human_readable_version, *loaded_config_file_name;
 
 static int version_string(void *ctx, const unsigned char *val, size_t len) {
     if (human_readable_key)
         sasprintf(&human_readable_version, "%.*s", (int)len, val);
+    if (loaded_config_file_name_key)
+        sasprintf(&loaded_config_file_name, "%.*s", (int)len, val);
     return 1;
 }
 
 static int version_map_key(void *ctx, const unsigned char *stringval, size_t stringlen) {
     human_readable_key = (stringlen == strlen("human_readable") &&
                           strncmp((const char *)stringval, "human_readable", strlen("human_readable")) == 0);
+    loaded_config_file_name_key = (stringlen == strlen("loaded_config_file_name") &&
+                                   strncmp((const char *)stringval, "loaded_config_file_name", strlen("loaded_config_file_name")) == 0);
     return 1;
 }
 
@@ -103,6 +108,21 @@ void display_running_version(void) {
         errx(EXIT_FAILURE, "Could not parse my own reply. That's weird. reply is %.*s", (int)reply_length, reply);
 
     printf("\rRunning i3 version: %s (pid %s)\n", human_readable_version, pid_from_atom);
+
+    if (loaded_config_file_name) {
+        struct stat sb;
+        time_t now;
+        char mtime[64];
+        printf("Loaded i3 config: %s", loaded_config_file_name);
+        if (stat(loaded_config_file_name, &sb) == -1) {
+            printf("\n");
+            ELOG("Cannot stat config file \"%s\"\n", loaded_config_file_name);
+        } else {
+            strftime(mtime, sizeof(mtime), "%c", localtime(&(sb.st_mtime)));
+            time(&now);
+            printf(" (Last modified: %s, %.f seconds ago)\n", mtime, difftime(now, sb.st_mtime));
+        }
+    }
 
 #ifdef __linux__
     size_t destpath_size = 1024;

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -814,6 +814,9 @@ IPC_HANDLER(get_version) {
     ystr("human_readable");
     ystr(i3_version);
 
+    ystr("loaded_config_file_name");
+    ystr(current_configpath);
+
     y(map_close);
 
     const unsigned char *payload;


### PR DESCRIPTION
Display the path of the used config and its last modified time in the output of i3 --moreversion.
See the issue #1785 for the discussion and the usage.
