### PR TITLE
i3bar/child: Tell shell to always exec child

### DIFF
--- a/i3bar/include/child.h
+++ b/i3bar/include/child.h
@@ -46,7 +46,7 @@ typedef struct {
  * about arguments and such
  *
  */
-void start_child(char *command);
+void start_child(const char *command);
 
 /*
  * kill()s the child process (if any). Called when exit()ing.

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -501,7 +501,7 @@ void child_write_output(void) {
  * in the bar config, no child will be started.
  *
  */
-void start_child(char *command) {
+void start_child(const char *command) {
     if (command == NULL)
         return;
 

--- a/i3bar/src/ipc.c
+++ b/i3bar/src/ipc.c
@@ -79,6 +79,9 @@ void got_output_reply(char *reply) {
  *
  */
 void got_bar_config(char *reply) {
+    const char *command;
+    char *command_ = NULL;
+
     DLOG("Received bar config \"%s\"\n", reply);
     /* We initiate the main function by requesting infos about the outputs and
      * workspaces. Everything else (creating the bars, showing the right workspace-
@@ -100,7 +103,16 @@ void got_bar_config(char *reply) {
     /* Resolve color strings to colorpixels and save them, then free the strings. */
     init_colors(&(config.colors));
 
-    start_child(config.command);
+    if (strncmp(config.command, "exec ", strlen("exec ")) == 0) {
+        command = config.command;
+    } else {
+        sasprintf(&command_, "exec %s", config.command);
+        command = command_;
+    }
+
+    start_child(command);
+
+    FREE(command_);
     FREE(config.command);
 }
 


### PR DESCRIPTION
Fixes an orphan issue when:
- Shell does not exec status_command (like dash)
- status_command is not using SIGSTOP/SIGCONT (like j4status)

Signed-off-by: Quentin Glidic <sardemff7+git@sardemff7.net>