### PR TITLE
Move cleanup code into atexit funtion (`src/main.c:i3_exit`).

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1565,12 +1565,6 @@ void cmd_layout_toggle(I3_CMD, const char *toggle_mode) {
  */
 void cmd_exit(I3_CMD) {
     LOG("Exiting due to user command.\n");
-#ifdef I3_ASAN_ENABLED
-    __lsan_do_leak_check();
-#endif
-    ipc_shutdown();
-    unlink(config.ipc_socket_path);
-    xcb_disconnect(conn);
     exit(0);
 
     /* unreached */

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,10 @@
 
 #include "sd-daemon.h"
 
+#ifdef I3_ASAN_ENABLED
+#include <sanitizer/lsan_interface.h>
+#endif
+
 /* The original value of RLIMIT_CORE when i3 was started. We need to restore
  * this before starting any other process, since we set RLIMIT_CORE to
  * RLIM_INFINITY for i3 debugging versions. */

--- a/src/main.c
+++ b/src/main.c
@@ -166,6 +166,13 @@ static void i3_exit(void) {
     ev_loop_destroy(main_loop);
 #endif
 
+#ifdef I3_ASAN_ENABLED
+    __lsan_do_leak_check();
+#endif
+    ipc_shutdown();
+    unlink(config.ipc_socket_path);
+    xcb_disconnect(conn);
+
     if (*shmlogname != '\0') {
         fprintf(stderr, "Closing SHM log \"%s\"\n", shmlogname);
         fflush(stderr);


### PR DESCRIPTION
* Cleanup should happen on all exits, not only on `i3-msg exit`.
  * e.g. I normally call `poweroff` in a running i3 -> i3 is killed by a signal -> ipc_socket is not unlinked.
* As this only moves some code from a function which calls `exit(0)` into
a function called from `atexit` this should work (NOT TESTED).