### PR TITLE
Quote the variables in i3-sensible-* correctly

### DIFF
--- a/i3-sensible-editor
+++ b/i3-sensible-editor
@@ -9,8 +9,8 @@
 # mechanism to find the preferred editor
 
 # Hopefully one of these is installed (no flamewars about preference please!):
-for editor in $VISUAL $EDITOR nano vim vi emacs pico qe mg jed gedit mc-edit; do
-    if command -v $editor > /dev/null 2>&1; then
-        exec $editor "$@"
+for editor in "$VISUAL" "$EDITOR" nano vim vi emacs pico qe mg jed gedit mc-edit; do
+    if command -v "$editor" > /dev/null 2>&1; then
+        exec "$editor" "$@"
     fi
 done

--- a/i3-sensible-pager
+++ b/i3-sensible-pager
@@ -11,8 +11,8 @@
 # Hopefully one of these is installed (no flamewars about preference please!):
 # We don't use 'more' because it will exit if the file is too short.
 # Worst case scenario we'll open the file in your editor.
-for pager in $PAGER less most w3m pg i3-sensible-editor; do
-    if command -v $pager > /dev/null 2>&1; then
-        exec $pager "$@"
+for pager in "$PAGER" less most w3m pg i3-sensible-editor; do
+    if command -v "$pager" > /dev/null 2>&1; then
+        exec "$pager" "$@"
     fi
 done

--- a/i3-sensible-terminal
+++ b/i3-sensible-terminal
@@ -8,9 +8,9 @@
 # We welcome patches that add distribution-specific mechanisms to find the
 # preferred terminal emulator. On Debian, there is the x-terminal-emulator
 # symlink for example.
-for terminal in $TERMINAL x-terminal-emulator urxvt rxvt terminator Eterm aterm xterm gnome-terminal roxterm xfce4-terminal termite lxterminal mate-terminal terminology; do
-    if command -v $terminal > /dev/null 2>&1; then
-        exec $terminal "$@"
+for terminal in "$TERMINAL" x-terminal-emulator urxvt rxvt terminator Eterm aterm xterm gnome-terminal roxterm xfce4-terminal termite lxterminal mate-terminal terminology; do
+    if command -v "$terminal" > /dev/null 2>&1; then
+        exec "$terminal" "$@"
     fi
 done
 


### PR DESCRIPTION
Previously, the variables $EDITOR, $PAGER, $TERMINAL and $VISUAL got
shell-expanded twice before executing them.