### PR TITLE
Raise dependency to cairo 1.14.4.

### DIFF
--- a/DEPENDS
+++ b/DEPENDS
@@ -24,7 +24,7 @@
 │ PCRE         │ 8.12   │ 8.35   │ http://www.pcre.org/                   │
 │ libsn¹       │ 0.10   │ 0.12   │ http://freedesktop.org/wiki/Software/startup-notification
 │ pango        │ 1.30.0 | 1.36.8 │ http://www.pango.org/                  │
-│ cairo        │ 1.12.2 │ 1.14.0 │ http://cairographics.org/              │
+│ cairo        │ 1.14.4 │ 1.14.4 │ http://cairographics.org/              │
 └──────────────┴────────┴────────┴────────────────────────────────────────┘
  ¹ libsn = libstartup-notification
  ² Pod::Simple is a Perl module required for converting the testsuite

--- a/common.mk
+++ b/common.mk
@@ -141,6 +141,9 @@ LIBSN_LIBS   := $(call ldflags_for_lib, libstartup-notification-1.0,startup-noti
 PANGO_CFLAGS := $(call cflags_for_lib, cairo)
 PANGO_CFLAGS += $(call cflags_for_lib, pangocairo)
 I3_CPPFLAGS  += -DPANGO_SUPPORT=1
+ifeq ($(shell $(PKG_CONFIG) --atleast-version=1.14.4 cairo 2>/dev/null && echo 1),1)
+I3_CPPFLAGS  += -DI3BAR_CAIRO=1
+endif
 PANGO_LIBS   := $(call ldflags_for_lib, cairo)
 PANGO_LIBS   += $(call ldflags_for_lib, pangocairo)
 


### PR DESCRIPTION
With the recent cairo bugfix, we can now switch to using cairo for
rendering i3bar per default by raising the minimum version of cairo
to 1.14.4.

resolves #2048