### PR TITLE
i3bar: accept "primary" for output config option

### DIFF
--- a/i3bar/src/outputs.c
+++ b/i3bar/src/outputs.c
@@ -189,11 +189,11 @@ static int outputs_end_map_cb(void *params_) {
     if (config.num_outputs > 0) {
         bool handle_output = false;
         for (int c = 0; c < config.num_outputs; c++) {
-            if (strcasecmp(params->outputs_walk->name, config.outputs[c]) != 0)
-                continue;
-
-            handle_output = true;
-            break;
+            if (strcasecmp(params->outputs_walk->name, config.outputs[c]) == 0 ||
+                (params->outputs_walk->primary && strcasecmp(config.outputs[c], "primary") == 0)) {
+                handle_output = true;
+                break;
+            }
         }
         if (!handle_output) {
             DLOG("Ignoring output \"%s\", not configured to handle it.\n",


### PR DESCRIPTION
If "primary" is given in a bar block `output` directive and there is a
primary output configured, handle that output.

fixes #2311
