### PR TITLE
Handle the EWMH atom _NET_WM_DESKTOP.

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -398,6 +398,9 @@ struct Window {
     /** The _NET_WM_WINDOW_TYPE for this window. */
     xcb_atom_t window_type;
 
+    /** The _NET_WM_DESKTOP for this window. */
+    uint32_t wm_desktop;
+
     /** Whether the window says it is a dock window */
     enum { W_NODOCK = 0,
            W_DOCK_TOP = 1,

--- a/include/ewmh.h
+++ b/include/ewmh.h
@@ -37,6 +37,13 @@ void ewmh_update_desktop_names(void);
 void ewmh_update_desktop_viewport(void);
 
 /**
+ * Updates _NET_WM_DESKTOP for all windows.
+ * A request will only be made if the cached value differs from the calculated value.
+ *
+ */
+void ewmh_update_wm_desktop(void);
+
+/**
  * Updates _NET_ACTIVE_WINDOW with the currently focused window.
  *
  * EWMH: The window ID of the currently active window or None if no window has
@@ -96,3 +103,21 @@ void ewmh_setup_hints(void);
  *
  */
 void ewmh_update_workarea(void);
+
+/**
+ * Returns the workspace container as enumerated by the EWMH desktop model.
+ * Returns NULL if no workspace could be found for the index.
+ *
+ * This is the reverse of ewmh_get_workspace_index.
+ *
+ */
+Con *ewmh_get_workspace_by_index(uint32_t idx);
+
+/**
+ * Returns the EWMH desktop index for the workspace the given container is on.
+ * Returns NET_WM_DESKTOP_NONE if the desktop index cannot be determined.
+ *
+ * This is the reverse of ewmh_get_workspace_by_index.
+ *
+ */
+uint32_t ewmh_get_workspace_index(Con *con);

--- a/include/workspace.h
+++ b/include/workspace.h
@@ -14,6 +14,14 @@
 #include "tree.h"
 #include "randr.h"
 
+/* We use NET_WM_DESKTOP_NONE for cases where we cannot determine the EWMH
+ * desktop index for a window. We cannot use a negative value like -1 since we
+ * need to use uint32_t as we actually need the full range of it. This is
+ * technically dangerous, but it's safe to assume that we will never have more
+ * than 4294967279 workspaces open at a time. */
+#define NET_WM_DESKTOP_NONE 0xFFFFFFF0
+#define NET_WM_DESKTOP_ALL 0xFFFFFFFF
+
 /**
  * Returns a pointer to the workspace with the given number (starting at 0),
  * creating the workspace if necessary (by allocating the necessary amount of

--- a/src/commands.c
+++ b/src/commands.c
@@ -1542,6 +1542,8 @@ void cmd_sticky(I3_CMD, const char *action) {
      * sure it gets pushed to the front now. */
     output_push_sticky_windows(focused);
 
+    ewmh_update_wm_desktop();
+
     cmd_output->needs_tree_render = true;
     ysuccess(true);
 }

--- a/src/con.c
+++ b/src/con.c
@@ -1080,6 +1080,7 @@ static bool _con_move_to_con(Con *con, Con *target, bool behind_focused, bool fi
     CALL(parent, on_remove_child);
 
     ipc_send_window_event("move", con);
+    ewmh_update_wm_desktop();
     return true;
 }
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -90,7 +90,7 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
         utf8_title_cookie, title_cookie,
         class_cookie, leader_cookie, transient_cookie,
         role_cookie, startup_id_cookie, wm_hints_cookie,
-        wm_normal_hints_cookie, motif_wm_hints_cookie, wm_user_time_cookie;
+        wm_normal_hints_cookie, motif_wm_hints_cookie, wm_user_time_cookie, wm_desktop_cookie;
 
     geomc = xcb_get_geometry(conn, d);
 
@@ -162,6 +162,7 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
     wm_normal_hints_cookie = xcb_icccm_get_wm_normal_hints(conn, window);
     motif_wm_hints_cookie = GET_PROPERTY(A__MOTIF_WM_HINTS, 5 * sizeof(uint64_t));
     wm_user_time_cookie = GET_PROPERTY(A__NET_WM_USER_TIME, UINT32_MAX);
+    wm_desktop_cookie = GET_PROPERTY(A__NET_WM_DESKTOP, UINT32_MAX);
 
     DLOG("Managing window 0x%08x\n", window);
 
@@ -193,6 +194,16 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
     startup_id_reply = xcb_get_property_reply(conn, startup_id_cookie, NULL);
     char *startup_ws = startup_workspace_for_window(cwindow, startup_id_reply);
     DLOG("startup workspace = %s\n", startup_ws);
+
+    /* Get _NET_WM_DESKTOP if it was set. */
+    xcb_get_property_reply_t *wm_desktop_reply;
+    wm_desktop_reply = xcb_get_property_reply(conn, wm_desktop_cookie, NULL);
+    cwindow->wm_desktop = NET_WM_DESKTOP_NONE;
+    if (wm_desktop_reply != NULL && xcb_get_property_value_length(wm_desktop_reply) != 0) {
+        uint32_t *wm_desktops = xcb_get_property_value(wm_desktop_reply);
+        cwindow->wm_desktop = (int32_t)wm_desktops[0];
+    }
+    FREE(wm_desktop_reply);
 
     /* check if the window needs WM_TAKE_FOCUS */
     cwindow->needs_take_focus = window_supports_protocol(cwindow->id, A_WM_TAKE_FOCUS);
@@ -244,6 +255,8 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
     nc = con_for_window(search_at, cwindow, &match);
     const bool match_from_restart_mode = (match && match->restart_mode);
     if (nc == NULL) {
+        Con *wm_desktop_ws = NULL;
+
         /* If not, check if it is assigned to a specific workspace */
         if ((assignment = assignment_for(cwindow, A_TO_WORKSPACE))) {
             DLOG("Assignment matches (%p)\n", match);
@@ -258,9 +271,23 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
             /* set the urgency hint on the window if the workspace is not visible */
             if (!workspace_is_visible(assigned_ws))
                 urgency_hint = true;
+        } else if (cwindow->wm_desktop != NET_WM_DESKTOP_NONE &&
+                   cwindow->wm_desktop != NET_WM_DESKTOP_ALL &&
+                   (wm_desktop_ws = ewmh_get_workspace_by_index(cwindow->wm_desktop)) != NULL) {
+            /* If _NET_WM_DESKTOP is set to a specific desktop, we open it
+             * there. Note that we ignore the special value 0xFFFFFFFF here
+             * since such a window will be made sticky anyway. */
+
+            DLOG("Using workspace %p / %s because _NET_WM_DESKTOP = %d.\n",
+                 wm_desktop_ws, wm_desktop_ws->name, cwindow->wm_desktop);
+
+            nc = con_descend_tiling_focused(wm_desktop_ws);
+            if (nc->type == CT_WORKSPACE)
+                nc = tree_open_con(nc, cwindow);
+            else
+                nc = tree_open_con(nc->parent, cwindow);
         } else if (startup_ws) {
-            /* If it’s not assigned, but was started on a specific workspace,
-             * we want to open it there */
+            /* If it was started on a specific workspace, we want to open it there. */
             DLOG("Using workspace on which this application was started (%s)\n", startup_ws);
             nc = con_descend_tiling_focused(workspace_get(startup_ws, NULL));
             DLOG("focused on ws %s: %p / %s\n", startup_ws, nc, nc->name);
@@ -392,6 +419,12 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
 
     if (xcb_reply_contains_atom(state_reply, A__NET_WM_STATE_STICKY))
         nc->sticky = true;
+
+    if (cwindow->wm_desktop == NET_WM_DESKTOP_ALL) {
+        DLOG("This window has _NET_WM_DESKTOP = 0xFFFFFFFF. Will float it and make it sticky.\n");
+        nc->sticky = true;
+        want_floating = true;
+    }
 
     FREE(state_reply);
     FREE(type_reply);
@@ -573,6 +606,13 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
      * This code needs to be in this part of manage_window() because the window
      * needs to be on the final workspace first. */
     con_set_urgency(nc, urgency_hint);
+
+    /* Update _NET_WM_DESKTOP. We invalidate the cached value first to force an update. */
+    cwindow->wm_desktop = NET_WM_DESKTOP_NONE;
+    ewmh_update_wm_desktop();
+
+    /* If a sticky window was mapped onto another workspace, make sure to pop it to the front. */
+    output_push_sticky_windows(focused);
 
 geom_out:
     free(geom);

--- a/src/move.c
+++ b/src/move.c
@@ -206,6 +206,7 @@ void tree_move(Con *con, int direction) {
 
                 DLOG("Swapped.\n");
                 ipc_send_window_event("move", con);
+                ewmh_update_wm_desktop();
                 return;
             }
 
@@ -214,6 +215,7 @@ void tree_move(Con *con, int direction) {
                  *  try to move it to a workspace on a different output */
                 move_to_output_directed(con, direction);
                 ipc_send_window_event("move", con);
+                ewmh_update_wm_desktop();
                 return;
             }
 
@@ -274,4 +276,5 @@ end:
 
     tree_flatten(croot);
     ipc_send_window_event("move", con);
+    ewmh_update_wm_desktop();
 }

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -101,6 +101,7 @@ Con *workspace_get(const char *num, bool *created) {
         ewmh_update_number_of_desktops();
         ewmh_update_desktop_names();
         ewmh_update_desktop_viewport();
+        ewmh_update_wm_desktop();
         if (created != NULL)
             *created = true;
     } else if (created != NULL) {
@@ -463,6 +464,7 @@ static void _workspace_show(Con *workspace) {
             ewmh_update_number_of_desktops();
             ewmh_update_desktop_names();
             ewmh_update_desktop_viewport();
+            ewmh_update_wm_desktop();
         }
     }
 

--- a/testcases/t/253-multiple-net-wm-state-atoms.t
+++ b/testcases/t/253-multiple-net-wm-state-atoms.t
@@ -20,7 +20,6 @@ use X11::XCB qw(:all);
 
 sub get_wm_state {
     sync_with_i3;
-    my $atom = $x->atom(name => '_NET_WM_STATE_HIDDEN');
 
     my ($con) = @_; 
     my $cookie = $x->get_property(

--- a/testcases/t/529-net-wm-desktop.t
+++ b/testcases/t/529-net-wm-desktop.t
@@ -1,0 +1,350 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests for _NET_WM_DESKTOP.
+# Ticket: #2153
+use i3test i3_autostart => 0;
+use X11::XCB qw(:all);
+
+###############################################################################
+
+sub get_net_wm_desktop {
+    sync_with_i3;
+
+    my ($con) = @_; 
+    my $cookie = $x->get_property(
+        0,  
+        $con->{id},
+        $x->atom(name => '_NET_WM_DESKTOP')->id,
+        $x->atom(name => 'CARDINAL')->id,
+        0,  
+        1
+    );  
+
+    my $reply = $x->get_property_reply($cookie->{sequence});
+    return undef if $reply->{length} != 1;
+
+    return unpack("L", $reply->{value});
+}
+
+sub send_net_wm_desktop {
+    my ($con, $idx) = @_;
+    my $msg = pack "CCSLLLLLL",
+        X11::XCB::CLIENT_MESSAGE, 32, 0,
+        $con->{id},
+        $x->atom(name => '_NET_WM_DESKTOP')->id,
+        $idx, 0, 0, 0, 0;
+
+    $x->send_event(0, $x->get_root_window(), X11::XCB::EVENT_MASK_SUBSTRUCTURE_REDIRECT, $msg);
+    sync_with_i3;
+}
+
+sub open_window_with_net_wm_desktop {
+    my $idx = shift;
+    my $window = open_window(
+        before_map => sub {
+            my ($window) = @_;
+            $x->change_property(
+                PROP_MODE_REPLACE,
+                $window->id,
+                $x->atom(name => '_NET_WM_DESKTOP')->id,
+                $x->atom(name => 'CARDINAL')->id,
+                32, 1,
+                pack('L', $idx),
+            );
+        },
+    );
+
+    return $window;
+}
+
+# We need to kill all windows in between tests since they survive the i3 restart
+# and will interfere with the following tests.
+sub kill_windows {
+    sync_with_i3;
+    cmd '[title="Window.*"] kill';
+}
+
+###############################################################################
+
+my ($config, $config_mm, $pid, $con);
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+bar {
+    status_command i3status
+}
+EOT
+
+$config_mm = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+workspace "0" output "fake-0"
+workspace "1" output "fake-0"
+workspace "2" output "fake-0"
+workspace "10" output "fake-1"
+workspace "11" output "fake-1"
+workspace "12" output "fake-1"
+
+fake-outputs 1024x768+0+0,1024x768+1024+0
+EOT
+
+###############################################################################
+# Upon managing a window which does not set _NET_WM_DESKTOP, the property is
+# set on the window.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 1';
+$con = open_window;
+
+is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set upon managing a window');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# Upon managing a window which sets _NET_WM_DESKTOP, the window is moved to
+# the specified desktop.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 0';
+open_window;
+cmd 'workspace 1';
+open_window;
+cmd 'workspace 2';
+open_window;
+
+$con = open_window_with_net_wm_desktop(1);
+
+is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP still has the correct value');
+is_num_children('1', 2, 'The window was moved to workspace 1');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# Upon managing a window which sets _NET_WM_DESKTOP to the appropriate value,
+# the window is made sticky and floating.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 0';
+$con = open_window_with_net_wm_desktop(0xFFFFFFFF);
+
+is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP still has the correct value');
+is(@{get_ws('0')->{floating_nodes}}, 1, 'The window is floating');
+ok(get_ws('0')->{floating_nodes}->[0]->{nodes}->[0]->{sticky}, 'The window is sticky');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# _NET_WM_DESKTOP is updated when the window is moved to another workspace
+# on the same output.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 0';
+open_window;
+cmd 'workspace 1';
+open_window;
+cmd 'workspace 0';
+$con = open_window;
+
+cmd 'move window to workspace 1';
+
+is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated when moving the window');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# _NET_WM_DESKTOP is updated when the floating window is moved to another
+# workspace on the same output.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 0';
+open_window;
+cmd 'workspace 1';
+open_window;
+cmd 'workspace 0';
+$con = open_window;
+cmd 'floating enable';
+
+cmd 'move window to workspace 1';
+
+is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated when moving the window');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# _NET_WM_DESKTOP is updated when the window is moved to another workspace
+# on another output.
+###############################################################################
+
+$pid = launch_with_config($config_mm);
+
+cmd 'workspace 0';
+open_window;
+cmd 'workspace 10';
+open_window;
+cmd 'workspace 0';
+$con = open_window;
+
+cmd 'move window to workspace 10';
+
+is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated when moving the window');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# _NET_WM_DESKTOP is removed when the window is withdrawn.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+$con = open_window;
+is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set (sanity check)');
+
+$con->unmap;
+wait_for_unmap($con);
+
+is(get_net_wm_desktop($con), undef, '_NET_WM_DESKTOP is removed');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# A _NET_WM_DESKTOP client message sent to the root window moves a window
+# to the correct workspace.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 0';
+open_window;
+cmd 'workspace 1';
+open_window;
+cmd 'workspace 0';
+
+$con = open_window;
+is_num_children('0', 2, 'The window is on workspace 0');
+
+send_net_wm_desktop($con, 1);
+
+is_num_children('0', 1, 'The window is no longer on workspace 0');
+is_num_children('1', 2, 'The window is now on workspace 1');
+is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# A _NET_WM_DESKTOP client message sent to the root window can make a window
+# sticky.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 0';
+$con = open_window;
+
+send_net_wm_desktop($con, 0xFFFFFFFF);
+
+is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP is updated');
+is(@{get_ws('0')->{floating_nodes}}, 1, 'The window is floating');
+ok(get_ws('0')->{floating_nodes}->[0]->{nodes}->[0]->{sticky}, 'The window is sticky');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# _NET_WM_DESKTOP is updated when a new workspace with a lower number is
+# opened and closed.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 1';
+$con = open_window;
+is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set sanity check)');
+
+cmd 'workspace 0';
+is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# _NET_WM_DESKTOP is updated when a window is made sticky by command.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 0';
+$con = open_window;
+cmd 'floating enable';
+is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set sanity check)');
+
+cmd 'sticky enable';
+is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP is updated');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+# _NET_WM_DESKTOP is updated when a window is made sticky by client message.
+###############################################################################
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 0';
+$con = open_window;
+cmd 'floating enable';
+is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set sanity check)');
+
+my $msg = pack "CCSLLLLLL",
+    X11::XCB::CLIENT_MESSAGE, 32, 0,
+    $con->{id},
+    $x->atom(name => '_NET_WM_STATE')->id,
+    1,
+    $x->atom(name => '_NET_WM_STATE_STICKY')->id,
+    0, 0, 0;
+
+$x->send_event(0, $x->get_root_window(), X11::XCB::EVENT_MASK_SUBSTRUCTURE_REDIRECT, $msg);
+sync_with_i3;
+
+is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP is updated');
+
+kill_windows;
+exit_gracefully($pid);
+
+###############################################################################
+
+done_testing;


### PR DESCRIPTION
We already claim _NET_WM_DESKTOP support in _NET_SUPPORTED since around 2009,
but haven't actually done anything with it. However, especially pagers like
gnome-panel rely on this property to be updated and many tools, like GTK, want
to use the corresponding client messages to make a window sticky, move it
around etc.

This patch implements full support according to the EWMH spec. This means:

* We set the property on all windows when managing it.
* We keep the property updated on all windows at all times.
* We read and respect the property upon managing a window if it was set before
  mapping the window.
* We react to client messages for it.
* We remove the property on withdrawn windows.

Note that the special value 0xFFFFFFFF, according to the spec, means that the
window shall be shown on all workspaces. We do this by making it sticky and
float it. This shows it on all workspaces at least on the output it is on.

Furthermore, the spec gives us the freedom to ignore _NET_WM_DESKTOP when
managing a window if we have good reason to. In our case, we give window
swallowing a higher priority since the user would likely expect that and we
want to keep placeholder windows only around for as long as we have to.
However, we do prioritize this property over, for example, startup
notifications.

fixes #2153