### PR TITLE
POC for i3bar-cairo

### DIFF
--- a/i3bar/include/cairo_util.h
+++ b/i3bar/include/cairo_util.h
@@ -1,0 +1,65 @@
+/*
+ * vim:ts=4:sw=4:expandtab
+ *
+ * © 2015 Ingo Bürk and contributors (see also: LICENSE)
+ *
+ * cairo_util.h: Utility for operations using cairo.
+ *
+ */
+#pragma once
+
+#include <cairo/cairo-xcb.h>
+
+/* Represents a color split by color channel. */
+typedef struct color_t {
+    double red;
+    double green;
+    double blue;
+
+    /* For compatibility, we also store the colorpixel for now. */
+    uint32_t colorpixel;
+} color_t;
+
+/* A wrapper grouping an XCB drawable and both a graphics context
+ * and the corresponding cairo objects representing it. */
+typedef struct surface_t {
+    /* The drawable which is being represented. */
+    xcb_drawable_t id;
+
+    // TODO remove this once i3 uses solely cairo for drawing operations
+    /* A classic XCB graphics context. This should not be used for
+     * drawing operations. */
+    xcb_gcontext_t gc;
+
+    /* A cairo surface representing the drawable. */
+    cairo_surface_t *surface;
+
+    /* The cairo object representing the drawale. In general,
+     * this is what one should use for any drawing operation. */
+    cairo_t *cr;
+} surface_t;
+
+/**
+ * Initialize the cairo surface to represent the given drawable.
+ *
+ */
+void cairo_surface_init(surface_t *surface, xcb_drawable_t drawable, int width, int height);
+
+/**
+ * Destroys the surface.
+ *
+ */
+void cairo_surface_free(surface_t *surface);
+
+/**
+ * Parses the given color in hex format to an internal color representation.
+ * Note that the input must begin with a hash sign, e.g., "#3fbc59".
+ *
+ */
+color_t cairo_hex_to_color(const char *color);
+
+/**
+ * Set the given color as the source color on the surface.
+ *
+ */
+void cairo_set_source_color(surface_t *surface, color_t color);

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -80,3 +80,4 @@ TAILQ_HEAD(statusline_head, status_block) statusline_head;
 #include "config.h"
 #include "libi3.h"
 #include "parse_json_header.h"
+#include "cairo_util.h"

--- a/i3bar/include/outputs.h
+++ b/i3bar/include/outputs.h
@@ -10,13 +10,34 @@
 #pragma once
 
 #include <xcb/xcb.h>
+#include <cairo/cairo-xcb.h>
 
 #include "common.h"
+#include "cairo_util.h"
 
 typedef struct i3_output i3_output;
 
 SLIST_HEAD(outputs_head, i3_output);
 struct outputs_head* outputs;
+
+struct i3_output {
+    char* name;   /* Name of the output */
+    bool active;  /* If the output is active */
+    bool primary; /* If it is the primary output */
+    bool visible; /* If the bar is visible on this output */
+    int ws;       /* The number of the currently visible ws */
+    rect rect;    /* The rect (relative to the root window) */
+
+    /* Off-screen buffer for preliminary rendering. */
+    surface_t buffer;
+    /* The actual window on which we draw. */
+    surface_t bar;
+
+    struct ws_head* workspaces;  /* The workspaces on this output */
+    struct tc_head* trayclients; /* The tray clients on this output */
+
+    SLIST_ENTRY(i3_output) slist; /* Pointer for the SLIST-Macro */
+};
 
 /*
  * Start parsing the received JSON string
@@ -36,20 +57,4 @@ void init_outputs(void);
  */
 i3_output* get_output_by_name(char* name);
 
-struct i3_output {
-    char* name;   /* Name of the output */
-    bool active;  /* If the output is active */
-    bool primary; /* If it is the primary output */
-    bool visible; /* If the bar is visible on this output */
-    int ws;       /* The number of the currently visible ws */
-    rect rect;    /* The rect (relative to the root window) */
-
-    xcb_window_t bar;     /* The id of the bar of the output */
-    xcb_pixmap_t buffer;  /* An extra pixmap for double-buffering */
-    xcb_gcontext_t bargc; /* The graphical context of the bar */
-
-    struct ws_head* workspaces;  /* The workspaces on this output */
-    struct tc_head* trayclients; /* The tray clients on this output */
-
-    SLIST_ENTRY(i3_output) slist; /* Pointer for the SLIST-Macro */
-};
+void init_surface(surface_t* surface, xcb_drawable_t drawable, int width, int height);

--- a/i3bar/include/xcb.h
+++ b/i3bar/include/xcb.h
@@ -24,6 +24,12 @@
 #define XEMBED_MAPPED (1 << 0)
 #define XEMBED_EMBEDDED_NOTIFY 0
 
