### PR TITLE
i3-dmenu-desktop: do not die on failed open

### DIFF
--- a/i3-dmenu-desktop
+++ b/i3-dmenu-desktop
@@ -25,7 +25,11 @@ binmode STDERR, ':utf8';
 # reads in a whole file
 sub slurp {
     my ($filename) = @_;
-    open(my $fh, '<', $filename) or die "$!";
+    my $fh;
+    if (!open($fh, '<', $filename)) {
+        warn "Could not open $filename: $!";
+        return undef;
+    }
     local $/;
     my $result;
     eval {


### PR DESCRIPTION
It is possible for the open() call in slurp() to fail. If it fails, it might be better to skip that file (i.e.: return undef, to mimic the "Could not read" error later in the function) rather than just killing the whole execution. 
Typically, the open fails on broken symlinks (which might happen if /etc/alternatives/ is getting messy).

## To reproduce :
`# ln -s /broken ~/.local/share/applications/broken.desktop`
## Current result :
```
# i3-dmenu-desktop 
No such file or directory at /usr/bin/i3-dmenu-desktop line 28.
```
And the dmenu does **not appear at all**
## Expected result:
```
# i3-dmenu-desktop 
Could not open /home/cedric/.local/share/applications/broken.desktop: No such file or directory at ./i3-dmenu-desktop line 28.
```
**But** the dmenu now appears despite the problematic file.