### PR TITLE
Make pango markup in mode names optional with a flag.

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -717,11 +717,15 @@ This event consists of a single serialized map containing a property
 This event consists of a single serialized map containing a property
 +change (string)+ which holds the name of current mode in use. The name
 is the same as specified in config when creating a mode. The default
-mode is simply named default.
+mode is simply named default. It contains a second property, +pango_markup+, which
+defines whether pango markup shall be used for displaying this mode.
 
 *Example:*
 ---------------------------
-{ "change": "default" }
+{
+  "change": "default",
+  "pango_markup": true
+}
 ---------------------------
 
 === window event

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -49,7 +49,7 @@ struct status_block {
 
     bool urgent;
     bool no_separator;
-    bool is_markup;
+    bool pango_markup;
 
     /* The amount of pixels necessary to render a separater after the block. */
     uint32_t sep_block_width;

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -206,7 +206,7 @@ static int stdin_string(void *context, const unsigned char *val, size_t len) {
         return 1;
     }
     if (strcasecmp(ctx->last_map_key, "markup") == 0) {
-        ctx->block.is_markup = (len == strlen("pango") && !strncasecmp((const char *)val, "pango", strlen("pango")));
+        ctx->block.pango_markup = (len == strlen("pango") && !strncasecmp((const char *)val, "pango", strlen("pango")));
         return 1;
     }
     if (strcasecmp(ctx->last_map_key, "align") == 0) {
@@ -275,15 +275,15 @@ static int stdin_end_map(void *context) {
 
     if (new_block->min_width_str) {
         i3String *text = i3string_from_utf8(new_block->min_width_str);
-        i3string_set_markup(text, new_block->is_markup);
+        i3string_set_markup(text, new_block->pango_markup);
         new_block->min_width = (uint32_t)predict_text_width(text);
         i3string_free(text);
     }
 
-    i3string_set_markup(new_block->full_text, new_block->is_markup);
+    i3string_set_markup(new_block->full_text, new_block->pango_markup);
 
     if (new_block->short_text != NULL)
-        i3string_set_markup(new_block->short_text, new_block->is_markup);
+        i3string_set_markup(new_block->short_text, new_block->pango_markup);
 
     TAILQ_INSERT_TAIL(&statusline_buffer, new_block, blocks);
     return 1;

--- a/i3bar/src/mode.c
+++ b/i3bar/src/mode.c
@@ -20,6 +20,8 @@
 struct mode_json_params {
     char *json;
     char *cur_key;
+    char *name;
+    bool pango_markup;
     mode *mode;
 };
 
@@ -31,17 +33,35 @@ static int mode_string_cb(void *params_, const unsigned char *val, size_t len) {
     struct mode_json_params *params = (struct mode_json_params *)params_;
 
     if (!strcmp(params->cur_key, "change")) {
-        /* Save the name */
-        params->mode->name = i3string_from_markup_with_length((const char *)val, len);
-        /* Save its rendered width */
-        params->mode->width = predict_text_width(params->mode->name);
+        char *copy = smalloc(sizeof(const unsigned char) * (len + 1));
+        strncpy(copy, (const char *)val, len);
+        copy[len] = '\0';
 
-        DLOG("Got mode change: %s\n", i3string_as_utf8(params->mode->name));
+        params->name = copy;
         FREE(params->cur_key);
-
         return 1;
     }
 
+    FREE(params->cur_key);
+    return 0;
+}
+
+/*
+ * Parse a boolean.
+ *
+ */
+static int mode_boolean_cb(void *params_, int val) {
+    struct mode_json_params *params = (struct mode_json_params *)params_;
+
+    if (strcmp(params->cur_key, "pango_markup") == 0) {
+        DLOG("Setting pango_markup to %d.\n", val);
+        params->pango_markup = val;
+
+        FREE(params->cur_key);
+        return 1;
+    }
+
+    FREE(params->cur_key);
     return 0;
 }
 
@@ -62,10 +82,27 @@ static int mode_map_key_cb(void *params_, const unsigned char *keyVal, size_t ke
     return 1;
 }
 
+static int mode_end_map_cb(void *params_) {
+    struct mode_json_params *params = (struct mode_json_params *)params_;
+
+    /* Save the name */
+    params->mode->name = i3string_from_utf8(params->name);
+    i3string_set_markup(params->mode->name, params->pango_markup);
+    /* Save its rendered width */
+    params->mode->width = predict_text_width(params->mode->name);
+
+    DLOG("Got mode change: %s\n", i3string_as_utf8(params->mode->name));
+    FREE(params->cur_key);
+
+    return 1;
+}
+
 /* A datastructure to pass all these callbacks to yajl */
 static yajl_callbacks mode_callbacks = {
     .yajl_string = mode_string_cb,
+    .yajl_boolean = mode_boolean_cb,
     .yajl_map_key = mode_map_key_cb,
+    .yajl_end_map = mode_end_map_cb,
 };
 
 /*

--- a/include/bindings.h
+++ b/include/bindings.h
@@ -25,7 +25,7 @@ const char *DEFAULT_BINDING_MODE;
  */
 Binding *configure_binding(const char *bindtype, const char *modifiers, const char *input_code,
                            const char *release, const char *border, const char *whole_window,
-                           const char *command, const char *mode);
+                           const char *command, const char *mode, bool pango_markup);
 
 /**
  * Grab the bound keys (tell X to send us keypress events for those keycodes)

--- a/include/config.h
+++ b/include/config.h
@@ -77,6 +77,7 @@ struct Variable {
  */
 struct Mode {
     char *name;
+    bool pango_markup;
     struct bindings_head *bindings;
 
     SLIST_ENTRY(Mode) modes;

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -66,7 +66,7 @@ CFGFUN(new_window, const char *windowtype, const char *border, const long width)
 CFGFUN(workspace, const char *workspace, const char *output);
 CFGFUN(binding, const char *bindtype, const char *modifiers, const char *key, const char *release, const char *border, const char *whole_window, const char *command);
 
-CFGFUN(enter_mode, const char *mode);
+CFGFUN(enter_mode, const char *pango_markup, const char *mode);
 CFGFUN(mode_binding, const char *bindtype, const char *modifiers, const char *key, const char *release, const char *border, const char *whole_window, const char *command);
 
 CFGFUN(bar_font, const char *font);

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -243,7 +243,7 @@ bool i3string_is_markup(i3String *str);
 /**
  * Set whether the i3String should use Pango markup.
  */
-void i3string_set_markup(i3String *str, bool is_markup);
+void i3string_set_markup(i3String *str, bool pango_markup);
 
 /**
  * Escape pango markup characters in the given string.

--- a/libi3/font.c
+++ b/libi3/font.c
@@ -103,7 +103,7 @@ static bool load_pango_font(i3Font *font, const char *desc) {
  */
 static void draw_text_pango(const char *text, size_t text_len,
                             xcb_drawable_t drawable, xcb_visualtype_t *visual, int x, int y,
-                            int max_width, bool is_markup) {
+                            int max_width, bool pango_markup) {
     /* Create the Pango layout */
     /* root_visual_type is cached in load_pango_font */
     cairo_surface_t *surface = cairo_xcb_surface_create(conn, drawable,
@@ -117,7 +117,7 @@ static void draw_text_pango(const char *text, size_t text_len,
     pango_layout_set_wrap(layout, PANGO_WRAP_CHAR);
     pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
 
-    if (is_markup)
+    if (pango_markup)
         pango_layout_set_markup(layout, text, text_len);
     else
         pango_layout_set_text(layout, text, text_len);
@@ -143,7 +143,7 @@ static void draw_text_pango(const char *text, size_t text_len,
  * Calculate the text width using Pango rendering.
  *
  */
-static int predict_text_width_pango(const char *text, size_t text_len, bool is_markup) {
+static int predict_text_width_pango(const char *text, size_t text_len, bool pango_markup) {
     /* Create a dummy Pango layout */
     /* root_visual_type is cached in load_pango_font */
     cairo_surface_t *surface = cairo_xcb_surface_create(conn, root_screen->root, root_visual_type, 1, 1);
@@ -154,7 +154,7 @@ static int predict_text_width_pango(const char *text, size_t text_len, bool is_m
     gint width;
     pango_layout_set_font_description(layout, savedFont->specific.pango_desc);
 
-    if (is_markup)
+    if (pango_markup)
         pango_layout_set_markup(layout, text, text_len);
     else
         pango_layout_set_text(layout, text, text_len);

--- a/libi3/string.c
+++ b/libi3/string.c
@@ -24,7 +24,7 @@ struct _i3String {
     xcb_char2b_t *ucs2;
     size_t num_glyphs;
     size_t num_bytes;
-    bool is_markup;
+    bool pango_markup;
 };
 
 /*
@@ -52,7 +52,7 @@ i3String *i3string_from_markup(const char *from_markup) {
     i3String *str = i3string_from_utf8(from_markup);
 
     /* Set the markup flag */
-    str->is_markup = true;
+    str->pango_markup = true;
 
     return str;
 }
@@ -86,7 +86,7 @@ i3String *i3string_from_markup_with_length(const char *from_markup, size_t num_b
     i3String *str = i3string_from_utf8_with_length(from_markup, num_bytes);
 
     /* set the markup flag */
-    str->is_markup = true;
+    str->pango_markup = true;
 
     return str;
 }
@@ -118,7 +118,7 @@ i3String *i3string_from_ucs2(const xcb_char2b_t *from_ucs2, size_t num_glyphs) {
  */
 i3String *i3string_copy(i3String *str) {
     i3String *copy = i3string_from_utf8(i3string_as_utf8(str));
-    copy->is_markup = str->is_markup;
+    copy->pango_markup = str->pango_markup;
     return copy;
 }
 
@@ -178,14 +178,14 @@ size_t i3string_get_num_bytes(i3String *str) {
  * Whether the given i3String is in Pango markup.
  */
 bool i3string_is_markup(i3String *str) {
-    return str->is_markup;
+    return str->pango_markup;
 }
 
 /*
  * Set whether the i3String should use Pango markup.
  */
-void i3string_set_markup(i3String *str, bool is_markup) {
-    str->is_markup = is_markup;
+void i3string_set_markup(i3String *str, bool pango_markup) {
+    str->pango_markup = pango_markup;
 }
 
 /*

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -326,8 +326,10 @@ state BINDCOMMAND:
 ################################################################################
 
 state MODENAME:
+  pango_markup = '--pango_markup'
+      ->
   modename = word
-      -> call cfg_enter_mode($modename); MODEBRACE
+      -> call cfg_enter_mode($pango_markup, $modename); MODEBRACE
 
 state MODEBRACE:
   end

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -108,7 +108,7 @@ CFGFUN(font, const char *font) {
 }
 
 CFGFUN(binding, const char *bindtype, const char *modifiers, const char *key, const char *release, const char *border, const char *whole_window, const char *command) {
-    configure_binding(bindtype, modifiers, key, release, border, whole_window, command, DEFAULT_BINDING_MODE);
+    configure_binding(bindtype, modifiers, key, release, border, whole_window, command, DEFAULT_BINDING_MODE, false);
 }
 
 /*******************************************************************************
@@ -116,12 +116,13 @@ CFGFUN(binding, const char *bindtype, const char *modifiers, const char *key, co
  ******************************************************************************/
 
 static char *current_mode;
+static bool current_mode_pango_markup;
 
 CFGFUN(mode_binding, const char *bindtype, const char *modifiers, const char *key, const char *release, const char *border, const char *whole_window, const char *command) {
-    configure_binding(bindtype, modifiers, key, release, border, whole_window, command, current_mode);
+    configure_binding(bindtype, modifiers, key, release, border, whole_window, command, current_mode, current_mode_pango_markup);
 }
 
-CFGFUN(enter_mode, const char *modename) {
+CFGFUN(enter_mode, const char *pango_markup, const char *modename) {
     if (strcasecmp(modename, DEFAULT_BINDING_MODE) == 0) {
         ELOG("You cannot use the name %s for your mode\n", DEFAULT_BINDING_MODE);
         exit(1);
@@ -129,6 +130,7 @@ CFGFUN(enter_mode, const char *modename) {
     DLOG("\t now in mode %s\n", modename);
     FREE(current_mode);
     current_mode = sstrdup(modename);
+    current_mode_pango_markup = (pango_markup != NULL);
 }
 
 CFGFUN(exec, const char *exectype, const char *no_startup_id, const char *command) {

--- a/src/window.c
+++ b/src/window.c
@@ -342,7 +342,7 @@ void window_update_motif_hints(i3Window *win, xcb_get_property_reply_t *prop, bo
 i3String *window_parse_title_format(i3Window *win) {
     /* We need to ensure that we only escape the window title if pango
      * is used by the current font. */
-    const bool is_markup = font_is_pango();
+    const bool pango_markup = font_is_pango();
 
     char *format = win->title_format;
     if (format == NULL)
@@ -359,19 +359,19 @@ i3String *window_parse_title_format(i3Window *win) {
     for (char *walk = format; *walk != '\0'; walk++) {
         if (STARTS_WITH(walk, "%title")) {
             if (escaped_title == NULL)
-                escaped_title = win->name == NULL ? "" : i3string_as_utf8(is_markup ? i3string_escape_markup(win->name) : win->name);
+                escaped_title = win->name == NULL ? "" : i3string_as_utf8(pango_markup ? i3string_escape_markup(win->name) : win->name);
 
             buffer_len = buffer_len - strlen("%title") + strlen(escaped_title);
             walk += strlen("%title") - 1;
         } else if (STARTS_WITH(walk, "%class")) {
             if (escaped_class == NULL)
-                escaped_class = is_markup ? g_markup_escape_text(win->class_class, -1) : win->class_class;
+                escaped_class = pango_markup ? g_markup_escape_text(win->class_class, -1) : win->class_class;
 
             buffer_len = buffer_len - strlen("%class") + strlen(escaped_class);
             walk += strlen("%class") - 1;
         } else if (STARTS_WITH(walk, "%instance")) {
             if (escaped_instance == NULL)
-                escaped_instance = is_markup ? g_markup_escape_text(win->class_instance, -1) : win->class_instance;
+                escaped_instance = pango_markup ? g_markup_escape_text(win->class_instance, -1) : win->class_instance;
 
             buffer_len = buffer_len - strlen("%instance") + strlen(escaped_instance);
             walk += strlen("%instance") - 1;
@@ -403,6 +403,6 @@ i3String *window_parse_title_format(i3Window *win) {
     *outwalk = '\0';
 
     i3String *formatted = i3string_from_utf8(buffer);
-    i3string_set_markup(formatted, is_markup);
+    i3string_set_markup(formatted, pango_markup);
     return formatted;
 }

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -53,7 +53,7 @@ mode "meh" {
 EOT
 
 my $expected = <<'EOT';
-cfg_enter_mode(meh)
+cfg_enter_mode((null), meh)
 cfg_mode_binding(bindsym, Mod1,Shift, x, (null), (null), (null), resize grow)
 cfg_mode_binding(bindcode, Mod1, 44, (null), (null), (null), resize shrink)
 cfg_mode_binding(bindsym, Mod1, x, --release, (null), (null), exec foo)
@@ -627,7 +627,7 @@ mode "yo" {
 EOT
 
 $expected = <<'EOT';
-cfg_enter_mode(yo)
+cfg_enter_mode((null), yo)
 cfg_mode_binding(bindsym, (null), x, (null), (null), (null), resize shrink left)
 ERROR: CONFIG: Expected one of these tokens: <end>, '#', 'set', 'bindsym', 'bindcode', 'bind', '}'
 ERROR: CONFIG: (in file <stdin>)


### PR DESCRIPTION
This introduces the flag "--pango" on the mode config directive to
explicitly enable pango markup for mode names. Not setting this will
cause the mode name to be rendered as is.
This fixes a regression in 4.11 where mode names containing characters
such as '<' would break user's configs as they didn't escape these
characters.

fixes #1992