### PR TITLE
Revert to default binding mode before reloading the config.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -71,6 +71,11 @@ bool parse_configuration(const char *override_configpath, bool use_nagbar) {
  */
 void load_configuration(xcb_connection_t *conn, const char *override_configpath, bool reload) {
     if (reload) {
+        /* If we are currently in a binding mode, we first revert to the
+         * default since we have no guarantee that the current mode will even
+         * still exist after parsing the config again. See #2228. */
+        switch_mode("default");
+
         /* First ungrab the keys */
         ungrab_all_keys(conn);
 

--- a/testcases/t/263-config-reload-reverts-bind-mode.t
+++ b/testcases/t/263-config-reload-reverts-bind-mode.t
@@ -1,0 +1,56 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Verifies that reloading the config reverts to the default
+# binding mode.
+# Ticket: #2228
+# Bug still in: 4.11-262-geb631ce
+use i3test i3_autostart => 0;
+
+my $config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+mode "othermode" {
+}
+EOT
+
+my $pid = launch_with_config($config);
+
+cmd 'mode othermode';
+
+my $i3 = i3(get_socket_path(0));
+$i3->connect->recv;
+
+my $cv = AnyEvent->condvar;
+$i3->subscribe({
+    mode => sub {
+        my ($event) = @_;
+        $cv->send($event->{change} eq 'default');
+    }
+})->recv;
+
+cmd 'reload';
+
+# Timeout after 0.5s
+my $t;
+$t = AnyEvent->timer(after => 0.5, cb => sub { $cv->send(0); });
+
+ok($cv->recv, 'Mode event received');
+
+exit_gracefully($pid);
+
+done_testing;


### PR DESCRIPTION
If a user reloads the config while in some binding mode, the binding mode
will revert to the default, but no event will ever be fired, causing a
broken i3bar mode display.

This patch explicitly reverts to the default binding mode before reloading
the config. We reload rather than switch to the binding mode after having
reloaded the config because there's no guarantee that mode will even still
exist.

fixes #2228