### PR TITLE
Don't add tray_output primary for generated example i3 config

### DIFF
--- a/i3.config
+++ b/i3.config
@@ -165,7 +165,6 @@ bindsym Mod1+r mode "resize"
 # finds out, if available)
 bar {
         status_command i3status
-        tray_output primary
 }
 
 #######################################################################

--- a/i3.config.keycodes
+++ b/i3.config.keycodes
@@ -152,5 +152,4 @@ bindcode $mod+27 mode "resize"
 # finds out, if available)
 bar {
         status_command i3status
-        tray_output primary
 }


### PR DESCRIPTION
With "tray_output primary" in config file generated by i3-config-wizard, the 3rd apps, like nm-applet,hexchat,dropbox doesn't show in tray. So let's users choose it. 