### PR TITLE
Bugfix: allow exec command to properly handle quoted ';' and ','

### DIFF
--- a/src/commands_parser.c
+++ b/src/commands_parser.c
@@ -221,10 +221,15 @@ char *parse_string(const char **walk, bool as_word) {
              * comma (,) and semicolon (;) which introduce a new
              * operation or command, respectively. Also, newlines
              * end a command. */
-            while (**walk != ';' && **walk != ',' &&
+            bool quote = false;
+            while ((**walk != ';' || quote) &&
+                   (**walk != ',' || quote) &&
                    **walk != '\0' && **walk != '\r' &&
-                   **walk != '\n')
+                   **walk != '\n') {
+                if (**walk == '"')
+                    quote = !quote;
                 (*walk)++;
+            }
         } else {
             /* For a word, the delimiters are white space (' ' or
              * '\t'), closing square bracket (]), comma (,) and

--- a/testcases/t/187-commands-parser.t
+++ b/testcases/t/187-commands-parser.t
@@ -80,6 +80,14 @@ is(parser_calls(
    "cmd_exec(--no-startup-id, i3-sensible-terminal)",
    'exec ok');
 
+# Tests execution of commands with quoted ',' or ';'
+is(parser_calls(
+   'exec i3-sensible-terminal -e echo "Hello, i3"; ' .
+   'exec --no-startup-id i3-sensible-terminal -e echo "Hello; i3"'),
+   "cmd_exec((null), i3-sensible-terminal -e echo \"Hello, i3\")\n" .
+   "cmd_exec(--no-startup-id, i3-sensible-terminal -e echo \"Hello; i3\")",
+   'exec ok');
+
 is(parser_calls(
    'resize shrink left; ' .
    'resize shrink left 25 px; ' .


### PR DESCRIPTION
Fixes bug [#2122](https://github.com/i3/i3/issues/2122), "Comma enclosed in quotes".

All tests pass.