### PR TITLE
Properly close disabled outputs restored during a restart.

### DIFF
--- a/include/randr.h
+++ b/include/randr.h
@@ -61,6 +61,12 @@ void init_ws_for_output(Output *output, Con *content);
 void randr_query_outputs(void);
 
 /**
+ * Disables the output and moves its content.
+ *
+ */
+void randr_disable_output(Output *output);
+
+/**
  * Returns the first output which is active.
  *
  */


### PR DESCRIPTION
If an output is disabled during a restart, for example because a binding
such as

    bindsym $mod+Shift+r exec "xrandr --auto", restart

is used, it can happen that we first write the layout to disk and only
then receive the RandR change events. This leads to a situation where
the restored tree will contain these outputs, but the restarted i3
process will not receive the RandR events, thus the internal output in i3
is marked disabled.

This patch finds these cases after a restart and force-disables the
affected outputs.

fixes #2326