### PR TITLE
Added Neovim to i3-sensible-editor

### DIFF
--- a/i3-sensible-editor
+++ b/i3-sensible-editor
@@ -9,7 +9,7 @@
 # mechanism to find the preferred editor
 
 # Hopefully one of these is installed (no flamewars about preference please!):
-for editor in "$VISUAL" "$EDITOR" nano vim vi emacs pico qe mg jed gedit mc-edit; do
+for editor in "$VISUAL" "$EDITOR" nano nvim vim vi emacs pico qe mg jed gedit mc-edit; do
     if command -v "$editor" > /dev/null 2>&1; then
         exec "$editor" "$@"
     fi


### PR DESCRIPTION
A lot of people are switching from Vim to Neovim, therefore I think it is logical to add 'nvim' to the list along with the 'vim' and 'vi' options.