### PR TITLE
Add the option to toggle between stacked/tabbed layout

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1811,8 +1811,8 @@ bindsym $mod+t split toggle
 
 === Manipulating layout
 
-Use +layout toggle split+, +layout stacking+, +layout tabbed+, +layout splitv+
-or +layout splith+ to change the current container layout to splith/splitv,
+Use +layout toggle split+, +layout toggle stack_tab+, +layout stacking+, +layout tabbed+, +layout splitv+
+or +layout splith+ to change the current container layout to splith/splitv, stacking/tabbed,
 stacking, tabbed layout, splitv or splith, respectively.
 
 To make the current window (!) fullscreen, use +fullscreen enable+ (or
@@ -1826,13 +1826,14 @@ enable+ respectively +floating disable+ (or +floating toggle+):
 *Syntax*:
 --------------------------------------------
 layout default|tabbed|stacking|splitv|splith
-layout toggle [split|all]
+layout toggle [split|stack_tab|all]
 --------------------------------------------
 
 *Examples*:
 --------------
 bindsym $mod+s layout stacking
 bindsym $mod+l layout toggle split
+bindsym $mod+l layout toggle stack_tab
 bindsym $mod+w layout tabbed
 
 # Toggle between stacking/tabbed/split:

--- a/include/commands.h
+++ b/include/commands.h
@@ -223,7 +223,7 @@ void cmd_move_direction(I3_CMD, const char *direction, long move_px);
 void cmd_layout(I3_CMD, const char *layout_str);
 
 /**
- * Implementation of 'layout toggle [all|split]'.
+ * Implementation of 'layout toggle [all|split|stack_tab]'.
  *
  */
 void cmd_layout_toggle(I3_CMD, const char *toggle_mode);

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -104,11 +104,11 @@ state LAYOUT:
   'toggle'
       -> LAYOUT_TOGGLE
 
-# layout toggle [split|all]
+# layout toggle [split|stack_tab|all]
 state LAYOUT_TOGGLE:
   end
       -> call cmd_layout_toggle($toggle_mode)
-  toggle_mode = 'split', 'all'
+  toggle_mode = 'split', 'stack_tab', 'all'
       -> call cmd_layout_toggle($toggle_mode)
 
 # append_layout <path>
@@ -128,7 +128,7 @@ state WORKSPACE:
       -> call cmd_workspace_back_and_forth()
   'number'
       -> WORKSPACE_NUMBER
-  workspace = string 
+  workspace = string
       -> call cmd_workspace_name($workspace, $no_auto_back_and_forth)
 
 state WORKSPACE_NUMBER:

--- a/src/commands.c
+++ b/src/commands.c
@@ -1533,7 +1533,7 @@ void cmd_layout(I3_CMD, const char *layout_str) {
 }
 
 /*
- * Implementation of 'layout toggle [all|split]'.
+ * Implementation of 'layout toggle [all|split|stack_tab]'.
  *
  */
 void cmd_layout_toggle(I3_CMD, const char *toggle_mode) {

--- a/src/con.c
+++ b/src/con.c
@@ -1699,8 +1699,8 @@ void con_set_layout(Con *con, layout_t layout) {
 /*
  * This function toggles the layout of a given container. toggle_mode can be
  * either 'default' (toggle only between stacked/tabbed/last_split_layout),
- * 'split' (toggle only between splitv/splith) or 'all' (toggle between all
- * layouts).
+ * 'split' (toggle only between splitv/splith), 'stack_tab' (toggle only between
+ * stacking/tabbed) or 'all' (toggle between all layouts).
  *
  */
 void con_toggle_layout(Con *con, const char *toggle_mode) {
@@ -1724,6 +1724,17 @@ void con_toggle_layout(Con *con, const char *toggle_mode) {
             else
                 con_set_layout(con, L_SPLITH);
         }
+    } else if (strcmp(toggle_mode, "stack_tab") == 0) {
+        /* Toggle between stacked / tabbed layouts. When the current layout is
+         * neither, set the layout to staked first. */
+         if (parent->layout != L_STACKED && parent->layout != L_TABBED)
+            con_set_layout(con, L_TABBED);
+         else {
+            if (parent->layout == L_STACKED)
+                con_set_layout(con, L_TABBED);
+            else
+                con_set_layout(con, L_STACKED);
+         }
     } else {
         if (parent->layout == L_STACKED)
             con_set_layout(con, L_TABBED);

--- a/src/con.c
+++ b/src/con.c
@@ -1727,14 +1727,8 @@ void con_toggle_layout(Con *con, const char *toggle_mode) {
     } else if (strcmp(toggle_mode, "stack_tab") == 0) {
         /* Toggle between stacked / tabbed layouts. When the current layout is
          * neither, set the layout to staked first. */
-         if (parent->layout != L_STACKED && parent->layout != L_TABBED)
-            con_set_layout(con, L_TABBED);
-         else {
-            if (parent->layout == L_STACKED)
-                con_set_layout(con, L_TABBED);
-            else
-                con_set_layout(con, L_STACKED);
-         }
+        layout_t new_layout = (parent->layout == L_TABBED) ? L_STACKED : L_TABBED;
+        con_set_layout(con, new_layout);
     } else {
         if (parent->layout == L_STACKED)
             con_set_layout(con, L_TABBED);

--- a/testcases/t/192-layout.t
+++ b/testcases/t/192-layout.t
@@ -95,4 +95,16 @@ cmd 'layout toggle all';
 ($nodes, $focus) = get_ws_content($tmp);
 is($nodes->[1]->{layout}, 'splitv', 'layout now splitv');
 
+cmd 'layout toggle stack_tab';
+($nodes, $focus) = get_ws_content($tmp);
+is($nodes->[1]->{layout}, 'tabbed', 'layout now tabbed');
+
+cmd 'layout toggle stack_tab';
+($nodes, $focus) = get_ws_content($tmp);
+is($nodes->[1]->{layout}, 'stacked', 'layout now stacked');
+
+cmd 'layout toggle stack_tab';
+($nodes, $focus) = get_ws_content($tmp);
+is($nodes->[1]->{layout}, 'tabbed', 'layout now tabbed');
+
 done_testing;


### PR DESCRIPTION
This PR adds a parameter called "stack_tab" to the "layout toggle" command. This makes it possible to toggle between stacked and tabbed layouts, muck like the "layout toggle split" works for splitv/splith layouts.

I don't like the name of the parameter very much, but I didn't have a better idea, so suggestions are welcome on that point :)

A possible improvement would be to remember the last layout used between stacked and tabbed, so that running the layout toggle stack_tab command when the layout is neither of them sets the layout to the last one used (again, much like the layout toggle split works).

I added test cases and documentation, but if I forgot anything feel free to tell me and I'll add what's missing.

Thanks for the work on i3, I'm falling in love with it :)
