### PR TITLE
Fix rendering of marks (and smaller fixed)

### DIFF
--- a/src/x.c
+++ b/src/x.c
@@ -332,8 +332,10 @@ static void x_draw_decoration_after_title(Con *con, struct deco_render_params *p
     /* Redraw the right border to cut off any text that went past it.
      * This is necessary when the text was drawn using XCB since cutting text off
      * automatically does not work there. For pango rendering, this isn't necessary. */
-    draw_util_rectangle(conn, &(con->parent->frame_buffer), p->color->background,
-                        dr->x + dr->width + br.width, dr->y, -br.width, dr->height);
+    if (!font_is_pango()) {
+        draw_util_rectangle(conn, &(con->parent->frame_buffer), p->color->background,
+                            dr->x + dr->width + br.width, dr->y, -br.width, dr->height);
+    }
 
     /* Draw a 1px separator line before and after every tab, so that tabs can
      * be easily distinguished. */

--- a/src/x.c
+++ b/src/x.c
@@ -555,8 +555,9 @@ void x_draw_decoration(Con *con) {
 
         draw_util_text(title, &(parent->frame_buffer),
                        p->color->text, p->color->background,
-                       con->deco_rect.x + 2, con->deco_rect.y + text_offset_y,
-                       con->deco_rect.width - 2);
+                       con->deco_rect.x + logical_px(2),
+                       con->deco_rect.y + text_offset_y,
+                       con->deco_rect.width - 2 * logical_px(2));
         I3STRING_FREE(title);
 
         goto after_title;
@@ -617,8 +618,9 @@ void x_draw_decoration(Con *con) {
     i3String *title = con->title_format == NULL ? win->name : con_parse_title_format(con);
     draw_util_text(title, &(parent->frame_buffer),
                    p->color->text, p->color->background,
-                   con->deco_rect.x + logical_px(2) + indent_px, con->deco_rect.y + text_offset_y,
-                   con->deco_rect.width - logical_px(2) - indent_px - mark_width - logical_px(2));
+                   con->deco_rect.x + logical_px(2) + indent_px,
+                   con->deco_rect.y + text_offset_y,
+                   con->deco_rect.width - indent_px - mark_width - 2 * logical_px(2));
     if (con->title_format != NULL)
         I3STRING_FREE(title);
 

--- a/src/x.c
+++ b/src/x.c
@@ -327,14 +327,19 @@ static void x_draw_decoration_after_title(Con *con, struct deco_render_params *p
     assert(con->parent != NULL);
 
     Rect *dr = &(con->deco_rect);
-    Rect br = con_border_style_rect(con);
 
     /* Redraw the right border to cut off any text that went past it.
      * This is necessary when the text was drawn using XCB since cutting text off
      * automatically does not work there. For pango rendering, this isn't necessary. */
     if (!font_is_pango()) {
+        /* We actually only redraw the far right two pixels as that is the
+         * distance we keep from the edge (not the entire border width).
+         * Redrawing the entire border would cause text to be cut off. */
         draw_util_rectangle(conn, &(con->parent->frame_buffer), p->color->background,
-                            dr->x + dr->width + br.width, dr->y, -br.width, dr->height);
+                            dr->x + dr->width - 2 * logical_px(1),
+                            dr->y,
+                            2 * logical_px(1),
+                            dr->height);
     }
 
     /* Draw a 1px separator line before and after every tab, so that tabs can


### PR DESCRIPTION
Attempt #2. This time we really only fix the cut off text and an edge case, but don't change how much titles are intended from the left resp. marks from the right.