### PR TITLE
i3-input: Proper position in non-standard cases.

### DIFF
--- a/i3-input/main.c
+++ b/i3-input/main.c
@@ -317,9 +317,30 @@ static int handle_key_press(void *ignored, xcb_connection_t *conn, xcb_key_press
 static xcb_rectangle_t get_window_position(void) {
     xcb_rectangle_t result = (xcb_rectangle_t){logical_px(50), logical_px(50), logical_px(500), font.height + logical_px(8)};
 
+    xcb_get_property_reply_t *supporting_wm_reply = NULL;
     xcb_get_input_focus_reply_t *input_focus = NULL;
     xcb_get_geometry_reply_t *geometry = NULL;
+    xcb_get_property_reply_t *wm_class = NULL;
     xcb_translate_coordinates_reply_t *coordinates = NULL;
+
+    xcb_atom_t A__NET_SUPPORTING_WM_CHECK;
+    xcb_intern_atom_cookie_t nswc_cookie = xcb_intern_atom(conn, 0, strlen("_NET_SUPPORTING_WM_CHECK"), "_NET_SUPPORTING_WM_CHECK");
+    xcb_intern_atom_reply_t *nswc_reply = xcb_intern_atom_reply(conn, nswc_cookie, NULL);
+    if (nswc_reply == NULL) {
+        ELOG("Could not intern atom _NET_SUPPORTING_WM_CHECK\n");
+        exit(-1);
+    }
+    A__NET_SUPPORTING_WM_CHECK = nswc_reply->atom;
+    free(nswc_reply);
+
+    supporting_wm_reply = xcb_get_property_reply(
+        conn, xcb_get_property(conn, false, root, A__NET_SUPPORTING_WM_CHECK, XCB_ATOM_WINDOW, 0, 32), NULL);
+    xcb_window_t *supporting_wm_win = NULL;
+    if (supporting_wm_reply == NULL || xcb_get_property_value_length(supporting_wm_reply) == 0) {
+        DLOG("Could not determine EWMH support window.\n");
+    } else {
+        supporting_wm_win = xcb_get_property_value(supporting_wm_reply);
+    }
 
     /* In rare cases, the window holding the input focus might disappear while we are figuring out its
      * position. To avoid this, we grab the server in the meantime. */
@@ -331,29 +352,47 @@ static xcb_rectangle_t get_window_position(void) {
         goto free_resources;
     }
 
+    /* We need to ignore the EWMH support window to which the focus can be set if there's no suitable window to focus. */
+    if (supporting_wm_win != NULL && input_focus->focus == *supporting_wm_win) {
+        DLOG("Input focus is on the EWMH support window, ignoring.\n");
+        goto free_resources;
+    }
+
     geometry = xcb_get_geometry_reply(conn, xcb_get_geometry(conn, input_focus->focus), NULL);
     if (geometry == NULL) {
         DLOG("Failed to received window geometry.\n");
         goto free_resources;
     }
 
-    coordinates = xcb_translate_coordinates_reply(
-        conn, xcb_translate_coordinates(conn, input_focus->focus, root, geometry->x, geometry->y), NULL);
-    if (coordinates == NULL) {
-        DLOG("Failed to translate coordinates.\n");
-        goto free_resources;
-    }
+    wm_class = xcb_get_property_reply(
+        conn, xcb_get_property(conn, false, input_focus->focus, XCB_ATOM_WM_CLASS, XCB_GET_PROPERTY_TYPE_ANY, 0, 32), NULL);
 
-    DLOG("Determined coordinates of window with input focus at x = %i / y = %i.\n", coordinates->dst_x, coordinates->dst_y);
-    result.x += coordinates->dst_x;
-    result.y += coordinates->dst_y;
+    /* We need to find out whether the input focus is on an i3 frame window. If it is, we must not translate the coordinates. */
+    if (wm_class == NULL || xcb_get_property_value_length(wm_class) == 0 || strcmp(xcb_get_property_value(wm_class), "i3-frame") != 0) {
+        coordinates = xcb_translate_coordinates_reply(
+            conn, xcb_translate_coordinates(conn, input_focus->focus, root, geometry->x, geometry->y), NULL);
+        if (coordinates == NULL) {
+            DLOG("Failed to translate coordinates.\n");
+            goto free_resources;
+        }
+
+        DLOG("Determined coordinates of window with input focus at x = %i / y = %i.\n", coordinates->dst_x, coordinates->dst_y);
+        result.x += coordinates->dst_x;
+        result.y += coordinates->dst_y;
+    } else {
+        DLOG("Determined coordinates of window with input focus at x = %i / y = %i.\n", geometry->x, geometry->y);
+        result.x += geometry->x;
+        result.y += geometry->y;
+    }
 
 free_resources:
     xcb_ungrab_server(conn);
     xcb_flush(conn);
 
+    FREE(supporting_wm_reply);
     FREE(input_focus);
     FREE(geometry);
+    FREE(wm_class);
     FREE(coordinates);
     return result;
 }


### PR DESCRIPTION
This commit fixes two issues:
* We detect the EWMH support window from the root window. If this window
  currently has the input focus, we ignore this. We do this because this
  window is not a window the user is aware of and positioning relative to
  it makes no sense.
* We also detect whether the current input focus is in an i3-frame window.
  This can happen, e.g., when selecting a parent (split) container. Since
  frame windows are direct children of the root window, we must not
  translate its coordinates or we get weird results and i3-input ends up
  off-screen (see #2312). For all other windows, including those without
  any WM_CLASS, we proceed as before.

fixes #2312