### PR TITLE
Only grab the mouse buttons that need to be grabbed.

### DIFF
--- a/include/bindings.h
+++ b/include/bindings.h
@@ -104,10 +104,10 @@ CommandResult *run_binding(Binding *bind, Con *con);
 bool load_keymap(void);
 
 /**
- * Returns true if the current config has any binding to a scroll wheel button
- * (4 or 5) which is a whole-window binding.
- * We need this to figure out whether we should grab all buttons or just 1-3
- * when managing a window. See #2049.
- *
+ * Returns a list of buttons that should be grabbed on a window.
+ * This list will always contain 1–3, all higher buttons will only be returned
+ * if there is a whole-window binding for it on some window in the current
+ * config.
+ * The list is terminated by a 0.
  */
-bool bindings_should_grab_scrollwheel_buttons(void);
+int *bindings_get_buttons_to_grab(void);

--- a/include/xcb.h
+++ b/include/xcb.h
@@ -171,4 +171,4 @@ void xcb_remove_property_atom(xcb_connection_t *conn, xcb_window_t window, xcb_a
  * Grab the specified buttons on a window when managing it.
  *
  */
-void xcb_grab_buttons(xcb_connection_t *conn, xcb_window_t window, bool bind_scrollwheel);
+void xcb_grab_buttons(xcb_connection_t *conn, xcb_window_t window, int *buttons);

--- a/src/manage.c
+++ b/src/manage.c
@@ -170,7 +170,9 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
     cwindow->id = window;
     cwindow->depth = get_visual_depth(attr->visual);
 
-    xcb_grab_buttons(conn, window, bindings_should_grab_scrollwheel_buttons());
+    int *buttons = bindings_get_buttons_to_grab();
+    xcb_grab_buttons(conn, window, buttons);
+    FREE(buttons);
 
     /* update as much information as possible so far (some replies may be NULL) */
     window_update_class(cwindow, xcb_get_property_reply(conn, class_cookie, NULL), true);

--- a/src/xcb.c
+++ b/src/xcb.c
@@ -346,20 +346,12 @@ release_grab:
  * Grab the specified buttons on a window when managing it.
  *
  */
-void xcb_grab_buttons(xcb_connection_t *conn, xcb_window_t window, bool bind_scrollwheel) {
-    uint8_t buttons[3];
-    int num = 0;
-
-    if (bind_scrollwheel) {
-        buttons[num++] = XCB_BUTTON_INDEX_ANY;
-    } else {
-        buttons[num++] = XCB_BUTTON_INDEX_1;
-        buttons[num++] = XCB_BUTTON_INDEX_2;
-        buttons[num++] = XCB_BUTTON_INDEX_3;
-    }
-
-    for (int i = 0; i < num; i++) {
+void xcb_grab_buttons(xcb_connection_t *conn, xcb_window_t window, int *buttons) {
+    int i = 0;
+    while (buttons[i] > 0) {
         xcb_grab_button(conn, false, window, XCB_EVENT_MASK_BUTTON_PRESS, XCB_GRAB_MODE_SYNC,
                         XCB_GRAB_MODE_ASYNC, root, XCB_NONE, buttons[i], XCB_BUTTON_MASK_ANY);
+
+        i++;
     }
 }


### PR DESCRIPTION
This is a followup to #2049. While we had fixed that bug by only grabbing
buttons 4 and 5 if there is a whole-window binding for that button, this
did not consider buttons higher than 5 as found on many mice.

Therefore, we now ditch the special handling for scrollwheel buttons and
instead do the same for all buttons higher than 3.

fixes #2271
