### PR TITLE
Add "output" to IPC events referencing a container

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -294,6 +294,11 @@ void dump_node(yajl_gen gen, struct Con *con, bool inplace_restart) {
     ystr("focused");
     y(bool, (con == focused));
 
+    if (con->type != CT_ROOT && con->type != CT_OUTPUT) {
+        ystr("output");
+        ystr(con_get_output(con)->name);
+    }
+
     ystr("layout");
     switch (con->layout) {
         case L_DEFAULT:


### PR DESCRIPTION
Add output to all events in ipc that references a container.

Closes #2478 