### PR TITLE
Update "mark" to "marks" in i3-save-tree.

### DIFF
--- a/i3-save-tree
+++ b/i3-save-tree
@@ -98,7 +98,7 @@ my %allowed_keys = map { ($_, 1) } qw(
     name
     geometry
     window_properties
-    mark
+    marks
     rect
 );
 


### PR DESCRIPTION
When allowing multiple marks on a container, we renamed the "mark"
field to "marks". This breaks i3-save-tree which will now filter out
the marks on a window because it doesn't match anymore. This commit
fixes that issue.

Thanks to /u/xenomachina for hinting to this issue.