### PR TITLE
Improvements for sticky windows

### DIFF
--- a/include/output.h
+++ b/include/output.h
@@ -27,4 +27,4 @@ Output *get_output_from_string(Output *current_output, const char *output_str);
  * workspace on that output.
  *
  */
-void output_push_sticky_windows(void);
+void output_push_sticky_windows(Con *to_focus);

--- a/src/commands.c
+++ b/src/commands.c
@@ -1598,7 +1598,7 @@ void cmd_sticky(I3_CMD, char *action) {
 
     /* A window we made sticky might not be on a visible workspace right now, so we need to make
      * sure it gets pushed to the front now. */
-    output_push_sticky_windows();
+    output_push_sticky_windows(focused);
 
     cmd_output->needs_tree_render = true;
     ysuccess(true);

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -736,7 +736,7 @@ static void handle_client_message(xcb_client_message_event_t *event) {
                 con->sticky = !con->sticky;
 
             DLOG("New sticky status for con = %p is %i.\n", con, con->sticky);
-            output_push_sticky_windows();
+            output_push_sticky_windows(focused);
         }
 
         tree_render();

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -363,6 +363,7 @@ static void workspace_defer_update_urgent_hint_cb(EV_P_ ev_timer *w, int revents
 
 static void _workspace_show(Con *workspace) {
     Con *current, *old = NULL;
+    Con *old_focus = focused;
 
     /* safe-guard against showing i3-internal workspaces like __i3_scratch */
     if (con_is_internal(workspace))
@@ -478,7 +479,7 @@ static void _workspace_show(Con *workspace) {
     ewmh_update_current_desktop();
 
     /* Push any sticky windows to the now visible workspace. */
-    output_push_sticky_windows();
+    output_push_sticky_windows(old_focus);
 }
 
 /*

--- a/testcases/t/251-sticky.t
+++ b/testcases/t/251-sticky.t
@@ -18,7 +18,7 @@
 # Ticket: #1455
 use i3test;
 
-my ($ws, $focused);
+my ($ws, $tmp, $focused);
 
 ###############################################################################
 # 1: Given a sticky tiling container, when the workspace is switched, then
@@ -62,9 +62,9 @@ is(@{get_ws($ws)->{floating_nodes}}, 2, 'multiple sticky windows can be used at 
 cmd '[class="findme"] kill';
 
 ###############################################################################
-# 4: Given a sticky floating container and a tiling container on the target
-#    workspace, when the workspace is switched, then the tiling container is
-#    focused.
+# 4: Given an unfocused sticky floating container and a tiling container on the
+#    target workspace, when the workspace is switched, then the tiling container
+#    is focused.
 ###############################################################################
 $ws = fresh_workspace;
 open_window;
@@ -72,13 +72,30 @@ $focused = get_focused($ws);
 fresh_workspace;
 open_floating_window(wm_class => 'findme');
 cmd 'sticky enable';
+open_window;
 cmd 'workspace ' . $ws;
 
 is(get_focused($ws), $focused, 'the tiling container has focus');
 cmd '[class="findme"] kill';
 
 ###############################################################################
-# 5: Given a floating container on a non-visible workspace, when the window
+# 5: Given a focused sticky floating container and a tiling container on the
+#    target workspace, when the workspace is switched, then the tiling container
+#    is focused.
+###############################################################################
+$ws = fresh_workspace;
+open_window;
+$tmp = fresh_workspace;
+open_floating_window(wm_class => 'findme');
+$focused = get_focused($tmp);
+cmd 'sticky enable';
+cmd 'workspace ' . $ws;
+
+is(get_focused($ws), $focused, 'the sticky container has focus');
+cmd '[class="findme"] kill';
+
+###############################################################################
+# 6: Given a floating container on a non-visible workspace, when the window
 #    is made sticky, then the window immediately jumps to the currently
 #    visible workspace.
 ###############################################################################


### PR DESCRIPTION
fixes #1924

@stapelberg I guess we need to decide whether focusing a sticky container if the target workspace is empty is what we want. On the one hand, it makes sense to focus the container on that workspace since that's the behavior we also have if one was on there before. On the other hand we have your point that accidentally switching workspaces means when the user switches back to the correct one, the sticky window will be focused.