### PR TITLE
Added background and border keys to the i3bar protocol.

### DIFF
--- a/docs/i3bar-protocol
+++ b/docs/i3bar-protocol
@@ -136,6 +136,10 @@ color::
 	when it is associated.
 	Colors are specified in hex (like in HTML), starting with a leading
 	hash sign. For example, +#ff0000+ means red.
+background::
+	Overrides the background color for this particular block.
+border::
+	Overrides the border color for this particular block.
 min_width::
 	The minimum width (in pixels) of the block. If the content of the
 	+full_text+ key take less space than the specified min_width, the block
@@ -207,6 +211,8 @@ An example of a block which uses all possible entries follows:
  "full_text": "E: 10.0.0.1 (1000 Mbit/s)",
  "short_text": "10.0.0.1",
  "color": "#00ff00",
+ "background": "#1c1c1c",
+ "border": "#ee0000",
  "min_width": 300,
  "align": "right",
  "urgent": false,

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -38,6 +38,8 @@ struct status_block {
     i3String *short_text;
 
     char *color;
+    char *background;
+    char *border;
 
     /* min_width can be specified either as a numeric value (in pixels) or as a
      * string. For strings, we set min_width to the measured text width of

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -75,6 +75,8 @@ static void clear_statusline(struct statusline_head *head, bool free_resources) 
             FREE(first->name);
             FREE(first->instance);
             FREE(first->min_width_str);
+            FREE(first->background);
+            FREE(first->border);
         }
 
         TAILQ_REMOVE(head, first, blocks);
@@ -203,6 +205,14 @@ static int stdin_string(void *context, const unsigned char *val, size_t len) {
     }
     if (strcasecmp(ctx->last_map_key, "color") == 0) {
         sasprintf(&(ctx->block.color), "%.*s", len, val);
+        return 1;
+    }
+    if (strcasecmp(ctx->last_map_key, "background") == 0) {
+        sasprintf(&(ctx->block.background), "%.*s", len, val);
+        return 1;
+    }
+    if (strcasecmp(ctx->last_map_key, "border") == 0) {
+        sasprintf(&(ctx->block.border), "%.*s", len, val);
         return 1;
     }
     if (strcasecmp(ctx->last_map_key, "markup") == 0) {


### PR DESCRIPTION
This patch adds two new status block keys, background and border, which
define the respective colors for the status block. If not specified, the
current behavior is kept, e.g., no background / border will be drawn.

If the status block is marked urgent, the urgent color is prioritized.

fixes #2022