### PR TITLE
Refactor extern definition of conn and root_screen

### DIFF
--- a/i3bar/include/xcb.h
+++ b/i3bar/include/xcb.h
@@ -24,8 +24,6 @@
 #define XEMBED_MAPPED (1 << 0)
 #define XEMBED_EMBEDDED_NOTIFY 0
 
-xcb_connection_t *xcb_connection;
-
 /* We define xcb_request_failed as a macro to include the relevant line number */
 #define xcb_request_failed(cookie, err_msg) _xcb_request_failed(cookie, err_msg, __LINE__)
 int _xcb_request_failed(xcb_void_cookie_t cookie, char *err_msg, int line);

--- a/include/i3.h
+++ b/include/i3.h
@@ -35,7 +35,6 @@ extern struct rlimit original_rlimit_core;
 extern bool debug_build;
 /** The number of file descriptors passed via socket activation. */
 extern int listen_fds;
-extern xcb_connection_t *conn;
 extern int conn_screen;
 /**
  * The EWMH support window that is used to indicate that an EWMH-compliant
@@ -61,7 +60,6 @@ extern TAILQ_HEAD(autostarts_always_head, Autostart) autostarts_always;
 extern TAILQ_HEAD(ws_assignments_head, Workspace_Assignment) ws_assignments;
 extern TAILQ_HEAD(assignments_head, Assignment) assignments;
 extern SLIST_HEAD(stack_wins_head, Stack_Window) stack_wins;
-extern xcb_screen_t *root_screen;
 
 /* Color depth, visual id and colormap to use when creating windows and
  * pixmaps. Will use 32 bit depth and an appropriate visual, if available,

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -27,6 +27,13 @@
 #define DEFAULT_DIR_MODE (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)
 
 /**
+ * XCB connection and root screen
+ *
+ */
+extern xcb_connection_t *conn;
+extern xcb_screen_t *root_screen;
+
+/**
  * Opaque data structure for storing strings.
  *
  */

--- a/libi3/dpi.c
+++ b/libi3/dpi.c
@@ -8,8 +8,6 @@
 #include "libi3.h"
 #include <math.h>
 
-extern xcb_screen_t *root_screen;
-
 /*
  * Convert a logical amount of pixels (e.g. 2 pixels on a “standard” 96 DPI
  * screen) to a corresponding amount of physical pixels on a standard or retina

--- a/libi3/font.c
+++ b/libi3/font.c
@@ -19,9 +19,6 @@
 
 #include "libi3.h"
 
-extern xcb_connection_t *conn;
-extern xcb_screen_t *root_screen;
-
 static const i3Font *savedFont = NULL;
 
 #if PANGO_SUPPORT

--- a/libi3/get_mod_mask.c
+++ b/libi3/get_mod_mask.c
@@ -12,8 +12,6 @@
 
 #include "libi3.h"
 
-extern xcb_connection_t *conn;
-
 /*
  * All-in-one function which returns the modifier mask (XCB_MOD_MASK_*) for the
  * given keysymbol, for example for XCB_NUM_LOCK (usually configured to mod2).

--- a/src/floating.c
+++ b/src/floating.c
@@ -11,8 +11,6 @@
  */
 #include "all.h"
 
-extern xcb_connection_t *conn;
-
 /*
  * Calculates sum of heights and sum of widths of all currently active outputs
  *

--- a/src/resize.c
+++ b/src/resize.c
@@ -11,8 +11,6 @@
  */
 #include "all.h"
 
-extern xcb_connection_t *conn;
-
 /*
  * This is an ugly data structure which we need because there is no standard
  * way of having nested functions (only available as a gcc extension at the


### PR DESCRIPTION
Move `extern xcb_connection_t *conn` and `extern xcb_screen_t *root_screen` into `libi3.h`.