### PR TITLE
generate parser enums stably: additionally sort on name

### DIFF
--- a/generate-command-parser.pl
+++ b/generate-command-parser.pl
@@ -112,7 +112,7 @@ for my $line (@lines) {
 # We sort descendingly by length to be able to replace occurences of the state
 # name even when one state’s name is included in another one’s (like FOR_WINDOW
 # is in FOR_WINDOW_COMMAND).
-my @keys = sort { length($b) <=> length($a) } keys %states;
+my @keys = sort { (length($b) <=> length($a)) or ($a cmp $b) } keys %states;
 
 open(my $enumfh, '>', "GENERATED_${prefix}_enums.h");
 


### PR DESCRIPTION
Since Perl decided to start randomising hash orders between runs, the parser generator generates a different enum each time, which means that the binary unnecessarily varies between runs.  I don't know if this has any other consequences.

This is a problem for the Debian Reproducible Builds Project; the binaries have different object tables, and different enum constants throughout the code, e.g.:

````diff
-   369: 00000000006532b0    24 OBJECT  LOCAL  DEFAULT   24 tokens_RENAME_WORKSPACE_T
-   370: 0000000000653280    48 OBJECT  LOCAL  DEFAULT   24 tokens_RESIZE_TILING_FINA
-   371: 0000000000653240    48 OBJECT  LOCAL  DEFAULT   24 tokens_MOVE_TO_POSITION_X
-   372: 0000000000653200    48 OBJECT  LOCAL  DEFAULT   24 tokens_MOVE_TO_POSITION_Y
-   373: 00000000006531c0    48 OBJECT  LOCAL  DEFAULT   24 tokens_FULLSCREEN_COMPAT
-   374: 0000000000653180    48 OBJECT  LOCAL  DEFAULT   24 tokens_MOVE_DIRECTION_PX
-   375: 0000000000653150    24 OBJECT  LOCAL  DEFAULT   24 tokens_WORKSPACE_NUMBER
-   376: 00000000006530c0   144 OBJECT  LOCAL  DEFAULT   24 tokens_RESIZE_DIRECTION
-   377: 0000000000653080    48 OBJECT  LOCAL  DEFAULT   24 tokens_RENAME_WORKSPACE
-   378: 0000000000653040    48 OBJECT  LOCAL  DEFAULT   24 tokens_MOVE_TO_POSITION
-   379: 0000000000652fe0    72 OBJECT  LOCAL  DEFAULT   24 tokens_BAR_HIDDEN_STATE
+   369: 00000000006532a0    48 OBJECT  LOCAL  DEFAULT   24 tokens_RESIZE_TILING_FINA
+   370: 0000000000653270    24 OBJECT  LOCAL  DEFAULT   24 tokens_RENAME_WORKSPACE_T
+   371: 0000000000653240    48 OBJECT  LOCAL  DEFAULT   24 tokens_MOVE_TO_POSITION_Y
+   372: 0000000000653200    48 OBJECT  LOCAL  DEFAULT   24 tokens_MOVE_TO_POSITION_X
+   373: 00000000006531c0    48 OBJECT  LOCAL  DEFAULT   24 tokens_MOVE_DIRECTION_PX
+   374: 0000000000653180    48 OBJECT  LOCAL  DEFAULT   24 tokens_FULLSCREEN_COMPAT
+   375: 0000000000653120    72 OBJECT  LOCAL  DEFAULT   24 tokens_BAR_HIDDEN_STATE
+   376: 00000000006530e0    48 OBJECT  LOCAL  DEFAULT   24 tokens_MOVE_TO_POSITION
+   377: 00000000006530b0    24 OBJECT  LOCAL  DEFAULT   24 tokens_WORKSPACE_NUMBER
+   378: 0000000000653080    48 OBJECT  LOCAL  DEFAULT   24 tokens_RENAME_WORKSPACE
+   379: 0000000000652fe0   144 OBJECT  LOCAL  DEFAULT   24 tokens_RESIZE_DIRECTION
````

Full diff: https://reproducible.debian.net/rb-pkg/unstable/amd64/i3-wm.html