### PR TITLE
Don't trigger binding on window border click unless --border is given.

### DIFF
--- a/src/click.c
+++ b/src/click.c
@@ -187,11 +187,10 @@ static int route_click(Con *con, xcb_button_press_event_t *event, const bool mod
      * default behavior. */
     if (dest == CLICK_DECORATION || dest == CLICK_INSIDE || dest == CLICK_BORDER) {
         Binding *bind = get_binding_from_xcb_event((xcb_generic_event_t *)event);
-        /* clicks over a window decoration will always trigger the binding and
-         * clicks on the inside of the window will only trigger a binding if
-         * the --whole-window flag was given for the binding. */
-        if (bind && ((dest == CLICK_DECORATION || bind->whole_window) ||
-                     (dest == CLICK_BORDER && bind->border))) {
+
+        if (bind != NULL && (dest == CLICK_DECORATION ||
+                             (dest == CLICK_INSIDE && bind->whole_window) ||
+                             (dest == CLICK_BORDER && bind->border))) {
             CommandResult *result = run_binding(bind, con);
 
             /* ASYNC_POINTER eats the event */


### PR DESCRIPTION
Prior to this commit a binding specifying only --whole-window would
trigger even when clicking on the window border. However, this should
only happen if --border is specified.

fixes #2348