### PR TITLE
Remove conditional compilation for cairo/pangocairo

### DIFF
--- a/DEPENDS
+++ b/DEPENDS
@@ -7,25 +7,25 @@
 ┌──────────────┬────────┬────────┬───────────────────────────────────────────────────────────┐
 │ dependency   │ min.   │ lkgv   │ URL                                                       │
 ├──────────────┼────────┼────────┼───────────────────────────────────────────────────────────┤
-│ pkg-config   │ 0.25   │ 0.28   │ http://pkgconfig.freedesktop.org/                         │
-│ libxcb       │ 1.1.93 │ 1.11   │ http://xcb.freedesktop.org/dist/                          │
+│ pkg-config   │ 0.25   │ 0.29   │ http://pkgconfig.freedesktop.org/                         │
+│ libxcb       │ 1.1.93 │ 1.12   │ http://xcb.freedesktop.org/dist/                          │
 │ xcb-util     │ 0.3.3  │ 0.4.1  │ http://xcb.freedesktop.org/dist/                          │
-│ xkbcommon    │ 0.4.0  │ 0.5.0  │ http://xkbcommon.org/                                     │
-│ xkbcommon-x11│ 0.4.0  │ 0.5.0  │ http://xkbcommon.org/                                     │
-│ util-cursor³⁴│ 0.0.99 │ 0.1.2  │ http://xcb.freedesktop.org/dist/                          │
+│ xkbcommon    │ 0.4.0  │ 0.6.1  │ http://xkbcommon.org/                                     │
+│ xkbcommon-x11│ 0.4.0  │ 0.6.1  │ http://xkbcommon.org/                                     │
+│ util-cursor³⁴│ 0.0.99 │ 0.1.3  │ http://xcb.freedesktop.org/dist/                          │
 │ util-wm⁴     │ 0.3.8  │ 0.3.8  │ http://xcb.freedesktop.org/dist/                          │
 │ util-keysyms⁴│ 0.3.8  │ 0.4.0  │ http://xcb.freedesktop.org/dist/                          │
 │ util-xrm⁴    │ 1.0.0  │ 1.0.0  │ https://github.com/Airblader/xcb-util-xrm                 │
 │ libev        │ 4.0    │ 4.19   │ http://libev.schmorp.de/                                  │
 │ yajl         │ 2.0.1  │ 2.1.0  │ http://lloyd.github.com/yajl/                             │
-│ asciidoc     │ 8.3.0  │ 8.6.8  │ http://www.methods.co.nz/asciidoc/                        │
+│ asciidoc     │ 8.3.0  │ 8.6.9  │ http://www.methods.co.nz/asciidoc/                        │
 │ xmlto        │ 0.0.23 │ 0.0.23 │ http://www.methods.co.nz/asciidoc/                        │
 │ Pod::Simple² │ 3.22   │ 3.22   │ http://search.cpan.org/~dwheeler/Pod-Simple-3.23/         │
 │ docbook-xml  │ 4.5    │ 4.5    │ http://www.methods.co.nz/asciidoc/                        │
-│ PCRE         │ 8.12   │ 8.35   │ http://www.pcre.org/                                      │
+│ PCRE         │ 8.12   │ 8.38   │ http://www.pcre.org/                                      │
 │ libsn¹       │ 0.10   │ 0.12   │ http://freedesktop.org/wiki/Software/startup-notification │
-│ pango        │ 1.30.0 | 1.36.8 │ http://www.pango.org/                                     │
-│ cairo        │ 1.14.4 │ 1.14.4 │ http://cairographics.org/                                 │
+│ pango        │ 1.30.0 | 1.40.1 │ http://www.pango.org/                                     │
+│ cairo        │ 1.14.4 │ 1.14.6 │ http://cairographics.org/                                 │
 └──────────────┴────────┴────────┴───────────────────────────────────────────────────────────┘
  ¹ libsn = libstartup-notification
  ² Pod::Simple is a Perl module required for converting the testsuite

