### PR TITLE
Add command to switch outputs back and forth

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1837,7 +1837,7 @@ output::
 ----------------------------------------------
 focus left|right|down|up
 focus parent|child|floating|tiling|mode_toggle
-focus output left|right|up|down|<output>
+focus output left|right|up|down|back_and_forth|<output>
 ----------------------------------------------
 
 *Examples*:

--- a/include/workspace.h
+++ b/include/workspace.h
@@ -22,6 +22,12 @@
 #define NET_WM_DESKTOP_NONE 0xFFFFFFF0
 #define NET_WM_DESKTOP_ALL 0xFFFFFFFF
 
+/* This contains the name of the previous output we were on if our current
+ * workspace's output is different, for use when switching output focus back
+ * and forth.
+ */
+extern char *previous_output_name;
+
 /**
  * Returns a pointer to the workspace with the given number (starting at 0),
  * creating the workspace if necessary (by allocating the necessary amount of

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -136,13 +136,15 @@ state WORKSPACE_NUMBER:
       -> call cmd_workspace_number($workspace, $no_auto_back_and_forth)
 
 # focus left|right|up|down
-# focus output <output>
+# focus output back_and_forth|<output>
 # focus tiling|floating|mode_toggle
 # focus parent|child
 # focus
 state FOCUS:
   direction = 'left', 'right', 'up', 'down'
       -> call cmd_focus_direction($direction)
+  'back_and_forth'
+      -> FOCUS_OUTPUT
   'output'
       -> FOCUS_OUTPUT
   window_mode = 'tiling', 'floating', 'mode_toggle'

--- a/src/commands.c
+++ b/src/commands.c
@@ -1650,7 +1650,16 @@ void cmd_focus_output(I3_CMD, const char *name) {
     current_output = get_output_of_con(current->con);
     assert(current_output != NULL);
 
-    output = get_output_from_string(current_output, name);
+    if (strcasecmp(name, "back_and_forth") == 0) {
+        if (!previous_output_name) {
+            DLOG("No previous output recorded. Not changing focus.\n");
+            return;
+        }
+
+        output = get_output_from_string(current_output, previous_output_name);
+    } else {
+        output = get_output_from_string(current_output, name);
+    }
 
     if (!output) {
         LOG("No such output found.\n");

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -21,6 +21,10 @@ static char *previous_workspace_name = NULL;
  * keybindings. */
 static char **binding_workspace_names = NULL;
 
+/* Stores the name of the previously selected output, for use when switching
+ * back and forth between outputs. */
+char *previous_output_name = NULL;
+
 /*
  * Sets ws->layout to splith/splitv if default_orientation was specified in the
  * configfile. Otherwise, it uses splith/splitv depending on whether the output
@@ -475,6 +479,9 @@ static void _workspace_show(Con *workspace) {
     Con *new_output = con_get_output(focused);
     if (old_output != new_output) {
         x_set_warp_to(&next->rect);
+
+        FREE(previous_output_name);
+        previous_output_name = sstrdup(old_output->name);
     }
 
     /* Update the EWMH hints */

--- a/testcases/t/531-focus-output-backandforth.t
+++ b/testcases/t/531-focus-output-backandforth.t
@@ -1,0 +1,85 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Verifies the 'focus output back_and_forth' command works properly.
+
+use i3test i3_autostart => 0;
+use List::Util qw(first);
+
+my $config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+fake-outputs 1024x768+0+0,1024x768+1024+0
+EOT
+my $pid = launch_with_config($config);
+
+my $tmp = fresh_workspace;
+my $i3 = i3(get_socket_path());
+
+################################################################################
+# use 'focus output back_and_forth' and verify that focus changes as expected
+################################################################################
+
+sub focused_output {
+    my $tree = $i3->get_tree->recv;
+    my $focused = $tree->{focus}->[0];
+    my $output = first { $_->{id} == $focused } @{$tree->{nodes}};
+    return $output->{name};
+}
+
+sync_with_i3;
+$x->root->warp_pointer(0, 0);
+sync_with_i3;
+
+is(focused_output, 'fake-0', 'focus on first output');
+cmd 'workspace 1';
+# ensure workspace 1 stays open
+open_window;
+
+cmd 'focus output back_and_forth';
+
+# we have not changed focus because there is no previous output recorded.
+# we should still be focused on the first workspace.
+is(focused_output, 'fake-0', 'focus on first output');
+
+cmd 'focus output right';
+is(focused_output, 'fake-1', 'focus on the second output');
+
+cmd 'focus output back_and_forth';
+# we should have switched back to the first output at this point.
+is(focused_output, 'fake-0', 'back to our previous output (fake-0)');
+
+cmd 'focus output back_and_forth';
+# now we should have switched back to the second output.
+is(focused_output, 'fake-1', 'back to our previous output (fake-1)');
+
+cmd 'workspace 2';
+# ensure workspace 2 stays open
+open_window;
+
+# focus on workspace 1 on the first output
+cmd 'workspace 1';
+is(focused_ws, '1', 'workspace 1 on first output');
+
+cmd 'focus output back_and_forth';
+
+# we should now be focused on the second output
+is(focused_output, 'fake-1', 'focus is on the second output');
+
+exit_gracefully($pid);
+
+done_testing;


### PR DESCRIPTION
First off, wanted to thank you, the main i3 authors for your work; i3's pretty useful and awesome.

I'm new to i3, X11 and C (pretty much everything), but I wanted to add a command that would allow back and forth focus between outputs.  Even though i3 already has a back-and-forth switch for workspaces, I wanted one specifically for outputs because I want to be able to order my workspace switching order independently of the ability to jump between monitors in a rapid fashion.

I chose "back and forth" as that was the closest equivalent behavior that I could find in i3; please let me know what is preferred, or what should corrected/changed.

Thank you.