### PR TITLE
Remove _NET_WM_STATE on withdrawn windows.

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -503,8 +503,10 @@ static void handle_unmap_notify_event(xcb_unmap_notify_event_t *event) {
         goto ignore_end;
     }
 
-    /* Since we close the container, we need to unset _NET_WM_DESKTOP according to the spec. */
+    /* Since we close the container, we need to unset _NET_WM_DESKTOP and
+     * _NET_WM_STATE according to the spec. */
     xcb_delete_property(conn, event->window, A__NET_WM_DESKTOP);
+    xcb_delete_property(conn, event->window, A__NET_WM_STATE);
 
     tree_close_internal(con, DONT_KILL_WINDOW, false, false);
     tree_render();

--- a/testcases/t/253-multiple-net-wm-state-atoms.t
+++ b/testcases/t/253-multiple-net-wm-state-atoms.t
@@ -33,7 +33,7 @@ sub get_wm_state {
 
     my $reply = $x->get_property_reply($cookie->{sequence});
     my $len = $reply->{length};
-    return 0 if $len == 0;
+    return undef if $len == 0;
 
     my @atoms = unpack("L$len", $reply->{value});
     return \@atoms;
@@ -63,6 +63,20 @@ is_deeply(get_wm_state($window), [ $wm_state_fullscreen ], 'only _NET_WM_STATE_F
 cmd 'sticky enable';
 cmd 'fullscreen disable';
 is_deeply(get_wm_state($window), [ $wm_state_sticky ], 'only _NET_WM_STATE_STICKY is set');
+
+###############################################################################
+# _NET_WM_STATE is removed when the window is withdrawn.
+###############################################################################
+
+fresh_workspace;
+$window = open_window;
+cmd 'sticky enable';
+is_deeply(get_wm_state($window), [ $wm_state_sticky ], 'sanity check: _NET_WM_STATE_STICKY is set');
+
+$window->unmap;
+wait_for_unmap($window);
+
+is(get_wm_state($window), undef, '_NET_WM_STATE is removed');
 
 ##########################################################################
 


### PR DESCRIPTION
According to the spec, _NET_WM_STATE must be removed when the window is
withdrawn, much like _NET_WM_DESKTOP.

fixes #2165