### PR TITLE
Don't force base 10 for parsing id.

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -297,7 +297,7 @@ void match_parse_property(Match *match, const char *ctype, const char *cvalue) {
 
     if (strcmp(ctype, "id") == 0) {
         char *end;
-        long parsed = strtol(cvalue, &end, 10);
+        long parsed = strtol(cvalue, &end, 0);
         if (parsed == LONG_MIN ||
             parsed == LONG_MAX ||
             parsed < 0 ||


### PR DESCRIPTION
We did the same for con_id recently due to a refactoring regression. We internally don't need it for id, but for users this is convenient in scripts.