### PR TITLE
Don't grab the buttons on the root window.

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -164,10 +164,6 @@ void regrab_all_buttons(xcb_connection_t *conn) {
         xcb_grab_buttons(conn, con->window->id, grab_scrollwheel);
     }
 
-    /* Also grab the root window to allow bindings to work on there as well. */
-    xcb_ungrab_button(conn, XCB_BUTTON_INDEX_ANY, root, XCB_BUTTON_MASK_ANY);
-    xcb_grab_buttons(conn, root, grab_scrollwheel);
-
     xcb_ungrab_server(conn);
 }
 


### PR DESCRIPTION
We don't actually need to grab the buttons to fix #2097, but doing so
will cause a freeze due to unreleased events.
    
We partially revert 6f12f02 which avoids the freeze, but doesn't break
functionality.

relates to #2097
fixes #2168
