### PR TITLE
Add setenv command

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -2241,6 +2241,27 @@ bindsym $mod+minus scratchpad show
 bindsym mod4+s [title="^Sup ::"] scratchpad show
 ------------------------------------------------
 
+=== Setting environment variables
+
+There is a command to set environment variables for the i3 process. This is
+useful if you want some environment for everything in your i3 session but
+don't have the means to do so from your display manager (or what you might
+otherwise use to start i3). Environment variables in the value are expanded.
+
+*Syntax*:
+--------------------
+setenv <key> <value>
+--------------------
+
+*Example*:
+
+---------------------------
+# Set language
+setenv LANG=de_DE.utf8
+# Amend PATH by ~/bin
+setenv PATH=$PATH:$HOME/bin
+---------------------------
+
 === Nop
 
 There is a no operation command +nop+ which allows you to override default

--- a/include/commands.h
+++ b/include/commands.h
@@ -305,3 +305,9 @@ void cmd_shmlog(I3_CMD, char *argument);
  *
  */
 void cmd_debuglog(I3_CMD, char *argument);
+
+/*
+ * Implementation of 'setenv <key> <value>'
+ *
+ */
+void cmd_setenv(I3_CMD, char *key, char *value);

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -40,6 +40,7 @@ state INITIAL:
   'title_format' -> TITLE_FORMAT
   'mode' -> MODE
   'bar' -> BAR
+  'setenv' -> SETENV
 
 state CRITERIA:
   ctype = 'class'       -> CRITERION
@@ -400,3 +401,12 @@ state BAR_W_ID:
       ->
   end
       -> call cmd_bar($bar_type, $bar_value, $bar_id)
+
+# setenv <key> <value>
+state SETENV:
+  key = word
+      -> SETENV_VALUE
+
+state SETENV_VALUE:
+  value = string
+      -> call cmd_setenv($key, $value)

--- a/testcases/t/187-commands-parser.t
+++ b/testcases/t/187-commands-parser.t
@@ -144,7 +144,7 @@ is(parser_calls("\nworkspace test"),
 ################################################################################
 
 is(parser_calls('unknown_literal'),
-   "ERROR: Expected one of these tokens: <end>, '[', 'move', 'exec', 'exit', 'restart', 'reload', 'shmlog', 'debuglog', 'border', 'layout', 'append_layout', 'workspace', 'focus', 'kill', 'open', 'fullscreen', 'split', 'floating', 'mark', 'unmark', 'resize', 'rename', 'nop', 'scratchpad', 'title_format', 'mode', 'bar'\n" .
+   "ERROR: Expected one of these tokens: <end>, '[', 'move', 'exec', 'exit', 'restart', 'reload', 'shmlog', 'debuglog', 'border', 'layout', 'append_layout', 'workspace', 'focus', 'kill', 'open', 'fullscreen', 'split', 'floating', 'mark', 'unmark', 'resize', 'rename', 'nop', 'scratchpad', 'title_format', 'mode', 'bar', 'setenv'\n" .
    "ERROR: Your command: unknown_literal\n" .
    "ERROR:               ^^^^^^^^^^^^^^^",
    'error for unknown literal ok');

--- a/testcases/t/526-setenv.t
+++ b/testcases/t/526-setenv.t
@@ -1,0 +1,66 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests if a 'move <key> <value>' command will set the environment variable <key> to <value>.
+#
+use i3test;
+
+use POSIX qw(mkfifo);
+use File::Temp qw(:POSIX tempfile);
+
+#####################################################################
+# Try to set FOOBAR to baz
+#####################################################################
+
+cmd('setenv FOOBAR baz');
+
+my $fifo = tmpnam();
+mkfifo($fifo, 0600) or BAIL_OUT("Could not create FIFO in $fifo");
+
+cmd("exec echo \$FOOBAR > $fifo");
+
+open(my $fh, '<', $fifo);
+# Block on the FIFO, this will return exactly when the command is done.
+my $text = <$fh>;
+chomp($text);
+close($fh);
+unlink($fifo);
+
+is($text, "baz", "simple setenv command");
+
+#####################################################################
+# Try to append to FOOBAR, to test expansion
+#####################################################################
+
+cmd('setenv FOOBAR foo$FOOBAR');
+
+cmd("exec sh -c 'echo \$FOOBAR > $fifo'");
+
+$fifo = tmpnam();
+mkfifo($fifo, 0600) or BAIL_OUT("Could not create FIFO in $fifo");
+
+cmd("exec echo \$FOOBAR > $fifo");
+
+open($fh, '<', $fifo);
+# Block on the FIFO, this will return exactly when the command is done.
+$text = <$fh>;
+chomp($text);
+close($fh);
+unlink($fifo);
+
+is($text, "foobaz", "setenv expansion");
+
+done_testing;


### PR DESCRIPTION
Enables users to change the environment of a running i3 session as well as changing the environment in the config file (so that users don't need to do that in their display manager and/or don't need a .xsession).