### PR TITLE
Added --no-auto-back-and-forth to workspace commands.

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1884,8 +1884,11 @@ for_window [instance=notepad] sticky enable
 === Changing (named) workspaces/moving to workspaces
 
 To change to a specific workspace, use the +workspace+ command, followed by the
-number or name of the workspace. To move containers to specific workspaces, use
-+move container to workspace+.
+number or name of the workspace. Pass the optional flag
++--no-auto-back-and-forth+ to disable <<back_and_forth>> for this specific call
+only.
+
+To move containers to specific workspaces, use +move container to workspace+.
 
 You can also switch to the next and previous workspace with the commands
 +workspace next+ and +workspace prev+, which is handy, for example, if you have
@@ -1916,8 +1919,8 @@ workspace using +move container to workspace back_and_forth+.
 -----------------------------------
 workspace next|prev|next_on_output|prev_on_output
 workspace back_and_forth
-workspace <name>
-workspace number <name>
+workspace [--no-auto-back-and-forth] <name>
+workspace [--no-auto-back-and-forth] number <name>
 
 move [window|container] [to] workspace <name>
 move [window|container] [to] workspace number <name>

--- a/include/commands.h
+++ b/include/commands.h
@@ -97,10 +97,10 @@ void cmd_append_layout(I3_CMD, const char *path);
 void cmd_workspace(I3_CMD, const char *which);
 
 /**
- * Implementation of 'workspace number <number>'
+ * Implementation of 'workspace [--no-auto-back-and-forth] number <number>'
  *
  */
-void cmd_workspace_number(I3_CMD, const char *which);
+void cmd_workspace_number(I3_CMD, const char *which, const char *no_auto_back_and_forth);
 
 /**
  * Implementation of 'workspace back_and_forth'.
@@ -109,10 +109,10 @@ void cmd_workspace_number(I3_CMD, const char *which);
 void cmd_workspace_back_and_forth(I3_CMD);
 
 /**
- * Implementation of 'workspace <name>'
+ * Implementation of 'workspace [--no-auto-back-and-forth] <name>'
  *
  */
-void cmd_workspace_name(I3_CMD, const char *name);
+void cmd_workspace_name(I3_CMD, const char *name, const char *no_auto_back_and_forth);
 
 /**
  * Implementation of 'mark [--add|--replace] [--toggle] <mark>'

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -117,9 +117,11 @@ state APPEND_LAYOUT:
 
 # workspace next|prev|next_on_output|prev_on_output
 # workspace back_and_forth
-# workspace <name>
-# workspace number <number>
+# workspace [--no-auto-back-and-forth] <name>
+# workspace [--no-auto-back-and-forth] number <number>
 state WORKSPACE:
+  no_auto_back_and_forth = '--no-auto-back-and-forth'
+      ->
   direction = 'next_on_output', 'prev_on_output', 'next', 'prev'
       -> call cmd_workspace($direction)
   'back_and_forth'
@@ -127,11 +129,11 @@ state WORKSPACE:
   'number'
       -> WORKSPACE_NUMBER
   workspace = string 
-      -> call cmd_workspace_name($workspace)
+      -> call cmd_workspace_name($workspace, $no_auto_back_and_forth)
 
 state WORKSPACE_NUMBER:
   workspace = string
-      -> call cmd_workspace_number($workspace)
+      -> call cmd_workspace_number($workspace, $no_auto_back_and_forth)
 
 # focus left|right|up|down
 # focus output <output>

--- a/src/commands.c
+++ b/src/commands.c
@@ -917,10 +917,11 @@ void cmd_workspace(I3_CMD, const char *which) {
 }
 
 /*
- * Implementation of 'workspace number <name>'
+ * Implementation of 'workspace [--no-auto-back-and-forth] number <name>'
  *
  */
