### PR TITLE
Fix colormap handling for containers.

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -699,4 +699,7 @@ struct Con {
 
     /* Depth of the container window */
     uint16_t depth;
+
+    /* The colormap for this con if a custom one is used. */
+    xcb_colormap_t colormap;
 };


### PR DESCRIPTION
This commit correctly handles colormaps by

* Using the static default colormap we determine on startup if the
  con has the corresponding depth. This avoids creating pointless
  colormaps.
* Not freeing the default colormap to not have stray colormaps on
  containers. This fixes an issue with certain programs such as xwd.
* Creating a custom colormap when necessary and freeing it when the
  container is killed.

fixes #2435