### PR TITLE
Cast con id as uintptr_t

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -9,6 +9,7 @@
  * commands.c: all command functions (see commands_parser.c)
  *
  */
+#include <stdint.h>
 #include <float.h>
 #include <stdarg.h>
 
@@ -1625,7 +1626,7 @@ void cmd_open(I3_CMD) {
     ystr("success");
     y(bool, true);
     ystr("id");
-    y(integer, (long int)con);
+    y(integer, (uintptr_t)con);
     y(map_close);
 
     cmd_output->needs_tree_render = true;

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -12,6 +12,7 @@
 #include "all.h"
 #include "yajl_utils.h"
 
+#include <stdint.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <fcntl.h>
@@ -217,7 +218,7 @@ static void dump_binding(yajl_gen gen, Binding *bind) {
 void dump_node(yajl_gen gen, struct Con *con, bool inplace_restart) {
     y(map_open);
     ystr("id");
-    y(integer, (long int)con);
+    y(integer, (uintptr_t)con);
 
     ystr("type");
     switch (con->type) {
@@ -444,7 +445,7 @@ void dump_node(yajl_gen gen, struct Con *con, bool inplace_restart) {
     ystr("focus");
     y(array_open);
     TAILQ_FOREACH(node, &(con->focus_head), focused) {
-        y(integer, (long int)node);
+        y(integer, (uintptr_t)node);
     }
     y(array_close);
 


### PR DESCRIPTION
Use `uintptr_t` to cast the con id to int instead of `long int`. This
type is guaranteed to hold the pointer as an int regardless of platform.

fixes #2283