-void cmd_workspace_number(I3_CMD, const char *which) {
+void cmd_workspace_number(I3_CMD, const char *which, const char *_no_auto_back_and_forth) {
+    const bool no_auto_back_and_forth = (_no_auto_back_and_forth != NULL);
     Con *output, *workspace = NULL;
 
     if (con_get_fullscreen_con(croot, CF_GLOBAL)) {
@@ -948,7 +949,7 @@ void cmd_workspace_number(I3_CMD, const char *which) {
         cmd_output->needs_tree_render = true;
         return;
     }
-    if (maybe_back_and_forth(cmd_output, workspace->name))
+    if (!no_auto_back_and_forth && maybe_back_and_forth(cmd_output, workspace->name))
         return;
     workspace_show(workspace);
 
@@ -976,10 +977,12 @@ void cmd_workspace_back_and_forth(I3_CMD) {
 }
 
 /*
- * Implementation of 'workspace <name>'
+ * Implementation of 'workspace [--no-auto-back-and-forth] <name>'
  *
  */
-void cmd_workspace_name(I3_CMD, const char *name) {
+void cmd_workspace_name(I3_CMD, const char *name, const char *_no_auto_back_and_forth) {
+    const bool no_auto_back_and_forth = (_no_auto_back_and_forth != NULL);
+
     if (strncasecmp(name, "__", strlen("__")) == 0) {
         LOG("You cannot switch to the i3-internal workspaces (\"%s\").\n", name);
         ysuccess(false);
@@ -993,7 +996,7 @@ void cmd_workspace_name(I3_CMD, const char *name) {
     }
 
     DLOG("should switch to workspace %s\n", name);
-    if (maybe_back_and_forth(cmd_output, name))
+    if (!no_auto_back_and_forth && maybe_back_and_forth(cmd_output, name))
         return;
     workspace_show_by_name(name);
 

--- a/testcases/t/187-commands-parser.t
+++ b/testcases/t/187-commands-parser.t
@@ -131,11 +131,11 @@ is(parser_calls('[con_mark="yay"] focus'),
 # commands being parsed due to the configuration, people might send IPC
 # commands with leading or trailing newlines.
 is(parser_calls("workspace test\n"),
-   'cmd_workspace_name(test)',
+   'cmd_workspace_name(test, (null))',
    'trailing whitespace stripped off ok');
 
 is(parser_calls("\nworkspace test"),
-   'cmd_workspace_name(test)',
+   'cmd_workspace_name(test, (null))',
    'trailing whitespace stripped off ok');
 
 ################################################################################
@@ -187,27 +187,27 @@ is(parser_calls('move something to somewhere'),
 ################################################################################
 
 is(parser_calls('workspace "foo"'),
-   'cmd_workspace_name(foo)',
+   'cmd_workspace_name(foo, (null))',
    'Command with simple double quotes ok');
 
 is(parser_calls('workspace "foo'),
-   'cmd_workspace_name(foo)',
+   'cmd_workspace_name(foo, (null))',
    'Command without ending double quotes ok');
 
 is(parser_calls('workspace "foo \"bar"'),
-   'cmd_workspace_name(foo "bar)',
+   'cmd_workspace_name(foo "bar, (null))',
    'Command with escaped double quotes ok');
 
 is(parser_calls('workspace "foo \\'),
-   'cmd_workspace_name(foo \\)',
+   'cmd_workspace_name(foo \\, (null))',
    'Command with single backslash in the end ok');
 
 is(parser_calls('workspace "foo\\\\bar"'),
-   'cmd_workspace_name(foo\\bar)',
+   'cmd_workspace_name(foo\\bar, (null))',
    'Command with escaped backslashes ok');
 
 is(parser_calls('workspace "foo\\\\\\"bar"'),
-   'cmd_workspace_name(foo\\"bar)',
+   'cmd_workspace_name(foo\\"bar, (null))',
    'Command with escaped double quotes after escaped backslashes ok');
 
 ################################################################################

--- a/testcases/t/256-no-auto-back-and-forth.t
+++ b/testcases/t/256-no-auto-back-and-forth.t
@@ -1,0 +1,57 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Test for the --no-auto-back-and-forth flag.
+# Ticket: #2028
+use i3test;
+
+my ($first, $second, $third);
+$first = "1:first";
+$second = "2:second";
+$third = "3:third";
+
+###############################################################################
+# Switching to another workspace when passing --no-auto-back-and-forth works
+# as if the flag wasn't set.
+###############################################################################
+
+cmd qq|workspace "$first"|;
+ok(get_ws($first)->{focused}, 'first workspace is focused');
+
+cmd qq|workspace --no-auto-back-and-forth "$second"|;
+ok(get_ws($second)->{focused}, 'second workspace is focused');
+
+cmd qq|workspace --no-auto-back-and-forth number "$third"|;
+ok(get_ws($third)->{focused}, 'third workspace is focused');
+
+###############################################################################
+# Switching to the focused workspace when passing --no-auto-back-and-forth
+# is a no-op.
+###############################################################################
+
+cmd qq|workspace "$second"|;
+cmd qq|workspace "$first"|;
+ok(get_ws($first)->{focused}, 'first workspace is focused');
+
+cmd qq|workspace --no-auto-back-and-forth "$first"|;
+ok(get_ws($first)->{focused}, 'first workspace is still focused');
+
+cmd qq|workspace --no-auto-back-and-forth number "$first"|;
+ok(get_ws($first)->{focused}, 'first  workspace is still focused');
+
+###############################################################################
+
+done_testing;


### PR DESCRIPTION
This patch introduces the --no-auto-back-and-forth flag to both of

    workspace --no-auto-back-and-forth <name>
    workspace --no-auto-back-and-forth number <number>

This flag will only have an effect if the back_and_forth feature is
enabled. If passed, the feature will be ignored for this particular
call only.

fixes #2028