### PR TITLE
added "toggle" option to "split" command

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1750,20 +1750,24 @@ get placed below the current one (splitv).
 
 If you apply this command to a split container with the same orientation,
 nothing will happen. If you use a different orientation, the split container’s
-orientation will be changed (if it does not have more than one window). Use
-+layout toggle split+ to change the layout of any split container from splitv
-to splith or vice-versa.
+orientation will be changed (if it does not have more than one window).
+The +toggle+ option will toggle the orientation of the split container if it
+contains a single window. Otherwise it makes the current window a split
+container with opposite orientation compared to the parent container.
+Use +layout toggle split+ to change the layout of any split container from
+splitv to splith or vice-versa.
 
 *Syntax*:
--------------------------
-split vertical|horizontal
--------------------------
+--------------------------------
+split vertical|horizontal|toggle
+--------------------------------
 
 *Example*:
-------------------------------
+-------------------------------
 bindsym $mod+v split vertical
 bindsym $mod+h split horizontal
-------------------------------
+bindsym $mod+t split toggle
+-------------------------------
 
 === Manipulating layout
 

--- a/include/commands.h
+++ b/include/commands.h
@@ -157,7 +157,7 @@ void cmd_floating(I3_CMD, const char *floating_mode);
 void cmd_move_workspace_to_output(I3_CMD, const char *name);
 
 /**
- * Implementation of 'split v|h|vertical|horizontal'.
+ * Implementation of 'split v|h|t|vertical|horizontal|toggle'.
  *
  */
 void cmd_split(I3_CMD, const char *direction);

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -191,9 +191,9 @@ state STICKY:
   action = 'enable', 'disable', 'toggle'
       -> call cmd_sticky($action)
 
-# split v|h|vertical|horizontal
+# split v|h|t|vertical|horizontal|toggle
 state SPLIT:
-  direction = 'horizontal', 'vertical', 'v', 'h'
+  direction = 'horizontal', 'vertical', 'toggle', 'v', 'h', 't'
       -> call cmd_split($direction)
 
 # floating enable|disable|toggle

--- a/src/commands.c
+++ b/src/commands.c
@@ -1228,7 +1228,7 @@ void cmd_move_workspace_to_output(I3_CMD, const char *name) {
 }
 
 /*
- * Implementation of 'split v|h|vertical|horizontal'.
+ * Implementation of 'split v|h|t|vertical|horizontal|toggle'.
  *
  */
 void cmd_split(I3_CMD, const char *direction) {
@@ -1243,7 +1243,22 @@ void cmd_split(I3_CMD, const char *direction) {
         }
 
         DLOG("matching: %p / %s\n", current->con, current->con->name);
-        tree_split(current->con, (direction[0] == 'v' ? VERT : HORIZ));
+        if (direction[0] == 't') {
+            layout_t current_layout;
+            if (current->con->type == CT_WORKSPACE) {
+                current_layout = current->con->layout;
+            } else {
+                current_layout = current->con->parent->layout;
+            }
+            /* toggling split orientation */
+            if (current_layout == L_SPLITH) {
+                tree_split(current->con, VERT);
+            } else {
+                tree_split(current->con, HORIZ);
+            }
+        } else {
+            tree_split(current->con, (direction[0] == 'v' ? VERT : HORIZ));
+        }
     }
 
     cmd_output->needs_tree_render = true;

--- a/testcases/t/122-split.t
+++ b/testcases/t/122-split.t
@@ -178,4 +178,34 @@ is(@{$content}, 2, 'two containers on workspace');
 is(@{$fst->{nodes}}, 2, 'first child has two children');
 is(@{$snd->{nodes}}, 0, 'second child has no children');
 
+######################################################################
+# Test split toggle
+######################################################################
+
+$tmp = fresh_workspace;
+cmd 'split h';
+cmd 'split toggle';
+$ws = get_ws($tmp);
+is($ws->{layout}, 'splitv', 'toggled workspace split');
+
+$tmp = fresh_workspace;
+cmd 'split h';
+cmd 'split toggle';
+cmd 'split toggle';
+$ws = get_ws($tmp);
+is($ws->{layout}, 'splith', 'toggled workspace back and forth');
+
+cmd 'open';
+cmd 'open';
+cmd 'split toggle';
+
+$content = get_ws_content($tmp);
+my $second = $content->[1];
+is($second->{layout}, 'splitv', 'toggled container orientation to vertical');
+
+cmd 'split toggle';
+$content = get_ws_content($tmp);
+$second = $content->[1];
+is($second->{layout}, 'splith', 'toggled container orientation back to horizontal');
+
 done_testing;


### PR DESCRIPTION
as requested in #1814.
I think this implements what @teto requests.

I chose this default behaviour, but it's quite a random choice:
In case the parent layout is neither `L_SPLITH` nor `L_SPLITV`, the split is done horizontally.