### PR TITLE
Bugfix: NULL dereference when stickying _NET_WM_DESKTOP_ALL windows

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -433,7 +433,7 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
     /* We ignore the hint for an internal workspace because windows in the
      * scratchpad also have this value, but upon restarting i3 we don't want
      * them to become sticky windows. */
-    if (cwindow->wm_desktop == NET_WM_DESKTOP_ALL && !con_is_internal(ws)) {
+    if (cwindow->wm_desktop == NET_WM_DESKTOP_ALL && (ws == NULL || !con_is_internal(ws))) {
         DLOG("This window has _NET_WM_DESKTOP = 0xFFFFFFFF. Will float it and make it sticky.\n");
         nc->sticky = true;
         want_floating = true;


### PR DESCRIPTION
This PR fixes a bug where `i3` will crash when starting some programs that set `_NET_WM_DESKTOP_ALL`.

In these cases, `ws` will be `NULL` here, triggering a null pointer dereference.

This bug was originally tested and found by me with `lemonbar` and was introduced in commit a15ce8cb8dddf118ed27deb79eb5d1b4103e8303: Assign the sticky value for _NET_WM_DESKTOP on scratchpad windows. (#2457)

Sorry if this PR is not perfectly up to standards, this is my first time contributing to i3.