### PR TITLE
Do not count '\' in comment as line continuation 

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1115,11 +1115,15 @@ show_marks yes
 Config files support line continuation, meaning when you end a line in a
 backslash character (`\`), the line-break will be ignored by the parser. This
 feature can be used to create more readable configuration files.
+Commented lines are not continued.
 
 *Examples*:
 -------------------
 bindsym Mod1+f \
 fullscreen toggle
+
+# this line is not continued \
+bindsym Mod1+F fullscreen toggle
 -------------------
 
 == Configuring i3bar

--- a/testcases/t/247-config-line-continuation.t
+++ b/testcases/t/247-config-line-continuation.t
@@ -198,4 +198,20 @@ EOT
 is(launch_get_border($config), 'none', 'no border');
 
 
+#####################################################################
+# test ignoring of line continuation within a comment
+#####################################################################
+
+$config = <<'EOT';
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+set $vartest \"special title\"
+for_window [title="$vartest"] border pixel 1
+# this line is not continued, so the following is not contained in this comment\
+for_window [title="$vartest"] border none
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
 done_testing;


### PR DESCRIPTION
fixes #2176 

I'll squash this into a single commit once you approved the changes.

@thatjpk: FYI