### PR TITLE
Don't create empty workspaces on restart

### DIFF
--- a/include/randr.h
+++ b/include/randr.h
@@ -118,4 +118,4 @@ Output *get_output_next_wrap(direction_t direction, Output *current);
  * Creates an output covering the root window.
  *
  */
-void create_root_output(xcb_connection_t *conn);
+Output *create_root_output(xcb_connection_t *conn);


### PR DESCRIPTION
This fixes a bug I introduced in #1921. When restarting i3 in place a
stray workspace was created on the root_output during restart. On first
start, this workspace would have been moved to the first real and empty
output.

However, this does not produce the desired result during restarts when
workspaces are alread present on all real outputs. The stray workspace would
still be added to the first real output which already contains some
workspaces. Thus, adding a new empty workspace to it.

Fix this by delaying creation of the root output's workspace until it is
known whether the output is active or not.

Fixes #1940

Tested on RandR (intel), Xinerama (Xephy -extension RANDR +extension XINERAMA and i3 --force-xinerama), each with none, one and two screens.