### PR TITLE
Add --no-auto-back-and-forth for moving windows.

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1916,16 +1916,16 @@ back_and_forth+; likewise, you can move containers to the previously focused
 workspace using +move container to workspace back_and_forth+.
 
 *Syntax*:
------------------------------------
+--------------------------------------------------------------------------------
 workspace next|prev|next_on_output|prev_on_output
 workspace back_and_forth
 workspace [--no-auto-back-and-forth] <name>
 workspace [--no-auto-back-and-forth] number <name>
 
-move [window|container] [to] workspace <name>
-move [window|container] [to] workspace number <name>
+move [--no-auto-back-and-forth] [window|container] [to] workspace <name>
+move [--no-auto-back-and-forth] [window|container] [to] workspace number <name>
 move [window|container] [to] workspace prev|next|current
------------------------------------
+--------------------------------------------------------------------------------
 
 *Examples*:
 -------------------------

--- a/include/commands.h
+++ b/include/commands.h
@@ -49,16 +49,16 @@ void cmd_move_con_to_workspace(I3_CMD, const char *which);
 void cmd_move_con_to_workspace_back_and_forth(I3_CMD);
 
 /**
- * Implementation of 'move [window|container] [to] workspace <name>'.
+ * Implementation of 'move [--no-auto-back-and-forth] [window|container] [to] workspace <name>'.
  *
  */
-void cmd_move_con_to_workspace_name(I3_CMD, const char *name);
+void cmd_move_con_to_workspace_name(I3_CMD, const char *name, const char *no_auto_back_and_forth);
 
 /**
- * Implementation of 'move [window|container] [to] workspace number <number>'.
+ * Implementation of 'move [--no-auto-back-and-forth] [window|container] [to] workspace number <number>'.
  *
  */
-void cmd_move_con_to_workspace_number(I3_CMD, const char *which);
+void cmd_move_con_to_workspace_number(I3_CMD, const char *which, const char *no_auto_back_and_forth);
 
 /**
  * Implementation of 'resize set <px> [px] <px> [px]'.

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -308,6 +308,8 @@ state MOVE:
       ->
   'to'
       ->
+  no_auto_back_and_forth = '--no-auto-back-and-forth'
+      ->
   'workspace'
       -> MOVE_WORKSPACE
   'output'
@@ -345,11 +347,11 @@ state MOVE_WORKSPACE:
   'number'
       -> MOVE_WORKSPACE_NUMBER
   workspace = string
-      -> call cmd_move_con_to_workspace_name($workspace)
+      -> call cmd_move_con_to_workspace_name($workspace, $no_auto_back_and_forth)
 
 state MOVE_WORKSPACE_NUMBER:
   number = string
-      -> call cmd_move_con_to_workspace_number($number)
+      -> call cmd_move_con_to_workspace_number($number, $no_auto_back_and_forth)
 
 state MOVE_TO_OUTPUT:
   output = string

--- a/src/commands.c
+++ b/src/commands.c
@@ -403,16 +403,17 @@ void cmd_move_con_to_workspace_back_and_forth(I3_CMD) {
 }
 
 /*
- * Implementation of 'move [window|container] [to] workspace <name>'.
+ * Implementation of 'move [--no-auto-back-and-forth] [window|container] [to] workspace <name>'.
  *
  */
