### PR TITLE
Don't log motion notify

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -1319,7 +1319,9 @@ static void property_notify(uint8_t state, xcb_window_t window, xcb_atom_t atom)
  *
  */
 void handle_event(int type, xcb_generic_event_t *event) {
-    DLOG("event type %d, xkb_base %d\n", type, xkb_base);
+    if (type != XCB_MOTION_NOTIFY)
+        DLOG("event type %d, xkb_base %d\n", type, xkb_base);
+
     if (randr_base > -1 &&
         type == randr_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY) {
         handle_screen_change(event);


### PR DESCRIPTION
Do not log an XCB_MOTION_NOTIFY event in handlers.c because this
clutters the log.

Only log in the motion notify handler if something important happens.