--- a/common.mk
+++ b/common.mk
@@ -147,9 +147,8 @@ LIBSN_LIBS   := $(call ldflags_for_lib, libstartup-notification-1.0,startup-noti
 # Pango
 PANGO_CFLAGS := $(call cflags_for_lib, cairo)
 PANGO_CFLAGS += $(call cflags_for_lib, pangocairo)
-I3_CPPFLAGS  += -DPANGO_SUPPORT=1
-ifeq ($(shell $(PKG_CONFIG) --atleast-version=1.14.4 cairo 2>/dev/null && echo 1),1)
-I3_CPPFLAGS  += -DCAIRO_SUPPORT=1
+ifneq ($(shell $(PKG_CONFIG) --atleast-version=1.14.4 cairo 2>/dev/null && echo 1),1)
+$(error "cairo >= 1.14.4 missing")
 endif
 PANGO_LIBS   := $(call ldflags_for_lib, cairo)
 PANGO_LIBS   += $(call ldflags_for_lib, pangocairo)

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Build-Depends: debhelper (>= 9),
                libyajl-dev (>= 2.0.4),
                libpcre3-dev (>= 1:8.10),
                libstartup-notification0-dev (>= 0.10),
-               libcairo2-dev,
+               libcairo2-dev (>= 1.14.4),
                libpango1.0-dev,
                libpod-simple-perl
 Standards-Version: 3.9.7

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -17,12 +17,8 @@
 #include <xcb/xproto.h>
 #include <xcb/xcb_keysyms.h>
 
-#if PANGO_SUPPORT
 #include <pango/pango.h>
-#endif
-#if CAIRO_SUPPORT
 #include <cairo/cairo-xcb.h>
-#endif
 
 #define DEFAULT_DIR_MODE (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)
 
@@ -73,10 +69,8 @@ struct Font {
             xcb_charinfo_t *table;
         } xcb;
 
-#if PANGO_SUPPORT
         /** The pango font description */
         PangoFontDescription *pango_desc;
-#endif
     } specific;
 };
 
@@ -525,7 +519,6 @@ typedef struct placeholder_t {
  */
 char *format_placeholders(char *format, placeholder_t *placeholders, int num);
 
-#if CAIRO_SUPPORT
 /* We need to flush cairo surfaces twice to avoid an assertion bug. See #1989
  * and https://bugs.freedesktop.org/show_bug.cgi?id=92455. */
 #define CAIRO_SURFACE_FLUSH(surface)  \
@@ -533,7 +526,6 @@ char *format_placeholders(char *format, placeholder_t *placeholders, int num);
         cairo_surface_flush(surface); \
         cairo_surface_flush(surface); \
     } while (0)
-#endif
 
 /* A wrapper grouping an XCB drawable and both a graphics context
  * and the corresponding cairo objects representing it. */
@@ -549,14 +541,12 @@ typedef struct surface_t {
     int width;
     int height;
 
-#if CAIRO_SUPPORT
     /* A cairo surface representing the drawable. */
     cairo_surface_t *surface;
 
     /* The cairo object representing the drawable. In general,
      * this is what one should use for any drawing operation. */
     cairo_t *cr;
-#endif
 } surface_t;
 
 /**

--- a/libi3/font.c
+++ b/libi3/font.c
@@ -13,15 +13,12 @@
 #include <err.h>
 
 #include <cairo/cairo-xcb.h>
-#if PANGO_SUPPORT
 #include <pango/pangocairo.h>
-#endif
 
 #include "libi3.h"
 
 static const i3Font *savedFont = NULL;
 
-#if PANGO_SUPPORT
 static xcb_visualtype_t *root_visual_type;
 static double pango_font_red;
 static double pango_font_green;
@@ -166,7 +163,6 @@ static int predict_text_width_pango(const char *text, size_t text_len, bool pang
 
     return width;
 }
-#endif
 
 /*
  * Loads a font for usage, also getting its metrics. If fallback is true,
@@ -187,7 +183,6 @@ i3Font load_font(const char *pattern, const bool fallback) {
         return font;
     }
 
-#if PANGO_SUPPORT
     /* Try to load a pango font if specified */
     if (strlen(pattern) > strlen("pango:") && !strncmp(pattern, "pango:", strlen("pango:"))) {
         const char *font_pattern = pattern + strlen("pango:");
@@ -202,7 +197,6 @@ i3Font load_font(const char *pattern, const bool fallback) {
             return font;
         }
     }
-#endif
 
     /* Send all our requests first */
     font.specific.xcb.id = xcb_generate_id(conn);
@@ -297,12 +291,10 @@ void free_font(void) {
                 free(savedFont->specific.xcb.info);
             break;
         }
-#if PANGO_SUPPORT
         case FONT_TYPE_PANGO:
             /* Free the font description */
             pango_font_description_free(savedFont->specific.pango_desc);
             break;
