### PR TITLE
Don't ignore focus on _NET_WM_DESKTOP client messages.

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -881,7 +881,7 @@ static void handle_client_message(xcb_client_message_event_t *event) {
                 return;
             }
 
-            con_move_to_workspace(con, ws, false, false, true);
+            con_move_to_workspace(con, ws, true, false, false);
         }
 
         tree_render();


### PR DESCRIPTION
Ignoring the focus leads to a broken focus if the pointer is, e.g.,
over i3bar at the point in time the window is moved by the client
message. It also causes i3bar's workspace display to break.

Thanks to GermainZ for reporting.