### PR TITLE
Handle _NET_ACTIVE_WINDOW for scratchpad windows.

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -716,14 +716,13 @@ static void handle_client_message(xcb_client_message_event_t *event) {
         }
 
         Con *ws = con_get_workspace(con);
-
         if (ws == NULL) {
             DLOG("Window is not being managed, ignoring _NET_ACTIVE_WINDOW\n");
             return;
         }
 
-        if (con_is_internal(ws)) {
-            DLOG("Workspace is internal, ignoring _NET_ACTIVE_WINDOW\n");
+        if (con_is_internal(ws) && ws != workspace_get("__i3_scratch", NULL)) {
+            DLOG("Workspace is internal but not scratchpad, ignoring _NET_ACTIVE_WINDOW\n");
             return;
         }
 
@@ -732,10 +731,19 @@ static void handle_client_message(xcb_client_message_event_t *event) {
             /* Always focus the con if it is from a pager, because this is most
              * likely from some user action */
             DLOG("This request came from a pager. Focusing con = %p\n", con);
-            workspace_show(ws);
-            con_focus(con);
+
+            if (con_is_internal(ws)) {
+                scratchpad_show(con);
+            } else {
+                workspace_show(ws);
+                con_focus(con);
+            }
         } else {
             /* Request is from an application. */
+            if (con_is_internal(ws)) {
+                DLOG("Ignoring request to make con = %p active because it's on an internal workspace.\n", con);
+                return;
+            }
 
             if (config.focus_on_window_activation == FOWA_FOCUS || (config.focus_on_window_activation == FOWA_SMART && workspace_is_visible(ws))) {
                 DLOG("Focusing con = %p\n", con);

--- a/testcases/t/195-net-active-window.t
+++ b/testcases/t/195-net-active-window.t
@@ -39,6 +39,7 @@ sub send_net_active_window {
         0;
 
     $x->send_event(0, $x->get_root_window(), X11::XCB::EVENT_MASK_SUBSTRUCTURE_REDIRECT, $msg);
+    sync_with_i3;
 }
 
 sub get_net_active_window {
@@ -130,6 +131,23 @@ is($x->input_focus, $win3->id, 'focus reverted to window 3');
 send_net_active_window($scratch->id);
 
 is($x->input_focus, $win3->id, 'window 3 still focused');
+
+################################################################################
+# A scratchpad window should be shown if _NET_ACTIVE_WINDOW from a pager
+# is received.
+################################################################################
+
+my $scratch = open_window;
+
+is($x->input_focus, $scratch->id, 'to-scratchpad window has focus');
+
+cmd 'move scratchpad';
+
+is($x->input_focus, $win3->id, 'focus reverted to window 3');
+
+send_net_active_window($scratch->id, 'pager');
+
+is($x->input_focus, $scratch->id, 'scratchpad window is shown');
 
 ################################################################################
 # Verify that the _NET_ACTIVE_WINDOW property is updated on the root window


### PR DESCRIPTION
We call scratchpad_show() on _NET_ACTIVE_WINDOW requests if the request
came from a pager. This is consistent with the i3 »focus« command because
we assume the user requested to see the window, so we do the only
sensible thing.

fixes #2455