-void cmd_move_con_to_workspace_name(I3_CMD, const char *name) {
+void cmd_move_con_to_workspace_name(I3_CMD, const char *name, const char *_no_auto_back_and_forth) {
     if (strncasecmp(name, "__", strlen("__")) == 0) {
         LOG("You cannot move containers to i3-internal workspaces (\"%s\").\n", name);
         ysuccess(false);
         return;
     }
 
+    const bool no_auto_back_and_forth = (_no_auto_back_and_forth != NULL);
     owindow *current;
 
     /* We have nothing to move:
@@ -432,7 +433,8 @@ void cmd_move_con_to_workspace_name(I3_CMD, const char *name) {
     /* get the workspace */
     Con *ws = workspace_get(name, NULL);
 
-    ws = maybe_auto_back_and_forth_workspace(ws);
+    if (!no_auto_back_and_forth)
+        ws = maybe_auto_back_and_forth_workspace(ws);
 
     HANDLE_EMPTY_MATCH;
 
@@ -447,10 +449,11 @@ void cmd_move_con_to_workspace_name(I3_CMD, const char *name) {
 }
 
 /*
- * Implementation of 'move [window|container] [to] workspace number <name>'.
+ * Implementation of 'move [--no-auto-back-and-forth] [window|container] [to] workspace number <name>'.
  *
  */
-void cmd_move_con_to_workspace_number(I3_CMD, const char *which) {
+void cmd_move_con_to_workspace_number(I3_CMD, const char *which, const char *_no_auto_back_and_forth) {
+    const bool no_auto_back_and_forth = (_no_auto_back_and_forth != NULL);
     owindow *current;
 
     /* We have nothing to move:
@@ -483,7 +486,8 @@ void cmd_move_con_to_workspace_number(I3_CMD, const char *which) {
         workspace = workspace_get(which, NULL);
     }
 
-    workspace = maybe_auto_back_and_forth_workspace(workspace);
+    if (!no_auto_back_and_forth)
+        workspace = maybe_auto_back_and_forth_workspace(workspace);
 
     HANDLE_EMPTY_MATCH;
 

--- a/testcases/t/187-commands-parser.t
+++ b/testcases/t/187-commands-parser.t
@@ -44,7 +44,7 @@ sub parser_calls {
 # The first call has only a single command, the following ones are consolidated
 # for performance.
 is(parser_calls('move workspace 3'),
-   'cmd_move_con_to_workspace_name(3)',
+   'cmd_move_con_to_workspace_name(3, (null))',
    'single number (move workspace 3) ok');
 
 is(parser_calls(
@@ -57,19 +57,19 @@ is(parser_calls(
    'move workspace 3: foobar; ' .
    'move workspace "3: foobar"; ' .
    'move workspace "3: foobar, baz"; '),
-   "cmd_move_con_to_workspace_name(3)\n" .
-   "cmd_move_con_to_workspace_name(3)\n" .
-   "cmd_move_con_to_workspace_name(3)\n" .
-   "cmd_move_con_to_workspace_name(foobar)\n" .
-   "cmd_move_con_to_workspace_name(torrent)\n" .
+   "cmd_move_con_to_workspace_name(3, (null))\n" .
+   "cmd_move_con_to_workspace_name(3, (null))\n" .
+   "cmd_move_con_to_workspace_name(3, (null))\n" .
+   "cmd_move_con_to_workspace_name(foobar, (null))\n" .
+   "cmd_move_con_to_workspace_name(torrent, (null))\n" .
    "cmd_move_workspace_to_output(LVDS1)\n" .
-   "cmd_move_con_to_workspace_name(3: foobar)\n" .
-   "cmd_move_con_to_workspace_name(3: foobar)\n" .
-   "cmd_move_con_to_workspace_name(3: foobar, baz)",
+   "cmd_move_con_to_workspace_name(3: foobar, (null))\n" .
+   "cmd_move_con_to_workspace_name(3: foobar, (null))\n" .
+   "cmd_move_con_to_workspace_name(3: foobar, baz, (null))",
    'move ok');
 
 is(parser_calls('move workspace 3: foobar, nop foo'),
-   "cmd_move_con_to_workspace_name(3: foobar)\n" .
+   "cmd_move_con_to_workspace_name(3: foobar, (null))\n" .
    "cmd_nop(foo)",
    'multiple ops (move workspace 3: foobar, nop foo) ok');
 
@@ -177,7 +177,7 @@ is(parser_calls('unknown_literal'),
    'error for unknown literal ok');
 
 is(parser_calls('move something to somewhere'),
-   "ERROR: Expected one of these tokens: 'window', 'container', 'to', 'workspace', 'output', 'mark', 'scratchpad', 'left', 'right', 'up', 'down', 'position', 'absolute'\n" .
+   "ERROR: Expected one of these tokens: 'window', 'container', 'to', '--no-auto-back-and-forth', 'workspace', 'output', 'mark', 'scratchpad', 'left', 'right', 'up', 'down', 'position', 'absolute'\n" .
    "ERROR: Your command: move something to somewhere\n" .
    "ERROR:                    ^^^^^^^^^^^^^^^^^^^^^^",
    'error for unknown literal ok');

--- a/testcases/t/256-no-auto-back-and-forth.t
+++ b/testcases/t/256-no-auto-back-and-forth.t
@@ -18,7 +18,7 @@
 # Ticket: #2028
 use i3test;
 
-my ($first, $second, $third);
+my ($first, $second, $third, $con);
 $first = "1:first";
 $second = "2:second";
 $third = "3:third";
@@ -51,6 +51,47 @@ ok(get_ws($first)->{focused}, 'first workspace is still focused');
 
 cmd qq|workspace --no-auto-back-and-forth number "$first"|;
 ok(get_ws($first)->{focused}, 'first  workspace is still focused');
+
+###############################################################################
+# Moving a window to another workspace when passing --no-auto-back-and-forth
+# works as if the flag wasn't set.
+###############################################################################
+
+cmd qq|workspace "$third"|;
+cmd qq|workspace "$second"|;
+cmd qq|workspace "$first"|;
+$con = open_window;
+cmd 'mark mywindow';
+
+cmd qq|move --no-auto-back-and-forth window to workspace "$second"|;
+is(@{get_ws($second)->{nodes}}, 1, 'window was moved to second workspace');
+cmd qq|[con_mark=mywindow] move window to workspace "$first"|;
+
+cmd qq|move --no-auto-back-and-forth window to workspace number "$third"|;
+is(@{get_ws($third)->{nodes}}, 1, 'window was moved to third workspace');
+cmd qq|[con_mark=mywindow] move window to workspace "$first"|;
+
+cmd '[con_mark=mywindow] kill';
+
+###############################################################################
+# Moving a window to the same workspace when passing --no-auto-back-and-forth
+# is a no-op.
+###############################################################################
+
+cmd qq|workspace "$second"|;
+cmd qq|workspace "$first"|;
+$con = open_window;
+cmd 'mark mywindow';
+
+cmd qq|move --no-auto-back-and-forth window to workspace "$first"|;
+is(@{get_ws($first)->{nodes}}, 1, 'window is still on first workspace');
+cmd qq|[con_mark=mywindow] move window to workspace "$first"|;
+
+cmd qq|move --no-auto-back-and-forth window to workspace number "$first"|;
+is(@{get_ws($first)->{nodes}}, 1, 'window is still on first workspace');
+cmd qq|[con_mark=mywindow] move window to workspace "$first"|;
+
+cmd '[con_mark=mywindow] kill';
 
 ###############################################################################
 


### PR DESCRIPTION
This patch extends the previously introduced flag --no-auto-back-and-forth
to also apply to

    move window to workspace <name>
    move window to workspace number <number>

relates to #2028