### PR TITLE
Add pledge support for OpenBSD

### DIFF
--- a/i3-msg/main.c
+++ b/i3-msg/main.c
@@ -119,6 +119,10 @@ static yajl_callbacks reply_callbacks = {
 };
 
 int main(int argc, char *argv[]) {
+#if defined(__OpenBSD__)
+    if (pledge("stdio rpath unix", NULL) == -1)
+        err(EXIT_FAILURE, "pledge");
+#endif
     char *env_socket_path = getenv("I3SOCK");
     if (env_socket_path)
         socket_path = sstrdup(env_socket_path);

--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -470,6 +470,11 @@ int main(int argc, char *argv[]) {
     font = load_font(pattern, true);
     set_font(&font);
 
+#if defined(__OpenBSD__)
+    if (pledge("stdio rpath wpath cpath getpw proc exec", NULL) == -1)
+        err(EXIT_FAILURE, "pledge");
+#endif
+
     xcb_rectangle_t win_pos = get_window_position();
 
     xcb_cursor_t cursor;

--- a/src/main.c
+++ b/src/main.c
@@ -802,6 +802,11 @@ int main(int argc, char *argv[]) {
         xcb_free_pixmap(conn, pixmap);
     }
 
+#if defined(__OpenBSD__)
+    if (pledge("stdio rpath wpath cpath proc exec unix", NULL) == -1)
+        err(EXIT_FAILURE, "pledge");
+#endif
+
     struct sigaction action;
 
     action.sa_sigaction = handle_signal;


### PR DESCRIPTION
[pledge(2)](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man2/pledge.2?query=pledge) is a new system call in OpenBSD that forces a process into restricted-service operation mode. The following three small patches adding pledge support to i3, i3-msg and i3-nagbar [have been tested](https://marc.info/?l=openbsd-ports-cvs&m=145069308429529&w=2) on OpenBSD-current for a few weeks now. See also the [discussion on the mailing list](https://marc.info/?t=145061676600001&r=1&w=2).
