### PR TITLE
Comply with documentation: 'workspace' token in 'assign' command

### DIFF
--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -146,6 +146,8 @@ state ASSIGN:
 state ASSIGN_WORKSPACE:
   '→'
       ->
+  'workspace'
+      ->
   workspace = string
       -> call cfg_assign($workspace)
 


### PR DESCRIPTION
According to the [User's Guide](https://i3wm.org/docs/userguide.html#_automatically_putting_clients_on_specific_workspaces), an `assign` command allows a `workspace` token after the selector, as an alternative or in addition to the unicode arrow `→`:
> Syntax:
> ```
> assign <criteria> [→] [workspace] <workspace>
> ```

In reality, however, the `workspace` token is not recognized.

Example:
```
assign [class="Firefox"] workspace "1: Browser"
```
should assign Firefox windows to workspace `1: Browser`, but the the browser window appears on a new workspace called `workspace "1: Browser"` instead.

With this fix, both `→` and `workspace` are recognized (and ignored) after the selector.
