### PR TITLE
Correctly count the number of windows for no_focus.

### DIFF
--- a/include/con.h
+++ b/include/con.h
@@ -201,6 +201,12 @@ Con *con_for_window(Con *con, i3Window *window, Match **store_match);
 int con_num_children(Con *con);
 
 /**
+ * Count the number of windows (i.e., leaf containers).
+ *
+ */
+int con_num_windows(Con *con);
+
+/**
  * Attaches the given container to the given parent. This happens when moving
  * a container or when inserting a new container at a specific place in the
  * tree.

--- a/src/con.c
+++ b/src/con.c
@@ -728,6 +728,26 @@ int con_num_children(Con *con) {
 }
 
 /*
+ * Count the number of windows (i.e., leaf containers).
+ *
+ */
+int con_num_windows(Con *con) {
+    if (con == NULL)
+        return 0;
+
+    if (con_has_managed_window(con))
+        return 1;
+
+    int num = 0;
+    Con *current = NULL;
+    TAILQ_FOREACH(current, &(con->nodes_head), nodes) {
+        num += con_num_windows(current);
+    }
+
+    return num;
+}
+
+/*
  * Updates the percent attribute of the children of the given container. This
  * function needs to be called when a window is added or removed from a
  * container.

--- a/src/manage.c
+++ b/src/manage.c
@@ -577,7 +577,7 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
         /* The first window on a workspace should always be focused. We have to
          * compare with == 1 because the container has already been inserted at
          * this point. */
-        if (con_num_children(ws) == 1) {
+        if (con_num_windows(ws) == 1) {
             DLOG("This is the first window on this workspace, ignoring no_focus.\n");
         } else {
             DLOG("no_focus was set for con = %p, not setting focus.\n", nc);


### PR DESCRIPTION
Previously we counted the number of (direct) children of the workspace to
decide whether no_focus should be applied or not. However, this doesn't
work correctly if there's a single container with multiple windows on the
workspace.

This patch correctly counts all windows on the workspace.

fixes #2292