### PR TITLE
Make resize grow|shrink width|height work for a nested split in the s…

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -615,7 +615,7 @@ static bool cmd_resize_tiling_width_height(I3_CMD, Con *current, const char *way
 
     while (current->type != CT_WORKSPACE &&
            current->type != CT_FLOATING_CON &&
-           con_orientation(current->parent) != search_orientation)
+           (con_orientation(current->parent) != search_orientation || con_num_children(current->parent) == 1))
         current = current->parent;
 
     /* get the default percentage */

--- a/testcases/t/141-resize.t
+++ b/testcases/t/141-resize.t
@@ -141,6 +141,21 @@ cmp_float($nodes->[1]->{percent}, 0.166666666666667, 'second window got 16%');
 cmp_float($nodes->[2]->{percent}, 0.166666666666667, 'third window got 16%');
 cmp_float($nodes->[3]->{percent}, 0.50, 'fourth window got 50%');
 
+################################################################################
+# Check that the resize grow/shrink width/height syntax works if a nested split
+# was set on the container, but no sibling has been opened yet. See #2015.
+################################################################################
+
+$tmp = fresh_workspace;
+$left = open_window;
+$right = open_window;
+
+cmd 'split h';
+cmd 'resize grow width 10px or 25 ppt';
+
+($nodes, $focus) = get_ws_content($tmp);
+cmp_float($nodes->[0]->{percent}, 0.25, 'left window got 25%');
+cmp_float($nodes->[1]->{percent}, 0.75, 'right window got 75%');
 
 ############################################################
 # checks that resizing floating windows works


### PR DESCRIPTION
…ame direction.

Suppose a horizontally oriented workspace has two windows open. Issuing "split h" on
the right window creates a nested horizontal container. If we now resize in "width"
direction, the resize doesn't work because it will only operate on the current parent,
which is a container with only one child, so the resize command exits.

This is unexpected behavior from a user point of view. Hence, with this patch, we
ensure that we don't just go up the tree until we find a parent with the correct
orientation, but also keep going if that parent has only a single child.

fixes #2015