### PR TITLE
Fix incorrect swallow of percent sign

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -396,6 +396,8 @@ i3String *window_parse_title_format(i3Window *win) {
         } else if (STARTS_WITH(walk + 1, "instance")) {
             outwalk += sprintf(outwalk, "%s", escaped_instance);
             walk += strlen("instance");
+        } else {
+            *(outwalk++) = *walk;
         }
     }
     *outwalk = '\0';


### PR DESCRIPTION
    title_format %other

would result in the title only being "other".