### PR TITLE
Changes for compiling i3 on Illumos

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -178,6 +178,10 @@ else ifneq ($(UNAME),OpenBSD)
 LIBS += -lrt
 endif
 
+ifeq ($(UNAME),SunOS)
+LIBS += -lsocket -liconv -lgen
+endif
+
 ifneq (,$(filter Linux GNU GNU/%, $(UNAME)))
 I3_CPPFLAGS += -D_GNU_SOURCE
 endif

--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -799,7 +799,7 @@ int main(int argc, char *argv[]) {
     struct stat stbuf;
     sasprintf(&config_dir, "%s/i3", xdg_config_home);
     if (stat(config_dir, &stbuf) != 0)
-        if (!mkdirp(config_dir))
+        if (mkdirp(config_dir, DEFAULT_DIR_MODE) != 0)
             err(EXIT_FAILURE, "mkdirp(%s) failed", config_dir);
     free(config_dir);
     free(xdg_config_home);

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -21,6 +21,8 @@
 #include <pango/pango.h>
 #endif
 
+#define DEFAULT_DIR_MODE (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)
+
 /**
  * Opaque data structure for storing strings.
  *
@@ -471,8 +473,10 @@ char *resolve_tilde(const char *path);
  */
 char *get_config_path(const char *override_configpath, bool use_system_paths);
 
+#if !defined(__sun)
 /**
  * Emulates mkdir -p (creates any missing folders)
  *
  */
-bool mkdirp(const char *path);
+int mkdirp(const char *path, mode_t mode);
+#endif

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1087,7 +1087,7 @@ int ipc_create_socket(const char *filename) {
     char *copy = sstrdup(resolved);
     const char *dir = dirname(copy);
     if (!path_exists(dir))
-        mkdirp(dir);
+        mkdirp(dir, DEFAULT_DIR_MODE);
     free(copy);
 
     /* Unlink the unix domain socket before */

--- a/src/util.c
+++ b/src/util.c
@@ -222,7 +222,7 @@ char *store_restart_layout(void) {
     char *filenamecopy = sstrdup(filename);
     char *base = dirname(filenamecopy);
     DLOG("Creating \"%s\" for storing the restart layout\n", base);
-    if (!mkdirp(base))
+    if (mkdirp(base, DEFAULT_DIR_MODE) != 0)
         ELOG("Could not create \"%s\" for storing the restart layout, layout will be lost.\n", base);
     free(filenamecopy);
 


### PR DESCRIPTION
Very minor changes for compiling i3 on Illumos/Solaris.

The main issue was a collision between libi3's `mkdirp` and that of libgen on Illumos/Solaris. Here I have resolved this by renaming `mkdirp`. (I'm hoping that it is acceptable since libi3 is internal.)