### PR TITLE
travis/cleanup-bintray: use dpkg --compare-versions

### DIFF
--- a/travis/cleanup-bintray.pl
+++ b/travis/cleanup-bintray.pl
@@ -25,7 +25,9 @@ my $client = HTTP::Tiny->new(
 my $resp = $client->get($apiurl);
 die "Getting versions failed: HTTP status $resp->{status} (content: $resp->{content})" unless $resp->{success};
 my $decoded = decode_json($resp->{content});
-my @versions = reverse sort @{$decoded->{versions}};
+my @versions = reverse sort {
+    (system("/usr/bin/dpkg", "--compare-versions", "$a", "gt", "$b") == 0) ? 1 : -1
+} @{$decoded->{versions}};
 
 # Keep the most recent 5 versions.
 splice(@versions, 0, 5);


### PR DESCRIPTION
…instead of lexicographically sorting strings, which fails for the
following situation:

    4.12-96-g086276b
    4.12-97-g59c070b
    4.12-108-gb850cfb

This bug resulted in new packages being built and uploaded, then
immediately deleted.

Thanks to eeemsi for reporting the issue.