### PR TITLE
Use separate buffers for i3bar statusline for each workspace, track short and long renders separately, fixes #1824

### DIFF
--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -31,6 +31,14 @@ typedef enum {
     ALIGN_RIGHT
 } blockalign_t;
 
+/* This data structure describes the way a status block should be rendered. These
+ * variables are updated each time the statusline is re-rendered. */
+struct status_block_render_desc {
+    uint32_t width;
+    uint32_t x_offset;
+    uint32_t x_append;
+};
+
 /* This data structure represents one JSON dictionary, multiple of these make
  * up one status line. */
 struct status_block {
@@ -56,11 +64,9 @@ struct status_block {
     /* The amount of pixels necessary to render a separater after the block. */
     uint32_t sep_block_width;
 
-    /* The amount of pixels necessary to render this block. These variables are
-     * only temporarily used in refresh_statusline(). */
-    uint32_t width;
-    uint32_t x_offset;
-    uint32_t x_append;
+    /* Continuously-updated information on how to render this status block. */
+    struct status_block_render_desc full_render;
+    struct status_block_render_desc short_render;
 
     /* Optional */
     char *name;

--- a/i3bar/include/outputs.h
+++ b/i3bar/include/outputs.h
@@ -46,8 +46,14 @@ struct i3_output {
     int ws;       /* The number of the currently visible ws */
     rect rect;    /* The rect (relative to the root window) */
 
-    /* Off-screen buffer for preliminary rendering. */
+    /* Off-screen buffer for preliminary rendering of the bar. */
     surface_t buffer;
+    /* Off-screen buffer for pre-rendering the statusline, separated to make clipping easier. */
+    surface_t statusline_buffer;
+    /* How much of statusline_buffer's horizontal space was used on last statusline render. */
+    int statusline_width;
+    /* Whether statusline block short texts where used on last statusline render. */
+    bool statusline_short_text;
     /* The actual window on which we draw. */
     surface_t bar;
 

--- a/i3bar/src/ipc.c
+++ b/i3bar/src/ipc.c
@@ -63,7 +63,6 @@ void got_output_reply(char *reply) {
     DLOG("Parsing outputs JSON...\n");
     parse_outputs_json(reply);
     DLOG("Reconfiguring windows...\n");
-    realloc_sl_buffer();
     reconfig_windows(false);
 
     i3_output *o_walk;
@@ -175,7 +174,6 @@ void got_bar_config_update(char *event) {
     /* update fonts and colors */
     init_xcb_late(config.fontname);
     init_colors(&(config.colors));
-    realloc_sl_buffer();
 
     draw_bars(false);
 }

--- a/i3bar/src/outputs.c
+++ b/i3bar/src/outputs.c
@@ -144,10 +144,16 @@ static int outputs_start_map_cb(void *params_) {
     if (params->cur_key == NULL) {
         new_output = smalloc(sizeof(i3_output));
         new_output->name = NULL;
+        new_output->active = false;
+        new_output->primary = false;
+        new_output->visible = false;
         new_output->ws = 0,
+        new_output->statusline_width = 0;
+        new_output->statusline_short_text = false;
         memset(&new_output->rect, 0, sizeof(rect));
         memset(&new_output->bar, 0, sizeof(surface_t));
         memset(&new_output->buffer, 0, sizeof(surface_t));
+        memset(&new_output->statusline_buffer, 0, sizeof(surface_t));
 
         new_output->workspaces = smalloc(sizeof(struct ws_head));
         TAILQ_INIT(new_output->workspaces);


### PR DESCRIPTION
In i3bar currently, when the statusline is rendered in short text mode, this destroys the local copy of the long-text for each workspace block, as well as the information about the rendered width of the block in long-text mode. That causes the bug described in issue #1824, and also a related problem with sending click events to the correct statusline block.

The changes in this PR correct those problems by keeping both versions of the text and tracking separately for each block how it renders in short and long mode. Also, the function for predicting the length of the statusline is factored out.

Additionally, the global statusline buffer surface is removed, instead i3 creates a separate statusline buffer for each output. This means that for the situation described in https://github.com/i3/i3/pull/1657#issuecomment-94624477, i3bar now uses option 1 instead of option 2.  This simplifies the code by removing the need to reallocate the global buffer as output sizes change dynamically, and also will make it easier for me to implement (in another PR) the feature in #2020 to change the bar's colors on the focused output.
