### PR TITLE
Fix building and testing on OpenBSD

### DIFF
--- a/i3-dump-log/main.c
+++ b/i3-dump-log/main.c
@@ -28,8 +28,10 @@
 #include "shmlog.h"
 #include <i3/ipc.h>
 
-static uint32_t offset_next_write,
-    wrap_count;
+#if !defined(__OpenBSD__)
+static uint32_t offset_next_write;
+#endif
+static uint32_t wrap_count;
 
 static i3_shmlog_header *header;
 static char *logbuffer,
@@ -57,17 +59,26 @@ static void print_till_end(void) {
 
 int main(int argc, char *argv[]) {
     int o, option_index = 0;
-    bool verbose = false,
-         follow = false;
+    bool verbose = false;
+#if !defined(__OpenBSD__)
+    bool follow = false;
+#endif
 
     static struct option long_options[] = {
         {"version", no_argument, 0, 'v'},
         {"verbose", no_argument, 0, 'V'},
+#if !defined(__OpenBSD__)
         {"follow", no_argument, 0, 'f'},
+#endif
         {"help", no_argument, 0, 'h'},
-        {0, 0, 0, 0}};
+        {0, 0, 0, 0}
+    };
 
+#if !defined(__OpenBSD__)
     char *options_string = "s:vfVh";
+#else
+    char *options_string = "vVh";
+#endif
 
     while ((o = getopt_long(argc, argv, options_string, long_options, &option_index)) != -1) {
         if (o == 'v') {
@@ -75,11 +86,17 @@ int main(int argc, char *argv[]) {
             return 0;
         } else if (o == 'V') {
             verbose = true;
+#if !defined(__OpenBSD__)
         } else if (o == 'f') {
             follow = true;
+#endif
         } else if (o == 'h') {
             printf("i3-dump-log " I3_VERSION "\n");
-            printf("i3-dump-log [-f] [-s <socket>]\n");
+#if !defined(__OpenBSD__)
+            printf("i3-dump-log [-fhVv]\n");
+#else
+            printf("i3-dump-log [-hVv]\n");
+#endif
             return 0;
         }
     }
@@ -162,6 +179,7 @@ int main(int argc, char *argv[]) {
     walk = logbuffer + sizeof(i3_shmlog_header);
     print_till_end();
 
+#if !defined(__OpenBSD__)
     if (follow) {
         /* Since pthread_cond_wait() expects a mutex, we need to provide one.
          * To not lock i3 (that’s bad, mhkay?) we just define one outside of
@@ -177,6 +195,7 @@ int main(int argc, char *argv[]) {
             }
         }
     }
+#endif
 
     return 0;
 }

--- a/include/shmlog.h
+++ b/include/shmlog.h
@@ -11,7 +11,9 @@
 #pragma once
 
 #include <stdint.h>
+#if !defined(__OpenBSD__)
 #include <pthread.h>
+#endif
 
 /* Default shmlog size if not set by user. */
 extern const int default_shmlog_size;
@@ -37,8 +39,10 @@ typedef struct i3_shmlog_header {
      * and don’t matter — clients use an equality check (==). */
     uint32_t wrap_count;
 
+#if !defined(__OpenBSD__)
     /* pthread condvar which will be broadcasted whenever there is a new
      * message in the log. i3-dump-log uses this to implement -f (follow, like
      * tail -f) in an efficient way. */
     pthread_cond_t condvar;
+#endif
 } i3_shmlog_header;

--- a/src/i3.mk
+++ b/src/i3.mk
@@ -6,7 +6,10 @@ i3_SOURCES           := $(filter-out $(i3_SOURCES_GENERATED),$(wildcard src/*.c)
 i3_HEADERS_CMDPARSER := $(wildcard include/GENERATED_*.h)
 i3_HEADERS           := $(filter-out $(i3_HEADERS_CMDPARSER),$(wildcard include/*.h))
 i3_CFLAGS             = $(XKB_COMMON_CFLAGS) $(XKB_COMMON_X11_CFLAGS) $(XCB_CFLAGS) $(XCB_KBD_CFLAGS) $(XCB_WM_CFLAGS) $(XCB_CURSOR_CFLAGS) $(XCB_XRM_CFLAGS) $(PANGO_CFLAGS) $(YAJL_CFLAGS) $(LIBEV_CFLAGS) $(PCRE_CFLAGS) $(LIBSN_CFLAGS)
-i3_LIBS               = $(XKB_COMMON_LIBS) $(XKB_COMMON_X11_LIBS) $(XCB_LIBS) $(XCB_XKB_LIBS) $(XCB_KBD_LIBS) $(XCB_WM_LIBS) $(XCB_CURSOR_LIBS) $(XCB_XRM_LIBS) $(PANGO_LIBS) $(YAJL_LIBS) $(LIBEV_LIBS) $(PCRE_LIBS) $(LIBSN_LIBS) -lm -lpthread
+i3_LIBS               = $(XKB_COMMON_LIBS) $(XKB_COMMON_X11_LIBS) $(XCB_LIBS) $(XCB_XKB_LIBS) $(XCB_KBD_LIBS) $(XCB_WM_LIBS) $(XCB_CURSOR_LIBS) $(XCB_XRM_LIBS) $(PANGO_LIBS) $(YAJL_LIBS) $(LIBEV_LIBS) $(PCRE_LIBS) $(LIBSN_LIBS) -lm
+ifneq ($(UNAME),OpenBSD)
+i3_LIBS               += -lpthread
+endif
 
 # When using clang, we use pre-compiled headers to speed up the build. With
 # gcc, this actually makes the build slower.

--- a/src/log.c
+++ b/src/log.c
@@ -20,7 +20,9 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <errno.h>
+#if !defined(__OpenBSD__)
 #include <pthread.h>
+#endif
 
 #include "util.h"
 #include "log.h"
@@ -157,11 +159,13 @@ void open_logbuffer(void) {
 
     header = (i3_shmlog_header *)logbuffer;
 
+#if !defined(__OpenBSD__)
     pthread_condattr_t cond_attr;
     pthread_condattr_init(&cond_attr);
     if (pthread_condattr_setpshared(&cond_attr, PTHREAD_PROCESS_SHARED) != 0)
         fprintf(stderr, "pthread_condattr_setpshared() failed, i3-dump-log -f will not work!\n");
     pthread_cond_init(&(header->condvar), &cond_attr);
+#endif
 
     logwalk = logbuffer + sizeof(i3_shmlog_header);
     loglastwrap = logbuffer + logbuffer_size;
@@ -277,8 +281,10 @@ static void vlog(const bool print, const char *fmt, va_list args) {
 
         store_log_markers();
 
+#if !defined(__OpenBSD__)
         /* Wake up all (i3-dump-log) processes waiting for condvar. */
         pthread_cond_broadcast(&(header->condvar));
+#endif
 
         if (print)
             fwrite(message, len, 1, stdout);

--- a/src/sd-daemon.c
+++ b/src/sd-daemon.c
@@ -45,9 +45,6 @@
 #include "sd-daemon.h"
 
 int sd_listen_fds(int unset_environment) {
-#if defined(DISABLE_SYSTEMD) || !defined(__linux__)
-    return 0;
-#else
     int r, fd;
     const char *e;
     char *p = NULL;
@@ -121,7 +118,6 @@ finish:
     }
 
     return r;
-#endif
 }
 
 int sd_is_fifo(int fd, const char *path) {

--- a/src/startup.c
+++ b/src/startup.c
@@ -103,8 +103,8 @@ static int _prune_startup_sequences(void) {
  */
 void startup_sequence_delete(struct Startup_Sequence *sequence) {
     assert(sequence != NULL);
-    DLOG("Deleting startup sequence %s, delete_at = %ld, current_time = %ld\n",
-         sequence->id, sequence->delete_at, time(NULL));
+    DLOG("Deleting startup sequence %s, delete_at = %lld, current_time = %lld\n",
+         sequence->id, (long long)sequence->delete_at, (long long)time(NULL));
 
     /* Unref the context, will be free()d */
     sn_launcher_context_unref(sequence->context);
@@ -239,8 +239,8 @@ void startup_monitor_event(SnMonitorEvent *event, void *userdata) {
             /* Mark the given sequence for deletion in 30 seconds. */
             time_t current_time = time(NULL);
             sequence->delete_at = current_time + 30;
-            DLOG("Will delete startup sequence %s at timestamp %ld\n",
-                 sequence->id, sequence->delete_at);
+            DLOG("Will delete startup sequence %s at timestamp %lld\n",
+                 sequence->id, (long long)sequence->delete_at);
 
             if (_prune_startup_sequences() == 0) {
                 DLOG("No more startup sequences running, changing root window cursor to default pointer.\n");

--- a/testcases/lib/StartXServer.pm
+++ b/testcases/lib/StartXServer.pm
@@ -69,15 +69,6 @@ sub start_xserver {
     my @displays = ();
     my @childpids = ();
 
-    $SIG{CHLD} = sub {
-        my $child = waitpid -1, POSIX::WNOHANG;
-        @pids = grep { $_ != $child } @pids;
-        return unless @pids == 0;
-        print STDERR "All X server processes died.\n";
-        print STDERR "Use ./complete-run.pl --parallel 1 --keep-xserver-output\n";
-        exit 1;
-    };
-
     # Yeah, I know it’s non-standard, but Perl’s POSIX module doesn’t have
     # _SC_NPROCESSORS_CONF.
     my $num_cores;
@@ -100,6 +91,15 @@ sub start_xserver {
     $displaynum++;
 
     say "Starting $parallel Xephyr instances, starting at :$displaynum...";
+
+    $SIG{CHLD} = sub {
+        my $child = waitpid -1, POSIX::WNOHANG;
+        @pids = grep { $_ != $child } @pids;
+        return unless @pids == 0;
+        print STDERR "All X server processes died.\n";
+        print STDERR "Use ./complete-run.pl --parallel 1 --keep-xserver-output\n";
+        exit 1;
+    };
 
     my @sockets_waiting;
     for (1 .. $parallel) {

--- a/testcases/t/180-fd-leaks.t
+++ b/testcases/t/180-fd-leaks.t
@@ -20,6 +20,9 @@ use i3test;
 use POSIX qw(mkfifo);
 use File::Temp qw(:POSIX tempfile);
 
+SKIP: {
+skip "Procfs not available on $^O", 1 if $^O eq 'openbsd';
+
 my $i3 = i3(get_socket_path());
 
 my $tmp = tmpnam();
@@ -58,5 +61,7 @@ for my $fd (keys %fds) {
 }
 
 is(scalar keys %fds, 0, 'No file descriptors leaked');
+
+}
 
 done_testing;


### PR DESCRIPTION
Those changes allow building on OpenBSD whose `pthread` implementation in not feature complete.
in `sd-daemon.c` there is this `!defined(__linux__)` check. I couldn't find any Linuxism in the following code and it builds just fine on OpenBSD. Maybe remove the check altogether instead of just checking for OpenBSD?