### PR TITLE
Use correct fallback color for decoration_border.

### DIFF
--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -347,6 +347,8 @@ CFGFUN(color, const char *colorclass, const char *border, const char *background
             }                                                                                          \
             if (decoration_border != NULL) {                                                           \
                 config.client.classname.decoration_border = draw_util_hex_to_color(decoration_border); \
+            } else {                                                                                   \
+                config.client.classname.decoration_border = config.client.classname.background;        \
             }                                                                                          \
         }                                                                                              \
     } while (0)


### PR DESCRIPTION
The newly introduced decoration_border color incorrectly uses the default value
for "background" as a fallback when not specified. Instead, it should use the
user-specified "background" as a fallback.

fixes #2149