### PR TITLE
adding custom container names (for composite and window containers)

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -295,6 +295,12 @@ void cmd_scratchpad_show(I3_CMD);
 void cmd_title_format(I3_CMD, const char *format);
 
 /**
+ * Implementation of 'rename window <name>'
+ *
+ */
+void cmd_rename_window(I3_CMD, const char *name);
+
+/**
  * Implementation of 'rename workspace <name> to <name>'
  *
  */

--- a/include/con.h
+++ b/include/con.h
@@ -449,6 +449,12 @@ void con_set_urgency(Con *con, bool urgent);
 char *con_get_tree_representation(Con *con);
 
 /**
+ * Returns the container title.
+ *
+ */
+char *con_get_title(Con *con);
+
+/**
  * force parent split containers to be redrawn
  *
  */

--- a/include/data.h
+++ b/include/data.h
@@ -594,6 +594,7 @@ struct Con {
     struct Rect geometry;
 
     char *name;
+    char *custom_name;
 
     /** The format with which the window's name should be displayed. */
     char *title_format;

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -128,7 +128,7 @@ state WORKSPACE:
       -> call cmd_workspace_back_and_forth()
   'number'
       -> WORKSPACE_NUMBER
-  workspace = string 
+  workspace = string
       -> call cmd_workspace_name($workspace, $no_auto_back_and_forth)
 
 state WORKSPACE_NUMBER:
@@ -272,11 +272,13 @@ state RENAME:
       -> RENAME_WORKSPACE
   'window'
       -> RENAME_WINDOW
+
 state RENAME_WINDOW:
   end
       -> call cmd_rename_window(NULL)
   name = string
       -> call cmd_rename_window($name)
+
 state RENAME_WORKSPACE:
   old_name = 'to'
       -> RENAME_WORKSPACE_LIKELY_TO

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -264,12 +264,19 @@ state RESIZE_HEIGHT:
   'px', end
       -> call cmd_resize_set(&width, &height)
 
+# rename window <name>
 # rename workspace <name> to <name>
 # rename workspace to <name>
 state RENAME:
   'workspace'
       -> RENAME_WORKSPACE
-
+  'window'
+      -> RENAME_WINDOW
+state RENAME_WINDOW:
+  end
+      -> call cmd_rename_window(NULL)
+  name = string
+      -> call cmd_rename_window($name)
 state RENAME_WORKSPACE:
   old_name = 'to'
       -> RENAME_WORKSPACE_LIKELY_TO

--- a/src/commands.c
+++ b/src/commands.c
@@ -1875,6 +1875,23 @@ void cmd_title_format(I3_CMD, const char *format) {
 }
 
 /*
+ * Implementation of 'rename window <name>'
+ *
+ */
+void cmd_rename_window(I3_CMD, const char *newname) {
+    owindow *current;
+    HANDLE_EMPTY_MATCH;
+    TAILQ_FOREACH(current, &owindows, owindows) {
+        DLOG("matching: %p / %s\n", current->con, current->con->name);
+        LOG("Renaming container con = %p\n", current->con);
+        current->con->custom_name = sstrdup(newname);
+        FREE(current->con->deco_render_params);
+    }
+    cmd_output->needs_tree_render = true;
+    ysuccess(true);
+}
+
+/*
  * Implementation of 'rename workspace [<name>] to <name>'
  *
  */

--- a/src/commands.c
+++ b/src/commands.c
@@ -1884,10 +1884,14 @@ void cmd_rename_window(I3_CMD, const char *newname) {
     TAILQ_FOREACH(current, &owindows, owindows) {
         DLOG("matching: %p / %s\n", current->con, current->con->name);
         LOG("Renaming container con = %p\n", current->con);
-        current->con->custom_name = sstrdup(newname);
-        FREE(current->con->deco_render_params);
+        if (newname == NULL) {
+            current->con->custom_name = NULL;
+        } else {
+            current->con->custom_name = sstrdup(newname);
+            FREE(current->con->deco_render_params);
+            cmd_output->needs_tree_render = true;
+        }
     }
-    cmd_output->needs_tree_render = true;
     ysuccess(true);
 }
 

--- a/src/con.c
+++ b/src/con.c
@@ -2007,6 +2007,18 @@ void con_set_urgency(Con *con, bool urgent) {
  * Create a string representing the subtree under con.
  *
  */
+char *con_get_title(Con *con) {
+    LOG("Called con_get_title()");
+    if (con->custom_name != NULL) {
+      return sstrdup(con->custom_name);
+    } else {
+      return con_get_tree_representation(con);
+    }
+}
+/*
+ * Create a string representing the subtree under con.
+ *
+ */
 char *con_get_tree_representation(Con *con) {
     /* this code works as follows:
      *  1) create a string with the layout type (D/V/H/T/S) and an opening bracket
@@ -2048,7 +2060,7 @@ char *con_get_tree_representation(Con *con) {
     /* 2) append representation of children */
     Con *child;
     TAILQ_FOREACH(child, &(con->nodes_head), nodes) {
-        char *child_txt = con_get_tree_representation(child);
+        char *child_txt = con_get_title(child);
 
         char *tmp_buf;
         sasprintf(&tmp_buf, "%s%s%s", buf,
@@ -2083,11 +2095,11 @@ i3String *con_parse_title_format(Con *con) {
     char *class;
     char *instance;
     if (win == NULL) {
-        title = pango_escape_markup(con_get_tree_representation(con));
+        title = pango_escape_markup(con_get_title(con));
         class = sstrdup("i3-frame");
         instance = sstrdup("i3-frame");
     } else {
-        title = pango_escape_markup(sstrdup((win->name == NULL) ? "" : i3string_as_utf8(win->name)));
+        title = pango_escape_markup(sstrdup((con->custom_name != NULL) ? con->custom_name : (win->name == NULL) ? "" : i3string_as_utf8(win->name)));
         class = pango_escape_markup(sstrdup((win->class_class == NULL) ? "" : win->class_class));
         instance = pango_escape_markup(sstrdup((win->class_instance == NULL) ? "" : win->class_instance));
     }

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -376,6 +376,11 @@ void dump_node(yajl_gen gen, struct Con *con, bool inplace_restart) {
     else
         y(null);
 
+    if (con->custom_name != NULL) {
+        ystr("custom_name");
+        ystr(con->custom_name);
+    }
+
     if (con->title_format != NULL) {
         ystr("title_format");
         ystr(con->title_format);

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -57,12 +57,14 @@ static int json_start_map(void *ctx) {
                 Con *ws = con_get_workspace(json_node);
                 json_node = con_new_skeleton(NULL, NULL);
                 json_node->name = NULL;
+                json_node->custom_name = NULL;
                 json_node->parent = ws;
                 DLOG("Parent is workspace = %p\n", ws);
             } else {
                 Con *parent = json_node;
                 json_node = con_new_skeleton(NULL, NULL);
                 json_node->name = NULL;
+                json_node->custom_name = NULL;
                 json_node->parent = parent;
             }
         }
@@ -265,6 +267,9 @@ static int json_string(void *ctx, const unsigned char *val, size_t len) {
         if (strcasecmp(last_key, "name") == 0) {
             json_node->name = scalloc(len + 1, 1);
             memcpy(json_node->name, val, len);
+        } else if (strcasecmp(last_key, "custom_name") == 0) {
+            json_node->custom_name = scalloc(len + 1, 1);
+            memcpy(json_node->custom_name, val, len);
         } else if (strcasecmp(last_key, "title_format") == 0) {
             json_node->title_format = scalloc(len + 1, 1);
             memcpy(json_node->title_format, val, len);

--- a/src/restore_layout.c
+++ b/src/restore_layout.c
@@ -219,11 +219,18 @@ static void open_placeholder_window(Con *con) {
         /* Set the same name as was stored in the layout file. While perhaps
          * slightly confusing in the first instant, this brings additional
          * clarity to which placeholder is waiting for which actual window. */
-        if (con->name != NULL)
+        if (con->custom_name != NULL) {
             xcb_change_property(restore_conn, XCB_PROP_MODE_REPLACE, placeholder,
-                                A__NET_WM_NAME, A_UTF8_STRING, 8, strlen(con->name), con->name);
-        DLOG("Created placeholder window 0x%08x for leaf container %p / %s\n",
-             placeholder, con, con->name);
+                          A__NET_WM_NAME, A_UTF8_STRING, 8, strlen(con->custom_name), con->custom_name);
+            DLOG("Created placeholder window 0x%08x for leaf container %p / %s\n",
+                               placeholder, con, con->custom_name);
+        } else if (con->name != NULL) {
+            xcb_change_property(restore_conn, XCB_PROP_MODE_REPLACE, placeholder,
+                          A__NET_WM_NAME, A_UTF8_STRING, 8, strlen(con->name), con->name);
+            DLOG("Created placeholder window 0x%08x for leaf container %p / %s\n",
+                               placeholder, con, con->name);
+        }
+
 
         placeholder_state *state = scalloc(1, sizeof(placeholder_state));
         state->window = placeholder;

--- a/src/x.c
+++ b/src/x.c
@@ -533,6 +533,18 @@ void x_draw_decoration(Con *con) {
     /* 6: draw the title */
     int text_offset_y = (con->deco_rect.height - config.font.height) / 2;
 
+    if (con->custom_name != NULL) {
+        i3String *title = i3string_from_utf8(con->custom_name);
+        draw_util_text(title, &(parent->frame_buffer),
+                       p->color->text, p->color->background,
+                       con->deco_rect.x + logical_px(2),
+                       con->deco_rect.y + text_offset_y,
+                       con->deco_rect.width - 2 * logical_px(2));
+        I3STRING_FREE(title);
+
+        goto after_title;
+    }
+
     struct Window *win = con->window;
     if (win == NULL) {
         i3String *title;


### PR DESCRIPTION
This should help with issue #860
It adds an additional attribute 'custom_name' to the Con struct and adjusts the rename command to allow setting and unsetting it for the currently selected container. (rename window[ \<name\>])
If a custom name is set it will be displayed in places where the container is represented somehow.
Custom names also get saved in JSON with the rest of the container and so will survive in place restarting of i3.

I chose to add an additional attribute instead of using the 'name' attribute because this allows to still display the class instance in the tree representation when no custom name has been set.
A prior attempt at using the 'name' attribute ended in the tree representation getting littered with window names. The container name seems to get set when the window changes its name.

I'd be happy to adjust this patch if needed.