### PR TITLE
Optionally set layout of container in focus rather than parent

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -105,6 +105,10 @@ struct Config {
     /** Default orientation for new containers */
     int default_orientation;
 
+    /** By default, we set the layout of the parent container. The user can
+     * disable this behavior with this option. */
+    bool set_parent_layout;
+
     /** By default, focus follows mouse. If the user explicitly wants to
      * turn this off (and instead rely only on the keyboard for changing
      * focus), we allow them to do this with this relatively special option.

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -45,6 +45,7 @@ CFGFUN(floating_maximum_size, const long width, const long height);
 CFGFUN(default_orientation, const char *orientation);
 CFGFUN(workspace_layout, const char *layout);
 CFGFUN(workspace_back_and_forth, const char *value);
+CFGFUN(set_parent_layout, const char *value);
 CFGFUN(focus_follows_mouse, const char *value);
 CFGFUN(mouse_warping, const char *value);
 CFGFUN(force_focus_wrapping, const char *value);

--- a/src/con.c
+++ b/src/con.c
@@ -1619,7 +1619,7 @@ void con_set_layout(Con *con, layout_t layout) {
     /* Users can focus workspaces, but not any higher in the hierarchy.
      * Focus on the workspace is a special case, since in every other case, the
      * user means "change the layout of the parent split container". */
-    if (con->type != CT_WORKSPACE)
+    if (config.set_parent_layout && con->type != CT_WORKSPACE)
         con = con->parent;
 
     /* We fill in last_split_layout when switching to a different layout

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -239,6 +239,10 @@ CFGFUN(hide_edge_borders, const char *borders) {
         config.hide_edge_borders = HEBM_NONE;
 }
 
+CFGFUN(set_parent_layout, const char *value) {
+    config.set_parent_layout = eval_boolstr(value);
+}
+
 CFGFUN(focus_follows_mouse, const char *value) {
     config.disable_focus_follows_mouse = !eval_boolstr(value);
 }


### PR DESCRIPTION
I have been using this patch personally for years, so i thought i ought to finally send it upstream.