### PR TITLE
Bug: parse con_id base 16

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -280,7 +280,7 @@ void match_parse_property(Match *match, const char *ctype, const char *cvalue) {
         }
 
         char *end;
-        long parsed = strtol(cvalue, &end, 10);
+        long parsed = strtol(cvalue, &end, 0);
         if (parsed == LONG_MIN ||
             parsed == LONG_MAX ||
             parsed < 0 ||


### PR DESCRIPTION
Mouse bindings that target the window that was clicked send the command
to the parser with `con_id` of the clicked window serialized base 16
for compatability with FreeBSD. See 7c2842e for explaination.

Set base to 0 for strtol to handle base 16 numbers for that reason.

This allows mouse bindings that target specific windows to work
correctly. Without this change, the focused window is always targetted
rather than the window that was actually clicked.

Regression introduced in b744c5e.