### PR TITLE
Don't allow floating workspaces anymore.

### DIFF
--- a/src/floating.c
+++ b/src/floating.c
@@ -116,47 +116,9 @@ void floating_enable(Con *con, bool automatic) {
         return;
     }
 
-    /* 1: If the container is a workspace container, we need to create a new
-     * split-container with the same layout and make that one floating. We
-     * cannot touch the workspace container itself because floating containers
-     * are children of the workspace. */
     if (con->type == CT_WORKSPACE) {
-        LOG("This is a workspace, creating new container around content\n");
-        if (con_num_children(con) == 0) {
-            LOG("Workspace is empty, aborting\n");
-            return;
-        }
-        /* TODO: refactor this with src/con.c:con_set_layout */
-        Con *new = con_new(NULL, NULL);
-        new->parent = con;
-        new->layout = con->layout;
-
-        /* since the new container will be set into floating mode directly
-         * afterwards, we need to copy the workspace rect. */
-        memcpy(&(new->rect), &(con->rect), sizeof(Rect));
-
-        Con *old_focused = TAILQ_FIRST(&(con->focus_head));
-        if (old_focused == TAILQ_END(&(con->focus_head)))
-            old_focused = NULL;
-
-        /* 4: move the existing cons of this workspace below the new con */
-        DLOG("Moving cons\n");
-        Con *child;
-        while (!TAILQ_EMPTY(&(con->nodes_head))) {
-            child = TAILQ_FIRST(&(con->nodes_head));
-            con_detach(child);
-            con_attach(child, new, true);
-        }
-
-        /* 4: attach the new split container to the workspace */
-        DLOG("Attaching new split to ws\n");
-        con_attach(new, con, false);
-
-        if (old_focused)
-            con_focus(old_focused);
-
-        con = new;
-        set_focus = false;
+        LOG("Container is a workspace, not enabling floating mode.\n");
+        return;
     }
 
     /* 1: detach the container from its parent */

--- a/testcases/t/155-floating-split-size.t
+++ b/testcases/t/155-floating-split-size.t
@@ -21,6 +21,9 @@ use i3test;
 
 my $tmp = fresh_workspace;
 
+open_window;
+cmd 'split v';
+
 #####################################################################
 # open a window with 200x80
 #####################################################################
@@ -29,6 +32,8 @@ my $first = open_window({
         rect => [ 0, 0, 200, 80],
         background_color => '#FF0000',
     });
+
+cmd 'split h';
 
 #####################################################################
 # Open a second window with 300x90


### PR DESCRIPTION
This is essentially a revert of daf00a9 which introduced a mechanism
to float workspace containers by wrapping all children into a new
container and floating it.

This caused a bug and there's no good reason (anymore) to allow doing
this in the first place as we don't support floating nested containers.

fixes #2166