### PR TITLE
Allow mouse bindings to run on the root window.

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -164,6 +164,10 @@ void regrab_all_buttons(xcb_connection_t *conn) {
         xcb_grab_buttons(conn, con->window->id, grab_scrollwheel);
     }
 
+    /* Also grab the root window to allow bindings to work on there as well. */
+    xcb_ungrab_button(conn, XCB_BUTTON_INDEX_ANY, root, XCB_BUTTON_MASK_ANY);
+    xcb_grab_buttons(conn, root, grab_scrollwheel);
+
     xcb_ungrab_server(conn);
 }
 


### PR DESCRIPTION
Previously, mouse bindings could only be run when a window was present,
by using --whole-window. Such bindings would not work on empty
workspaces. However, this is a valid usecase for bindings like

    bindsym $mod+button4 workspace prev
    bindsym $mod+button5 workspace next

Hence, we need to grab the root window as well and run bindings on it.

fixes #2097