### PR TITLE
do not match docks in config and command criteria

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -480,7 +480,7 @@ void dump_node(yajl_gen gen, struct Con *con, bool inplace_restart) {
         if (match->restart_mode)
             continue;
         y(map_open);
-        if (match->dock != -1) {
+        if (match->dock != M_DONTCHECK) {
             ystr("dock");
             y(integer, match->dock);
             ystr("insert_where");

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -48,6 +48,7 @@ static int json_start_map(void *ctx) {
         LOG("creating new swallow\n");
         current_swallow = smalloc(sizeof(Match));
         match_init(current_swallow);
+        current_swallow->dock = M_DONTCHECK;
         TAILQ_INSERT_TAIL(&(json_node->swallow_head), current_swallow, matches);
         swallow_is_empty = true;
     } else {

--- a/src/match.c
+++ b/src/match.c
@@ -27,7 +27,6 @@
  */
 void match_init(Match *match) {
     memset(match, 0, sizeof(Match));
-    match->dock = M_DONTCHECK;
     match->urgent = U_DONTCHECK;
     /* we use this as the placeholder value for "not set". */
     match->window_type = UINT32_MAX;
@@ -53,7 +52,7 @@ bool match_is_empty(Match *match) {
             match->id == XCB_NONE &&
             match->window_type == UINT32_MAX &&
             match->con_id == NULL &&
-            match->dock == -1 &&
+            match->dock == M_NODOCK &&
             match->floating == M_ANY);
 }
 

--- a/src/restore_layout.c
+++ b/src/restore_layout.c
@@ -240,6 +240,7 @@ static void open_placeholder_window(Con *con) {
         /* create temporary id swallow to match the placeholder */
         Match *temp_id = smalloc(sizeof(Match));
         match_init(temp_id);
+        temp_id->dock = M_DONTCHECK;
         temp_id->id = placeholder;
         TAILQ_INSERT_HEAD(&(con->swallow_head), temp_id, matches);
     }

--- a/testcases/t/264-dock-criteria.t
+++ b/testcases/t/264-dock-criteria.t
@@ -1,0 +1,71 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Verifies that command or config criteria does not match dock clients
+# Bug still in: 4.12-38-ge690e3d
+use i3test i3_autostart => 0;
+
+my $config = <<EOT;
+# i3 config file (v4)
+for_window [class="dock"] move workspace current
+EOT
+
+my $pid = launch_with_config($config);
+
+my $ws = fresh_workspace();
+
+
+## command criteria should not match dock windows
+open_window({
+    window_type => $x->atom(name => '_NET_WM_WINDOW_TYPE_DOCK'),
+    wm_class => "x"
+});
+
+is(get_dock_clients, 1, "created one docked client");
+is_num_children($ws, 0, 'no container on the current workspace');
+
+cmd '[class="^x$"] move workspace current';
+
+does_i3_live
+is(get_dock_clients, 1, "one docked client after move");
+is_num_children($ws, 0, 'no container on the current workspace');
+
+cmd '[class="^x$"] fullscreen';
+
+does_i3_live
+is(get_dock_clients, 1, "one docked client after fullscreen");
+is_num_children($ws, 0, 'no container on the current workspace');
+
+cmd '[class="^x$"] kill';
+
+does_i3_live
+is(get_dock_clients, 1, "one docked client after kill");
+is_num_children($ws, 0, 'no container on the current workspace');
+
+
+## config criteria should not match dock windows
+open_window({
+    window_type => $x->atom(name => '_NET_WM_WINDOW_TYPE_DOCK'),
+    wm_class => "dock"
+});
+
+does_i3_live
+is(get_dock_clients, 2, "created second docked client");
+is_num_children($ws, 0, 'no container on the current workspace');
+
+
+exit_gracefully($pid);
+done_testing;


### PR DESCRIPTION
When currently matching windows with criteria in the config or in a command, the dock clients are also matched. For example, running `i3-msg [class="i3bar"] fullscreen` crashes i3 and `i3-msg [class=".*"] move workspace current` moves all windows including the i3bar windows as normal containers to the current workspace.

This seems wrong, as I cannot focus dock clients and therefore do not see a reason why criteria should match them to issue commands on them. So, I have changed the match struct to not match dock clients for command and config criteria. The matching for loading and restoring layout is left unchanged, as I was not sure whether it should apply here, too.