### PR TITLE
Modify construction of config variables list to ensure they match by longest lexeme.

### DIFF
--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -879,9 +879,23 @@ bool parse_file(const char *f, bool use_nagbar) {
                 v_value++;
 
             struct Variable *new = scalloc(1, sizeof(struct Variable));
+            struct Variable *test = NULL, *loc = NULL;
             new->key = sstrdup(v_key);
             new->value = sstrdup(v_value);
-            SLIST_INSERT_HEAD(&variables, new, variables);
+            /* ensure that the correct variable is matched in case of one being
+             * the prefix of another */
+            SLIST_FOREACH(test, &variables, variables) {
+                if (strlen(new->key) >= strlen(test->key))
+                    break;
+                loc = test;
+            }
+
+            if (loc == NULL) {
+                SLIST_INSERT_HEAD(&variables, new, variables);
+            } else {
+                SLIST_INSERT_AFTER(loc, new, variables);
+            }
+
             DLOG("Got new variable %s = %s\n", v_key, v_value);
             continue;
         }

--- a/testcases/t/183-config-variables.t
+++ b/testcases/t/183-config-variables.t
@@ -79,6 +79,22 @@ EOT
 
 is(launch_get_border($config), 'none', 'no border');
 
+#####################################################################
+# test that longest matching variable name is substituted
+#####################################################################
+
+$config = <<'EOT';
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+set $var normal title
+set $vartest special title
+set $vart mundane title
+for_window [title="$vartest"] border none
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
 
 
 done_testing;


### PR DESCRIPTION
Does not change default behavior when two variable declarations use the exact same name.

fixes #2235