### PR TITLE
travis: build ubuntu packages for xenial, not wily

### DIFF
--- a/travis/bintray-autobuild-ubuntu.json
+++ b/travis/bintray-autobuild-ubuntu.json
@@ -15,7 +15,7 @@
         {
             "includePattern": "deb/ubuntu-amd64/(.*\\.deb)$",
 	    "matrixParams": {
-                "deb_distribution": "wily",
+                "deb_distribution": "xenial",
                 "deb_component": "main",
                 "deb_architecture": "amd64"
 	    },
@@ -24,7 +24,7 @@
         {
             "includePattern": "deb/ubuntu-i386/(.*\\.deb)$",
 	    "matrixParams": {
-                "deb_distribution": "wily",
+                "deb_distribution": "xenial",
                 "deb_component": "main",
                 "deb_architecture": "i386"
 	    },

--- a/travis/travis-base-ubuntu-386.Dockerfile
+++ b/travis/travis-base-ubuntu-386.Dockerfile
@@ -1,7 +1,7 @@
 # vim:ft=Dockerfile
 # Same as travis-base.Dockerfile, but without the test suite dependencies since
 # we only build Debian packages on Ubuntu i386, we don’t run the tests.
-FROM i386/ubuntu:wily
+FROM i386/ubuntu:xenial
 
 RUN echo force-unsafe-io > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup
 # Paper over occasional network flakiness of some mirrors.
@@ -24,9 +24,10 @@ RUN linux32 apt-get update && \
 
 # Install i3 build dependencies.
 COPY debian/control /usr/src/i3-debian-packaging/control
-RUN echo 'deb http://dl.bintray.com/i3/i3-autobuild-ubuntu wily main' > /etc/apt/sources.list.d/i3-autobuild.list && \
+RUN echo 'deb http://dl.bintray.com/i3/i3-autobuild-ubuntu xenial main' > /etc/apt/sources.list.d/i3-autobuild.list && \
     linux32 apt-get update && \
     linux32 apt-get --allow-unauthenticated install i3-autobuild-keyring && \
+    rm -f /var/lib/apt/lists/dl.bintray.com_i3_i3-autobuild-ubuntu_* && \
     linux32 apt-get update && \
     DEBIAN_FRONTEND=noninteractive mk-build-deps --install --remove --tool 'apt-get --no-install-recommends -y' /usr/src/i3-debian-packaging/control && \
     rm -rf /var/lib/apt/lists/*

--- a/travis/travis-base-ubuntu.Dockerfile
+++ b/travis/travis-base-ubuntu.Dockerfile
@@ -1,7 +1,7 @@
 # vim:ft=Dockerfile
 # Same as travis-base.Dockerfile, but without the test suite dependencies since
 # we only build Debian packages on Ubuntu, we don’t run the tests.
-FROM ubuntu:wily
+FROM ubuntu:xenial
 
 RUN echo force-unsafe-io > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup
 # Paper over occasional network flakiness of some mirrors.
@@ -25,9 +25,10 @@ RUN apt-get update && \
 
 # Install i3 build dependencies.
 COPY debian/control /usr/src/i3-debian-packaging/control
-RUN echo 'deb http://dl.bintray.com/i3/i3-autobuild-ubuntu wily main' > /etc/apt/sources.list.d/i3-autobuild.list && \
+RUN echo 'deb http://dl.bintray.com/i3/i3-autobuild-ubuntu xenial main' > /etc/apt/sources.list.d/i3-autobuild.list && \
     apt-get update && \
     apt-get --allow-unauthenticated install i3-autobuild-keyring && \
+    rm -f /var/lib/apt/lists/dl.bintray.com_i3_i3-autobuild-ubuntu_* && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive mk-build-deps --install --remove --tool 'apt-get --no-install-recommends -y' /usr/src/i3-debian-packaging/control && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The extra rm command when configuring the repository is necessary
because of https://bugs.debian.org/838779.