### PR TITLE
Fix segfault when calling "i3 -C".

### DIFF
--- a/libi3/get_colorpixel.c
+++ b/libi3/get_colorpixel.c
@@ -42,7 +42,7 @@ uint32_t get_colorpixel(const char *hex) {
     uint8_t b = strtol(strgroups[2], NULL, 16);
 
     /* Shortcut: if our screen is true color, no need to do a roundtrip to X11 */
-    if (root_screen->root_depth == 24 || root_screen->root_depth == 32) {
+    if (root_screen == NULL || root_screen->root_depth == 24 || root_screen->root_depth == 32) {
         return (0xFF << 24) | (r << 16 | g << 8 | b);
     }
 

--- a/testcases/complete-run.pl
+++ b/testcases/complete-run.pl
@@ -30,6 +30,7 @@ BEGIN {
 
 # these are shipped with the testsuite
 use lib $dirname . 'lib';
+use i3test::Util qw(slurp);
 use StartXServer;
 use StatusLine;
 use TestWorker;
@@ -156,7 +157,7 @@ for my $display (@displays) {
 
 # Read previous timing information, if available. We will be able to roughly
 # predict the test duration and schedule a good order for the tests.
-my $timingsjson = StartXServer::slurp('.last_run_timings.json');
+my $timingsjson = slurp('.last_run_timings.json') if -e '.last_run_timings.json';
 %timings = %{decode_json($timingsjson)} if length($timingsjson) > 0;
 
 # Re-order the files so that those which took the longest time in the previous
@@ -245,7 +246,7 @@ printf("\t%s with %.2f seconds\n", $_, $timings{$_})
 if ($numtests == 1) {
     say '';
     say 'Test output:';
-    say StartXServer::slurp($logfile);
+    say slurp($logfile);
 }
 
 END { cleanup() }

--- a/testcases/lib/StartXServer.pm
+++ b/testcases/lib/StartXServer.pm
@@ -5,19 +5,13 @@ use strict;
 use warnings;
 use Exporter 'import';
 use Time::HiRes qw(sleep);
+use i3test::Util qw(slurp);
 use v5.10;
 
 our @EXPORT = qw(start_xserver);
 
 my @pids;
 my $x_socketpath = '/tmp/.X11-unix/X';
-
-# reads in a whole file
-sub slurp {
-    open(my $fh, '<', shift) or return '';
-    local $/;
-    <$fh>;
-}
 
 # forks an X server process
 sub fork_xserver {
@@ -86,8 +80,11 @@ sub start_xserver {
 
     # Yeah, I know it’s non-standard, but Perl’s POSIX module doesn’t have
     # _SC_NPROCESSORS_CONF.
-    my $cpuinfo = slurp('/proc/cpuinfo');
-    my $num_cores = scalar grep { /model name/ } split("\n", $cpuinfo);
+    my $num_cores;
+    if (-e '/proc/cpuinfo') {
+        my $cpuinfo = slurp('/proc/cpuinfo');
+        $num_cores = scalar grep { /model name/ } split("\n", $cpuinfo);
+    }
     # If /proc/cpuinfo does not exist, we fall back to 2 cores.
     $num_cores ||= 2;
 

--- a/testcases/lib/i3test/Util.pm
+++ b/testcases/lib/i3test/Util.pm
@@ -1,0 +1,47 @@
+package i3test::Util;
+# vim:ts=4:sw=4:expandtab
+
+use strict;
+use warnings;
+use v5.10;
+
+use Exporter qw(import);
+our @EXPORT = qw(
+    slurp
+);
+
+=encoding utf-8
+
+=head1 NAME
+
+i3test::Util - General utility functions
+
+=cut
+
+=head1 EXPORT
+
+=cut
+
+=head2 slurp($fn)
+
+Reads the entire file specified in the arguments and returns the content.
+
+=cut
+sub slurp {
+    my ($file) = @_;
+    my $content = do {
+        local $/ = undef;
+        open my $fh, "<", $file or die "could not open $file: $!";
+        <$fh>;
+    };
+
+    return $content;
+}
+
+=head1 AUTHOR
+
+Michael Stapelberg <michael@i3wm.org>
+
+=cut
+
+1

--- a/testcases/t/171-config-migrate.t
+++ b/testcases/t/171-config-migrate.t
@@ -22,13 +22,6 @@ use Cwd qw(abs_path);
 use File::Temp qw(tempfile tempdir);
 use v5.10;
 
-# reads in a whole file
-sub slurp {
-    open my $fh, '<', shift;
-    local $/;
-    <$fh>;
-}
-
 sub migrate_config {
     my ($config) = @_;
 

--- a/testcases/t/262-config-validation.t
+++ b/testcases/t/262-config-validation.t
@@ -1,0 +1,39 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Ensures that calling i3 with the -C switch works (smoke test).
+# Ticket: #2144
+use i3test i3_autostart => 0;
+use POSIX ":sys_wait_h";
+use Time::HiRes qw(sleep);
+
+my $config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+invalid
+EOT
+
+my $exit_code = launch_with_config($config, validate_config => 1);
+isnt($exit_code, 0, 'i3 exited with an error code');
+
+my $log = get_i3_log;
+
+# We don't care so much about the output (there are tests for this), but rather
+# that we got correct output at all instead of, e.g., a segfault.
+ok($log =~ /Expected one of these tokens/, 'an invalid config token was found');
+
+done_testing;


### PR DESCRIPTION
Commit 287a0b4 introduced a segfault when validating the i3 config
as the root_screen will not be set in this case, causing a null
pointer dereference.

fixes #2144