-#endif
         default:
             assert(false);
             break;
@@ -329,14 +321,12 @@ void set_font_colors(xcb_gcontext_t gc, color_t foreground, color_t background) 
             xcb_change_gc(conn, gc, mask, values);
             break;
         }
-#if PANGO_SUPPORT
         case FONT_TYPE_PANGO:
             /* Save the foreground font */
             pango_font_red = foreground.red;
             pango_font_green = foreground.green;
             pango_font_blue = foreground.blue;
             break;
-#endif
         default:
             assert(false);
             break;
@@ -348,11 +338,7 @@ void set_font_colors(xcb_gcontext_t gc, color_t foreground, color_t background) 
  *
  */
 bool font_is_pango(void) {
-#if PANGO_SUPPORT
     return savedFont->type == FONT_TYPE_PANGO;
-#else
-    return false;
-#endif
 }
 
 static int predict_text_width_xcb(const xcb_char2b_t *text, size_t text_len);
@@ -397,11 +383,9 @@ static void draw_text_xcb(const xcb_char2b_t *text, size_t text_len, xcb_drawabl
 void draw_text(i3String *text, xcb_drawable_t drawable, xcb_gcontext_t gc,
                xcb_visualtype_t *visual, int x, int y, int max_width) {
     assert(savedFont != NULL);
-#if PANGO_SUPPORT
     if (visual == NULL) {
         visual = root_visual_type;
     }
-#endif
 
     switch (savedFont->type) {
         case FONT_TYPE_NONE:
@@ -411,13 +395,11 @@ void draw_text(i3String *text, xcb_drawable_t drawable, xcb_gcontext_t gc,
             draw_text_xcb(i3string_as_ucs2(text), i3string_get_num_glyphs(text),
                           drawable, gc, x, y, max_width);
             break;
-#if PANGO_SUPPORT
         case FONT_TYPE_PANGO:
             /* Render the text using Pango */
             draw_text_pango(i3string_as_utf8(text), i3string_get_num_bytes(text),
                             drawable, visual, x, y, max_width, i3string_is_markup(text));
             return;
-#endif
         default:
             assert(false);
     }
@@ -450,13 +432,11 @@ void draw_text_ascii(const char *text, xcb_drawable_t drawable,
             }
             break;
         }
-#if PANGO_SUPPORT
         case FONT_TYPE_PANGO:
             /* Render the text using Pango */
             draw_text_pango(text, strlen(text),
                             drawable, root_visual_type, x, y, max_width, false);
             return;
-#endif
         default:
             assert(false);
     }
@@ -547,12 +527,10 @@ int predict_text_width(i3String *text) {
             return 0;
         case FONT_TYPE_XCB:
             return predict_text_width_xcb(i3string_as_ucs2(text), i3string_get_num_glyphs(text));
-#if PANGO_SUPPORT
         case FONT_TYPE_PANGO:
             /* Calculate extents using Pango */
             return predict_text_width_pango(i3string_as_utf8(text), i3string_get_num_bytes(text),
                                             i3string_is_markup(text));
-#endif
         default:
             assert(false);
             return 0;

--- a/libi3/string.c
+++ b/libi3/string.c
@@ -13,9 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if PANGO_SUPPORT
 #include <glib.h>
-#endif
 
 #include "libi3.h"
 
@@ -192,15 +190,11 @@ void i3string_set_markup(i3String *str, bool pango_markup) {
  * Escape pango markup characters in the given string.
  */
 i3String *i3string_escape_markup(i3String *str) {
-#if PANGO_SUPPORT
     const char *text = i3string_as_utf8(str);
     char *escaped = g_markup_escape_text(text, -1);
     i3String *result = i3string_from_utf8(escaped);
     free(escaped);
     return result;
-#else
-    return str;
-#endif
 }
 
 /*

--- a/src/util.c
+++ b/src/util.c
@@ -327,12 +327,10 @@ char *pango_escape_markup(char *input) {
     if (!font_is_pango())
         return input;
 
-#if PANGO_SUPPORT
     char *escaped = g_markup_escape_text(input, -1);
     FREE(input);
 
     return escaped;
-#endif
 }
 
 /*


### PR DESCRIPTION
We strive to avoid conditional compilation in i3 as much as possible.
cairo and pangocairo have been around long enough in the versions that
we need that it’s time to unconditionally depend on them.

Also update DEPENDS with the last-known-good-versions while at it.