### PR TITLE
changed old `cfgparse.y` reference to `config_parser.c`

### DIFF
--- a/docs/hacking-howto
+++ b/docs/hacking-howto
@@ -117,7 +117,7 @@ containers, searching containers, getting specific properties from containers,
 
 src/config.c::
 Contains all functions handling the configuration file (calling the parser
-(src/cfgparse.y) with the correct path, switching key bindings mode).
+src/config_parser.c) with the correct path, switching key bindings mode).
 
 src/debug.c::
 Contains debugging functions to print unhandled X events.


### PR DESCRIPTION
Just came across this. `cfgparse.y` was finally removed in b304e6a.