### PR TITLE
Use bash instead of sh in i3-sensible scripts

### DIFF
--- a/i3-sensible-editor
+++ b/i3-sensible-editor
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This code is released in public domain by Han Boetes <han@mijncomputer.nl>
 #

--- a/i3-sensible-pager
+++ b/i3-sensible-pager
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This code is released in public domain by Han Boetes <han@mijncomputer.nl>
 

--- a/i3-sensible-terminal
+++ b/i3-sensible-terminal
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This code is released in public domain by Han Boetes <han@mijncomputer.nl>
 #


### PR DESCRIPTION
In the script you use 'command -v' which AFAIK is a bash built-in and
thus not available on all shells. Although /bin/sh links to /bin/bash on
many systems it does not on every system. So it is possible that it does
not work.