### PR TITLE
Avoid rendering the tree twice in a row

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -643,8 +643,8 @@ void binding_free(Binding *bind) {
 /*
  * Runs the given binding and handles parse errors. If con is passed, it will
  * execute the command binding with that container selected by criteria.
- * Returns a CommandResult for running the binding's command. Caller should
- * render tree if needs_tree_render is true. Free with command_result_free().
+ * Returns a CommandResult for running the binding's command. Free with
+ * command_result_free().
  *
  */
 CommandResult *run_binding(Binding *bind, Con *con) {

--- a/src/click.c
+++ b/src/click.c
@@ -198,11 +198,7 @@ static int route_click(Con *con, xcb_button_press_event_t *event, const bool mod
             xcb_allow_events(conn, XCB_ALLOW_ASYNC_POINTER, event->time);
             xcb_flush(conn);
 
-            if (result->needs_tree_render)
-                tree_render();
-
             command_result_free(result);
-
             return 0;
         }
     }
@@ -370,10 +366,6 @@ int handle_button_press(xcb_button_press_event_t *event) {
             Binding *bind = get_binding_from_xcb_event((xcb_generic_event_t *)event);
             if (bind != NULL && bind->whole_window) {
                 CommandResult *result = run_binding(bind, NULL);
-                if (result->needs_tree_render) {
-                    tree_render();
-                }
-
                 command_result_free(result);
             }
         }

--- a/src/key_press.c
+++ b/src/key_press.c
@@ -31,9 +31,5 @@ void handle_key_press(xcb_key_press_event_t *event) {
         return;
 
     CommandResult *result = run_binding(bind, NULL);
-
-    if (result->needs_tree_render)
-        tree_render();
-
     command_result_free(result);
 }


### PR DESCRIPTION
The callee already renders the tree if necessary, so despite the documentation
of the function, doing it again on the caller side is unnecessary.