+xcb_connection_t *xcb_connection;
+
+/* We define xcb_request_failed as a macro to include the relevant line number */
+#define xcb_request_failed(cookie, err_msg) _xcb_request_failed(cookie, err_msg, __LINE__)
+int _xcb_request_failed(xcb_void_cookie_t cookie, char *err_msg, int line);
+
 struct xcb_color_strings_t {
     char *bar_fg;
     char *bar_bg;

--- a/i3bar/src/cairo_util.c
+++ b/i3bar/src/cairo_util.c
@@ -1,0 +1,71 @@
+/*
+ * vim:ts=4:sw=4:expandtab
+ *
+ * © 2015 Ingo Bürk and contributors (see also: LICENSE)
+ *
+ * cairo_util.c: Utility for operations using cairo.
+ *
+ */
+#include <stdlib.h>
+#include <err.h>
+#include <xcb/xcb.h>
+#include <xcb/xcb_aux.h>
+#include <cairo/cairo-xcb.h>
+
+#include "common.h"
+#include "libi3.h"
+
+xcb_connection_t *xcb_connection;
+xcb_screen_t *root_screen;
+
+/*
+ * Initialize the cairo surface to represent the given drawable.
+ *
+ */
+void cairo_surface_init(surface_t *surface, xcb_drawable_t drawable, int width, int height) {
+    surface->id = drawable;
+
+    surface->gc = xcb_generate_id(xcb_connection);
+    xcb_void_cookie_t gc_cookie = xcb_create_gc_checked(xcb_connection, surface->gc, surface->id, 0, NULL);
+    if (xcb_request_failed(gc_cookie, "Could not create graphical context"))
+        exit(EXIT_FAILURE);
+
+    surface->surface = cairo_xcb_surface_create(xcb_connection, surface->id, get_visualtype(root_screen), width, height);
+    surface->cr = cairo_create(surface->surface);
+}
+
+/*
+ * Destroys the surface.
+ *
+ */
+void cairo_surface_free(surface_t *surface) {
+    xcb_free_gc(xcb_connection, surface->gc);
+    cairo_surface_destroy(surface->surface);
+    cairo_destroy(surface->cr);
+}
+
+/*
+ * Parses the given color in hex format to an internal color representation.
+ * Note that the input must begin with a hash sign, e.g., "#3fbc59".
+ *
+ */
+color_t cairo_hex_to_color(const char *color) {
+    char groups[3][3] = {
+        {color[1], color[2], '\0'},
+        {color[3], color[4], '\0'},
+        {color[5], color[6], '\0'}};
+
+    return (color_t){
+        .red = strtol(groups[0], NULL, 16) / 255.0,
+        .green = strtol(groups[1], NULL, 16) / 255.0,
+        .blue = strtol(groups[2], NULL, 16) / 255.0,
+        .colorpixel = get_colorpixel(color)};
+}
+
+/*
+ * Set the given color as the source color on the surface.
+ *
+ */
+void cairo_set_source_color(surface_t *surface, color_t color) {
+    cairo_set_source_rgb(surface->cr, color.red, color.green, color.blue);
+}

--- a/i3bar/src/outputs.c
+++ b/i3bar/src/outputs.c
@@ -151,7 +151,8 @@ static int outputs_start_map_cb(void *params_) {
         new_output->name = NULL;
         new_output->ws = 0,
         memset(&new_output->rect, 0, sizeof(rect));
-        new_output->bar = XCB_NONE;
+        memset(&new_output->bar, 0, sizeof(surface_t));
+        memset(&new_output->buffer, 0, sizeof(surface_t));
 
         new_output->workspaces = smalloc(sizeof(struct ws_head));
         TAILQ_INIT(new_output->workspaces);

--- a/libi3/font.c
+++ b/libi3/font.c
@@ -12,8 +12,8 @@
 #include <stdbool.h>
 #include <err.h>
 
-#if PANGO_SUPPORT
 #include <cairo/cairo-xcb.h>
+#if PANGO_SUPPORT
 #include <pango/pangocairo.h>
 #endif
 


### PR DESCRIPTION
This is a (fairly advanced) proof of concept for using cairo to draw i3bar. All drawing calls have been replaced and a graphics context is only directly used to call font rendering routines which, in the pango case at least, will use their own cairo context anyway (this could probably be also be improved).

There are some things that would have to be done still. For example, we can move away from "colorpixels" and store colors in their own double^3 structure since this POC does it a little backwards by shifting bits back again.

This PR is not meant to be merged in this state, but should rather serve as a discussion basis for #1878 as well as a playground to see what it looks like being rendered with cairo.

I think the PR shows nicely that using cairo actually compresses the drawing code a little bit. Also note that I have ran a valgrind on it and there are some mem leaks, but I also have them with the unmodified bar. Also I haven't tested the POC extensively yet (short text, cut-offs, multiple outputs, …)

I recommend looking at commits one by one as the changes might otherwise be a little overwhelming.