### PR TITLE
remove useless get_first_output() call

### DIFF
--- a/src/randr.c
+++ b/src/randr.c
@@ -793,9 +793,6 @@ static bool __randr_query_outputs(void) {
         disable_randr(conn);
     }
 
-    /* Verifies that there is at least one active output as a side-effect. */
-    get_first_output();
-
     /* Just go through each active output and assign one workspace */
     TAILQ_FOREACH(output, &outputs, outputs) {
         if (!output->active)


### PR DESCRIPTION
Since `get_first_output()` now returns NULL when there are none, this call does nothing useful.
NB: If someone more familiar with the codebase find *this* check *still necessary*, the call should not be removed, but its result checked instead.