### PR TITLE
Update information on where to find #i3 on IRC

### DIFF
--- a/PACKAGE-MAINTAINER
+++ b/PACKAGE-MAINTAINER
@@ -42,7 +42,7 @@ If you have any questions, ideas, hints, problems or whatever, please do not
 hesitate to contact me. I will help you out. Just drop me an E-Mail (find the
 address at https://michael.stapelberg.de/Impressum/, scroll down to bottom),
 contact me using the same address in jabber or ask on our IRC channel:
-(#i3 on irc.twice-irc.de).
+(#i3 on irc.freenode.net).
 
 Thanks again for your efforts,
 Michael


### PR DESCRIPTION
I was unsure on whether to update the information in the slides since maybe the should remain as how they were presented, but I saw in the log that they have received similar updates before.