### PR TITLE
Match on all criteria even if con_id or con_mark are given.

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -223,11 +223,25 @@ bool match_matches_window(Match *match, i3Window *window) {
         }
     }
 
-    /* We don’t check the mark because this function is not even called when
-     * the mark would have matched - it is checked in cmdparse.y itself */
     if (match->mark != NULL) {
-        LOG("mark does not match\n");
-        return false;
+        if ((con = con_by_window_id(window->id)) == NULL)
+            return false;
+
+        bool matched = false;
+        mark_t *mark;
+        TAILQ_FOREACH(mark, &(con->marks_head), marks) {
+            if (regex_matches(match->mark, mark->name)) {
+                matched = true;
+                break;
+            }
+        }
+
+        if (matched) {
+            LOG("mark matches\n");
+        } else {
+            LOG("mark does not match\n");
+            return false;
+        }
     }
 
     return true;

--- a/testcases/t/261-match-con_id-con_mark-combinations.t
+++ b/testcases/t/261-match-con_id-con_mark-combinations.t
@@ -1,0 +1,51 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Ticket: #2111
+use i3test;
+
+my ($ws);
+
+###############################################################################
+# Verify that con_id can be combined with other criteria
+###############################################################################
+
+$ws = fresh_workspace;
+open_window(wm_class => 'matchme');
+
+cmd '[con_id=__focused__ class=doesnotmatch] kill';
+is(@{get_ws($ws)->{nodes}}, 1, 'window was not killed');
+
+cmd '[con_id=__focused__ class=matchme] kill';
+is(@{get_ws($ws)->{nodes}}, 0, 'window was killed');
+
+###############################################################################
+# Verify that con_mark can be combined with other criteria
+###############################################################################
+
+$ws = fresh_workspace;
+open_window(wm_class => 'matchme');
+cmd 'mark marked';
+
+cmd '[con_mark=marked class=doesnotmatch] kill';
+is(@{get_ws($ws)->{nodes}}, 1, 'window was not killed');
+
+cmd '[con_mark=marked class=matchme] kill';
+is(@{get_ws($ws)->{nodes}}, 0, 'window was killed');
+
+###############################################################################
+
+done_testing;


### PR DESCRIPTION
Previously, if a match specification contained the con_id or con_mark criterion,
all other criteria were ignored. However, a user may want to specify one of
those two unique identifiers and still specify others as well, for example to
match the currently focused window, but only if it has a certain WM_CLASS:

    [con_id=__focused__ class=special] kill

We now check all specified criteria.

fixes #2111