### PR TITLE
Allow "modifier none" in i3bar to disable the modifier.

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1238,7 +1238,7 @@ the windows key). The default value for the hidden_state is hide.
 -------------------------
 mode dock|hide|invisible
 hidden_state hide|show
-modifier <Modifier>
+modifier <Modifier>|none
 ------------------------
 
 *Example*:
@@ -1250,7 +1250,8 @@ bar {
 }
 ----------------
 
-Available modifiers are Mod1-Mod5, Shift, Control (see +xmodmap(1)+).
+Available modifiers are Mod1-Mod5, Shift, Control (see +xmodmap(1)+). You can
+also use "none" if you don't want any modifier to trigger this behavior.
 
 === Mouse button commands
 

--- a/i3bar/src/config.c
+++ b/i3bar/src/config.c
@@ -121,6 +121,11 @@ static int config_string_cb(void *params_, const unsigned char *val, size_t _len
 
     if (!strcmp(cur_key, "modifier")) {
         DLOG("modifier = %.*s\n", len, val);
+        if (len == 4 && !strncmp((const char *)val, "none", strlen("none"))) {
+            config.modifier = XCB_NONE;
+            return 1;
+        }
+
         if (len == 5 && !strncmp((const char *)val, "shift", strlen("shift"))) {
             config.modifier = ShiftMask;
             return 1;
@@ -140,16 +145,12 @@ static int config_string_cb(void *params_, const unsigned char *val, size_t _len
                 case '3':
                     config.modifier = Mod3Mask;
                     return 1;
-                /*
-                case '4':
-                    config.modifier = Mod4Mask;
-                    return 1;
-                */
                 case '5':
                     config.modifier = Mod5Mask;
                     return 1;
             }
         }
+
         config.modifier = Mod4Mask;
         return 1;
     }

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -1094,7 +1094,7 @@ void xcb_chk_cb(struct ev_loop *loop, ev_check *watcher, int revents) {
             DLOG("received an xkb event\n");
 
             xcb_xkb_state_notify_event_t *state = (xcb_xkb_state_notify_event_t *)event;
-            if (state->xkbType == XCB_XKB_STATE_NOTIFY) {
+            if (state->xkbType == XCB_XKB_STATE_NOTIFY && config.modifier != XCB_NONE) {
                 int modstate = state->mods & config.modifier;
 
 #define DLOGMOD(modmask, status)                        \

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -453,7 +453,7 @@ state BAR_ID:
       -> call cfg_bar_id($bar_id); BAR
 
 state BAR_MODIFIER:
-  modifier = 'Mod1', 'Mod2', 'Mod3', 'Mod4', 'Mod5', 'Control', 'Ctrl', 'Shift'
+  modifier = 'Mod1', 'Mod2', 'Mod3', 'Mod4', 'Mod5', 'Control', 'Ctrl', 'Shift', 'none', 'off'
       -> call cfg_bar_modifier($modifier); BAR
 
 state BAR_WHEEL_UP_CMD:

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -446,6 +446,9 @@ CFGFUN(bar_modifier, const char *modifier) {
         current_bar->modifier = M_CONTROL;
     else if (strcmp(modifier, "Shift") == 0)
         current_bar->modifier = M_SHIFT;
+    else if (strcmp(modifier, "none") == 0 ||
+             strcmp(modifier, "off") == 0)
+        current_bar->modifier = M_NONE;
 }
 
 static void bar_configure_binding(const char *button, const char *command) {
@@ -575,6 +578,7 @@ CFGFUN(bar_start) {
     TAILQ_INIT(&(current_bar->bar_bindings));
     TAILQ_INIT(&(current_bar->tray_outputs));
     current_bar->tray_padding = 2;
+    current_bar->modifier = M_MOD4;
 }
 
 CFGFUN(bar_finish) {

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -611,6 +611,9 @@ static void dump_bar_config(yajl_gen gen, Barconfig *config) {
 
     ystr("modifier");
     switch (config->modifier) {
+        case M_NONE:
+            ystr("none");
+            break;
         case M_CONTROL:
             ystr("ctrl");
             break;
@@ -626,11 +629,6 @@ static void dump_bar_config(yajl_gen gen, Barconfig *config) {
         case M_MOD3:
             ystr("Mod3");
             break;
-        /*
-               case M_MOD4:
-               ystr("Mod4");
-               break;
-               */
         case M_MOD5:
             ystr("Mod5");
             break;


### PR DESCRIPTION
This allows "modifier none" (and "modifier off") for the bar config
in order to disable the modifier key altogether. This is useful
for users who use a different approach to hiding / showing the bar,
e.g., a custom keybind that involved multiple keys or scripts.

fixes 2208