### PR TITLE
Medium optimization

### DIFF
--- a/i3bar/src/ipc.c
+++ b/i3bar/src/ipc.c
@@ -199,7 +199,7 @@ void got_data(struct ev_loop *loop, ev_io *watcher, int events) {
     int fd = watcher->fd;
 
     /* First we only read the header, because we know its length */
-    uint32_t header_len = strlen(I3_IPC_MAGIC) + sizeof(uint32_t) * 2;
+    uint32_t header_len = I3_IPC_MAGIC_LEN + sizeof(uint32_t) * 2;
     char *header = smalloc(header_len);
 
     /* We first parse the fixed-length IPC header, to know, how much data
@@ -224,15 +224,15 @@ void got_data(struct ev_loop *loop, ev_io *watcher, int events) {
         rec += n;
     }
 
-    if (strncmp(header, I3_IPC_MAGIC, strlen(I3_IPC_MAGIC))) {
+    if (strncmp(header, I3_IPC_MAGIC, I3_IPC_MAGIC_LEN)) {
         ELOG("Wrong magic code: %.*s\n Expected: %s\n",
-             (int)strlen(I3_IPC_MAGIC),
+             (int)I3_IPC_MAGIC_LEN,
              header,
              I3_IPC_MAGIC);
         exit(EXIT_FAILURE);
     }
 
-    char *walk = header + strlen(I3_IPC_MAGIC);
+    char *walk = header + I3_IPC_MAGIC_LEN;
     uint32_t size;
     memcpy(&size, (uint32_t *)walk, sizeof(uint32_t));
     walk += sizeof(uint32_t);
@@ -283,15 +283,15 @@ int i3_send_msg(uint32_t type, const char *payload) {
     }
 
     /* We are a wellbehaved client and send a proper header first */
-    uint32_t to_write = strlen(I3_IPC_MAGIC) + sizeof(uint32_t) * 2 + len;
+    uint32_t to_write = I3_IPC_MAGIC_LEN + sizeof(uint32_t) * 2 + len;
     /* TODO: I'm not entirely sure if this buffer really has to contain more
      * than the pure header (why not just write() the payload from *payload?),
      * but we leave it for now */
     char *buffer = smalloc(to_write);
     char *walk = buffer;
 
-    strncpy(buffer, I3_IPC_MAGIC, strlen(I3_IPC_MAGIC));
-    walk += strlen(I3_IPC_MAGIC);
+    strncpy(buffer, I3_IPC_MAGIC, I3_IPC_MAGIC_LEN);
+    walk += I3_IPC_MAGIC_LEN;
     memcpy(walk, &len, sizeof(uint32_t));
     walk += sizeof(uint32_t);
     memcpy(walk, &type, sizeof(uint32_t));

--- a/include/i3/ipc.h
+++ b/include/i3/ipc.h
@@ -27,6 +27,9 @@ typedef struct i3_ipc_header {
 /** Never change this, only on major IPC breakage (don’t do that) */
 #define I3_IPC_MAGIC "i3-ipc"
 
+/** Used not to have to always calculate the length of a const string  */
+#define I3_IPC_MAGIC_LEN (sizeof(I3_IPC_MAGIC) - 1)
+
 /** The payload of the message will be interpreted as a command */
 #define I3_IPC_MESSAGE_TYPE_COMMAND 0
 

--- a/libi3/ipc_recv_message.c
+++ b/libi3/ipc_recv_message.c
@@ -31,7 +31,7 @@
 int ipc_recv_message(int sockfd, uint32_t *message_type,
                      uint32_t *reply_length, uint8_t **reply) {
     /* Read the message header first */
-    const uint32_t to_read = strlen(I3_IPC_MAGIC) + sizeof(uint32_t) + sizeof(uint32_t);
+    const uint32_t to_read = I3_IPC_MAGIC_LEN + sizeof(uint32_t) + sizeof(uint32_t);
     char msg[to_read];
     char *walk = msg;
 
@@ -47,12 +47,12 @@ int ipc_recv_message(int sockfd, uint32_t *message_type,
         read_bytes += n;
     }
 
-    if (memcmp(walk, I3_IPC_MAGIC, strlen(I3_IPC_MAGIC)) != 0) {
+    if (memcmp(walk, I3_IPC_MAGIC, I3_IPC_MAGIC_LEN) != 0) {
         ELOG("IPC: invalid magic in reply\n");
         return -3;
     }
 
-    walk += strlen(I3_IPC_MAGIC);
+    walk += I3_IPC_MAGIC_LEN;
     memcpy(reply_length, walk, sizeof(uint32_t));
     walk += sizeof(uint32_t);
     if (message_type != NULL)


### PR DESCRIPTION
Removed all I3_IPC_MAGIC's calls to strlen.

I3_IPC_MAGIC is a constant string literal, so why not store the size
instead of even inside the same function calling strlen so many times?

Also, strlen loops through the string until it finds the NULL char,
but we know I3_IPC_MAGIC is a string literal, so calling sizeof, which
is calculated at compile time, saves a lot of loops.