### PR TITLE
Reject empty swallow definitions

### DIFF
--- a/testcases/t/216-layout-restore-split-swallows.t
+++ b/testcases/t/216-layout-restore-split-swallows.t
@@ -54,9 +54,6 @@ print $fh <<'EOT';
     "floating": "auto_off",
     "layout": "splitv",
     "percent": 0.883854166666667,
-    "swallows": [
-       {}
-    ],
     "type": "con",
     "nodes": [
         {
@@ -65,9 +62,6 @@ print $fh <<'EOT';
             "floating": "auto_off",
             "layout": "splitv",
             "percent": 1,
-            "swallows": [
-               {}
-            ],
             "type": "con",
             "nodes": [
                 {

--- a/testcases/t/234-layout-restore-output.t
+++ b/testcases/t/234-layout-restore-output.t
@@ -54,7 +54,7 @@ print $fh <<'EOT';
             "percent": 1,
             "swallows": [
                {
-               // "class": "^URxvt$",
+                  "class": "^URxvt$"
                // "instance": "^urxvt$",
                // "title": "^vals\\@w00t\\:\\ \\~$"
                }
@@ -119,7 +119,7 @@ print $fh <<'EOT';
             "percent": 1,
             "swallows": [
                {
-               // "class": "^URxvt$",
+                  "class": "^URxvt$"
                // "instance": "^urxvt$",
                // "title": "^vals\\@w00t\\:\\ \\~$"
                }
@@ -165,7 +165,7 @@ print $fh <<'EOT';
             "percent": 1,
             "swallows": [
                {
-               // "class": "^URxvt$",
+                  "class": "^URxvt$"
                // "instance": "^urxvt$",
                // "title": "^vals\\@w00t\\:\\ \\~$"
                }
@@ -213,7 +213,7 @@ print $fh <<'EOT';
             "percent": 1,
             "swallows": [
                {
-               // "class": "^URxvt$",
+                  "class": "^URxvt$"
                // "instance": "^urxvt$",
                // "title": "^vals\\@w00t\\:\\ \\~$"
                }


### PR DESCRIPTION
Empty swallow definitions don't make sense and can lead to crashes,
for that reason we reject them.

fixes #2099
