### PR TITLE
draw client borders in border color, not background

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -836,9 +836,9 @@ workspace "2: vim" output VGA1
 You can change all colors which i3 uses to draw the window decorations.
 
 *Syntax*:
-------------------------------------------------------
-<colorclass> <border> <background> <text> <indicator>
-------------------------------------------------------
+-------------------------------------------------------------------------
+<colorclass> <border> <background> <text> <indicator> <decoration_border>
+-------------------------------------------------------------------------
 
 Where colorclass can be one of:
 
@@ -864,19 +864,19 @@ Colors are in HTML hex format (#rrggbb), see the following example:
 
 *Examples (default colors)*:
 ---------------------------------------------------------
-# class                 border  backgr. text    indicator
-client.focused          #4c7899 #285577 #ffffff #2e9ef4
-client.focused_inactive #333333 #5f676a #ffffff #484e50
-client.unfocused        #333333 #222222 #888888 #292d2e
-client.urgent           #2f343a #900000 #ffffff #900000
-client.placeholder      #000000 #0c0c0c #ffffff #000000
+# class                 border  backgr. text    indicator decoration_border
+client.focused          #4c7899 #285577 #ffffff #2e9ef4   #285577
+client.focused_inactive #333333 #5f676a #ffffff #484e50   #5f676a
+client.unfocused        #333333 #222222 #888888 #292d2e   #222222
+client.urgent           #2f343a #900000 #ffffff #900000   #900000
+client.placeholder      #000000 #0c0c0c #ffffff #000000   #0c0c0c
 
 client.background       #ffffff
 ---------------------------------------------------------
 
 Note that for the window decorations, the color around the child window is the
-background color, and the border color is only the two thin lines at the top of
-the window.
+"decoration_border", and "border" color is only the two thin lines around the
+titlebar.
 
 The indicator color is used for indicating where a new window will be opened.
 For horizontal split containers, the right border will be painted in indicator

--- a/include/config.h
+++ b/include/config.h
@@ -54,6 +54,7 @@ struct Colortriple {
     color_t background;
     color_t text;
     color_t indicator;
+    color_t decoration_border;
 };
 
 /**

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -59,7 +59,7 @@ CFGFUN(no_focus);
 CFGFUN(ipc_socket, const char *path);
 CFGFUN(restart_state, const char *path);
 CFGFUN(popup_during_fullscreen, const char *value);
-CFGFUN(color, const char *colorclass, const char *border, const char *background, const char *text, const char *indicator);
+CFGFUN(color, const char *colorclass, const char *border, const char *background, const char *text, const char *indicator, const char *decoration_border);
 CFGFUN(color_single, const char *colorclass, const char *color);
 CFGFUN(floating_modifier, const char *modifiers);
 CFGFUN(new_window, const char *windowtype, const char *border, const long width);

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -282,9 +282,15 @@ state COLOR_TEXT:
 
 state COLOR_INDICATOR:
   indicator = word
-      -> call cfg_color($colorclass, $border, $background, $text, $indicator)
+      -> COLOR_DECORATION_BORDER
   end
-      -> call cfg_color($colorclass, $border, $background, $text, NULL)
+      -> call cfg_color($colorclass, $border, $background, $text, NULL, NULL)
+
+state COLOR_DECORATION_BORDER:
+  decoration_border = word
+      -> call cfg_color($colorclass, $border, $background, $text, $indicator, $decoration_border)
+  end
+      -> call cfg_color($colorclass, $border, $background, $text, $indicator, NULL)
 
 # <exec|exec_always> [--no-startup-id] command
 state EXEC:

--- a/src/config.c
+++ b/src/config.c
@@ -189,12 +189,13 @@ void load_configuration(xcb_connection_t *conn, const char *override_configpath,
     memset(&config, 0, sizeof(config));
 
 /* Initialize default colors */
-#define INIT_COLOR(x, cborder, cbackground, ctext, cindicator) \
-    do {                                                       \
-        x.border = draw_util_hex_to_color(cborder);            \
-        x.background = draw_util_hex_to_color(cbackground);    \
-        x.text = draw_util_hex_to_color(ctext);                \
-        x.indicator = draw_util_hex_to_color(cindicator);      \
+#define INIT_COLOR(x, cborder, cbackground, ctext, cindicator)     \
+    do {                                                           \
+        x.border = draw_util_hex_to_color(cborder);                \
+        x.background = draw_util_hex_to_color(cbackground);        \
+        x.text = draw_util_hex_to_color(ctext);                    \
+        x.indicator = draw_util_hex_to_color(cindicator);          \
+        x.decoration_border = draw_util_hex_to_color(cbackground); \
     } while (0)
 
     config.client.background = draw_util_hex_to_color("#000000");

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -335,17 +335,20 @@ CFGFUN(color_single, const char *colorclass, const char *color) {
     config.client.background = draw_util_hex_to_color(color);
 }
 
-CFGFUN(color, const char *colorclass, const char *border, const char *background, const char *text, const char *indicator) {
-#define APPLY_COLORS(classname)                                                        \
-    do {                                                                               \
-        if (strcmp(colorclass, "client." #classname) == 0) {                           \
-            config.client.classname.border = draw_util_hex_to_color(border);           \
-            config.client.classname.background = draw_util_hex_to_color(background);   \
-            config.client.classname.text = draw_util_hex_to_color(text);               \
-            if (indicator != NULL) {                                                   \
-                config.client.classname.indicator = draw_util_hex_to_color(indicator); \
-            }                                                                          \
-        }                                                                              \
+CFGFUN(color, const char *colorclass, const char *border, const char *background, const char *text, const char *indicator, const char *decoration_border) {
+#define APPLY_COLORS(classname)                                                                        \
+    do {                                                                                               \
+        if (strcmp(colorclass, "client." #classname) == 0) {                                           \
+            config.client.classname.border = draw_util_hex_to_color(border);                           \
+            config.client.classname.background = draw_util_hex_to_color(background);                   \
+            config.client.classname.text = draw_util_hex_to_color(text);                               \
+            if (indicator != NULL) {                                                                   \
+                config.client.classname.indicator = draw_util_hex_to_color(indicator);                 \
+            }                                                                                          \
+            if (decoration_border != NULL) {                                                           \
+                config.client.classname.decoration_border = draw_util_hex_to_color(decoration_border); \
+            }                                                                                          \
+        }                                                                                              \
     } while (0)
 
     APPLY_COLORS(focused_inactive);

--- a/src/x.c
+++ b/src/x.c
@@ -299,7 +299,7 @@ void x_window_kill(xcb_window_t window, kill_window_t kill_window) {
     free(event);
 }
 
-static void x_draw_decoration_border(Con *con, struct deco_render_params *p) {
+static void x_draw_title_border(Con *con, struct deco_render_params *p) {
     assert(con->parent != NULL);
 
     Rect *dr = &(con->deco_rect);
@@ -344,7 +344,7 @@ static void x_draw_decoration_after_title(Con *con, struct deco_render_params *p
     }
 
     /* Redraw the border. */
-    x_draw_decoration_border(con, p);
+    x_draw_title_border(con, p);
 }
 
 /*
@@ -464,21 +464,24 @@ void x_draw_decoration(Con *con) {
          * rectangle because some childs are not freely resizable and we want
          * their background color to "shine through". */
         if (!(borders_to_hide & ADJ_LEFT_SCREEN_EDGE)) {
-            draw_util_rectangle(conn, &(con->frame_buffer), p->color->background,
-                                0, 0, br.x, r->height);
+            draw_util_rectangle(conn, &(con->frame_buffer), p->color->decoration_border, 0, 0, br.x, r->height);
         }
         if (!(borders_to_hide & ADJ_RIGHT_SCREEN_EDGE)) {
-            draw_util_rectangle(conn, &(con->frame_buffer), p->color->background,
-                                r->width + (br.width + br.x), 0, -(br.width + br.x), r->height);
+            draw_util_rectangle(conn, &(con->frame_buffer),
+                                p->color->decoration_border, r->width + (br.width + br.x), 0,
+                                -(br.width + br.x), r->height);
         }
         if (!(borders_to_hide & ADJ_LOWER_SCREEN_EDGE)) {
-            draw_util_rectangle(conn, &(con->frame_buffer), p->color->background,
-                                br.x, r->height + (br.height + br.y), r->width + br.width, -(br.height + br.y));
+            draw_util_rectangle(conn, &(con->frame_buffer),
+                                p->color->decoration_border, br.x, r->height + (br.height +
+                                                                                br.y),
+                                r->width + br.width, -(br.height + br.y));
         }
         /* pixel border needs an additional line at the top */
         if (p->border_style == BS_PIXEL && !(borders_to_hide & ADJ_UPPER_SCREEN_EDGE)) {
-            draw_util_rectangle(conn, &(con->frame_buffer), p->color->background,
-                                br.x, 0, r->width + br.width, br.y);
+            draw_util_rectangle(conn, &(con->frame_buffer),
+                                p->color->decoration_border, br.x, 0, r->width + br.width,
+                                br.y);
         }
 
         /* Highlight the side of the border at which the next window will be
@@ -521,7 +524,7 @@ void x_draw_decoration(Con *con) {
                         con->deco_rect.x, con->deco_rect.y, con->deco_rect.width, con->deco_rect.height);
 
     /* 5: draw two unconnected horizontal lines in border color */
-    x_draw_decoration_border(con, p);
+    x_draw_title_border(con, p);
 
     /* 6: draw the title */
     int text_offset_y = (con->deco_rect.height - config.font.height) / 2;

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -412,19 +412,19 @@ is(parser_calls($config),
 ################################################################################
 
 $config = <<'EOT';
-client.focused          #4c7899 #285577 #ffffff #2e9ef4
+client.focused          #4c7899 #285577 #ffffff #2e9ef4 #b34d4c
 client.focused_inactive #333333 #5f676a #ffffff #484e50
 client.unfocused        #333333 #222222 #888888 #292d2e
-client.urgent           #2f343a #900000 #ffffff #900000
+client.urgent           #2f343a #900000 #ffffff #900000 #c00000
 client.placeholder      #000000 #0c0c0c #ffffff #000000
 EOT
 
 $expected = <<'EOT';
-cfg_color(client.focused, #4c7899, #285577, #ffffff, #2e9ef4)
-cfg_color(client.focused_inactive, #333333, #5f676a, #ffffff, #484e50)
-cfg_color(client.unfocused, #333333, #222222, #888888, #292d2e)
-cfg_color(client.urgent, #2f343a, #900000, #ffffff, #900000)
-cfg_color(client.placeholder, #000000, #0c0c0c, #ffffff, #000000)
+cfg_color(client.focused, #4c7899, #285577, #ffffff, #2e9ef4, #b34d4c)
+cfg_color(client.focused_inactive, #333333, #5f676a, #ffffff, #484e50, NULL)
+cfg_color(client.unfocused, #333333, #222222, #888888, #292d2e, NULL)
+cfg_color(client.urgent, #2f343a, #900000, #ffffff, #900000, #c00000)
+cfg_color(client.placeholder, #000000, #0c0c0c, #ffffff, #000000, NULL)
 EOT
 
 is(parser_calls($config),
@@ -449,7 +449,7 @@ ERROR: CONFIG: (in file <stdin>)
 ERROR: CONFIG: Line   1: hide_edge_border both
 ERROR: CONFIG:           ^^^^^^^^^^^^^^^^^^^^^
 ERROR: CONFIG: Line   2: client.focused          #4c7899 #285577 #ffffff #2e9ef4
-cfg_color(client.focused, #4c7899, #285577, #ffffff, #2e9ef4)
+cfg_color(client.focused, #4c7899, #285577, #ffffff, #2e9ef4, NULL)
 EOT
 
 $expected = $expected_all_tokens . $expected_end;
@@ -469,7 +469,7 @@ ERROR: CONFIG: (in file <stdin>)
 ERROR: CONFIG: Line   1: hide_edge_borders FOOBAR
 ERROR: CONFIG:                             ^^^^^^
 ERROR: CONFIG: Line   2: client.focused          #4c7899 #285577 #ffffff #2e9ef4
-cfg_color(client.focused, #4c7899, #285577, #ffffff, #2e9ef4)
+cfg_color(client.focused, #4c7899, #285577, #ffffff, #2e9ef4, NULL)
 EOT
 
 is(parser_calls($config),


### PR DESCRIPTION
I mainly use windows without title bars (ie. 'pixel' border, not 'normal'), and sometimes have a little trouble seeing which window is focused. Because of this I like to make the window border a color that stands out a bit more, but that has the unfortunate side effect of also making focused client title bars (for clients that do have a 'normal' border) stand out because the 'background' color is used for drawing the borders. I find that a bit confusing, and think that the color called "border" should be used for client borders, instead of "background".
