### PR TITLE
Check output crossing on ENTER_NOTIFY to dockarea.

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -148,15 +148,12 @@ static void handle_enter_notify(xcb_enter_notify_event_t *event) {
         enter_child = true;
     }
 
-    /* If not, then the user moved their cursor to the root window. In that case, we adjust c_ws */
-    if (con == NULL) {
+    /* If we cannot find the container, the user moved their cursor to the root
+     * window. In this case and if they used it to a dock, we need to focus the
+     * workspace on the correct output. */
+    if (con == NULL || con->parent->type == CT_DOCKAREA) {
         DLOG("Getting screen at %d x %d\n", event->root_x, event->root_y);
         check_crossing_screen_boundary(event->root_x, event->root_y);
-        return;
-    }
-
-    if (con->parent->type == CT_DOCKAREA) {
-        DLOG("Ignoring, this is a dock client\n");
         return;
     }
 


### PR DESCRIPTION
When receiving an ENTER_NOTIFY event on a dock client we returned as to not
focus the dock client (cf. #321 and #323). However, we still need to check
for crossing output boundaries and if that happened focus the new output.

Otherwise it can happen that the cursor is on a different output than the
focused output. When opening a window, this would open it on the old output
and then warp the mouse there. This effect will be even worse if the window
is immediately moved with 'move position mouse' as the window will end up
in its correct position on the new output and the cursor warped to the old
output.

relates to #2081