### PR TITLE
i3-dmenu-desktop: Remove quotes around exec cmd

### DIFF
--- a/i3-dmenu-desktop
+++ b/i3-dmenu-desktop
@@ -444,7 +444,7 @@ EOT
     if (exists($app->{StartupNotify}) && !$app->{StartupNotify}) {
         $nosn = '--no-startup-id';
     }
-    $cmd = qq|exec $nosn "$exec"|;
+    $cmd = qq|exec $nosn $exec|;
 }
 
 system('i3-msg', $cmd) == 0 or die "Could not launch i3-msg: $?";


### PR DESCRIPTION
The reason for this patch is discussed more in depth here: SirCmpwn/sway#521

The real issue is that the `exec` command in i3 doesn't treat quoted arguments the same way as other commands do. For instance `exec "firefox        " http://google.com` is the same as `exec firefox http://google.com` in i3. This is an unfortunate design, but something that most likely won't change because of backwards compatibility.

Sway aims to be compatible with i3, but we would like to avoid implementing this behavior if it doesn't break too much for the users.

This patch solves some of the issue by making `i3-dmenu-desktop` compatible with sway, without affecting how it works with i3.