### PR TITLE
Break list of commands in parser test

### DIFF
--- a/testcases/t/187-commands-parser.t
+++ b/testcases/t/187-commands-parser.t
@@ -144,7 +144,34 @@ is(parser_calls("\nworkspace test"),
 ################################################################################
 
 is(parser_calls('unknown_literal'),
-   "ERROR: Expected one of these tokens: <end>, '[', 'move', 'exec', 'exit', 'restart', 'reload', 'shmlog', 'debuglog', 'border', 'layout', 'append_layout', 'workspace', 'focus', 'kill', 'open', 'fullscreen', 'sticky', 'split', 'floating', 'mark', 'unmark', 'resize', 'rename', 'nop', 'scratchpad', 'title_format', 'mode', 'bar'\n" .
+   "ERROR: Expected one of these tokens: <end>, '[', " .
+   "'move', " .
+   "'exec', " .
+   "'exit', " .
+   "'restart', " .
+   "'reload', " .
+   "'shmlog', " .
+   "'debuglog', " .
+   "'border', " .
+   "'layout', " .
+   "'append_layout', " .
+   "'workspace', " .
+   "'focus', " .
+   "'kill', " .
+   "'open', " .
+   "'fullscreen', " .
+   "'sticky', " .
+   "'split', " .
+   "'floating', " .
+   "'mark', " .
+   "'unmark', " .
+   "'resize', " .
+   "'rename', " .
+   "'nop', " .
+   "'scratchpad', " .
+   "'title_format', " .
+   "'mode', " .
+   "'bar'\n" .
    "ERROR: Your command: unknown_literal\n" .
    "ERROR:               ^^^^^^^^^^^^^^^",
    'error for unknown literal ok');


### PR DESCRIPTION
This will avoid merge conflicts (and hence necessary rebases) in many cases as the commands are now on one line each.