### PR TITLE
Check duplicated bindings after translating keysym

### DIFF
--- a/include/config_parser.h
+++ b/include/config_parser.h
@@ -32,6 +32,11 @@ struct ConfigResultIR {
 struct ConfigResultIR *parse_config(const char *input, struct context *context);
 
 /**
+ * launch nagbar to indicate errors in the configuration file.
+ */
+void start_config_error_nagbar(const char *configpath, bool has_errors);
+
+/**
  * Parses the given file by first replacing the variables, then calling
  * parse_config and launching i3-nagbar if use_nagbar is true.
  *

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -830,6 +830,34 @@ static char *migrate_config(char *input, off_t size) {
     return converted;
 }
 
+/**
+ * Launch nagbar to indicate errors in the configuration file.
+ */
+void start_config_error_nagbar(const char *configpath, bool has_errors) {
+    char *editaction, *pageraction;
+    sasprintf(&editaction, "i3-sensible-editor \"%s\" && i3-msg reload\n", configpath);
+    sasprintf(&pageraction, "i3-sensible-pager \"%s\"\n", errorfilename);
+    char *argv[] = {
+        NULL, /* will be replaced by the executable path */
+        "-f",
+        (config.font.pattern ? config.font.pattern : "fixed"),
+        "-t",
+        (has_errors ? "error" : "warning"),
+        "-m",
+        (has_errors ? "You have an error in your i3 config file!" : "Your config is outdated. Please fix the warnings to make sure everything works."),
+        "-b",
+        "edit config",
+        editaction,
+        (errorfilename ? "-b" : NULL),
+        (has_errors ? "show errors" : "show warnings"),
+        pageraction,
+        NULL};
+
+    start_nagbar(&config_error_nagbar_pid, argv);
+    free(editaction);
+    free(pageraction);
+}
+
 /*
  * Parses the given file by first replacing the variables, then calling
  * parse_config and possibly launching i3-nagbar.
@@ -1005,29 +1033,7 @@ bool parse_file(const char *f, bool use_nagbar) {
         if (version == 3)
             ELOG("Please convert your configfile first, then fix any remaining errors (see above).\n");
 
-        char *editaction,
-            *pageraction;
-        sasprintf(&editaction, "i3-sensible-editor \"%s\" && i3-msg reload\n", f);
-        sasprintf(&pageraction, "i3-sensible-pager \"%s\"\n", errorfilename);
-        char *argv[] = {
-            NULL, /* will be replaced by the executable path */
-            "-f",
-            (config.font.pattern ? config.font.pattern : "fixed"),
-            "-t",
-            (context->has_errors ? "error" : "warning"),
-            "-m",
-            (context->has_errors ? "You have an error in your i3 config file!" : "Your config is outdated. Please fix the warnings to make sure everything works."),
-            "-b",
-            "edit config",
-            editaction,
-            (errorfilename ? "-b" : NULL),
-            (context->has_errors ? "show errors" : "show warnings"),
-            pageraction,
-            NULL};
-
-        start_nagbar(&config_error_nagbar_pid, argv);
-        free(editaction);
-        free(pageraction);
+        start_config_error_nagbar(f, context->has_errors);
     }
 
     bool has_errors = context->has_errors;


### PR DESCRIPTION
1). See the issue #1926. For example, the second keybinding is not detected as a duplicate:
        bindcode Mod4+24 sticky toggle
        bindsym Mod4+q focus parent
2). To fix it, check duplicated bindings when translating the keysym to keycodes.
