### PR TITLE
Implement new window::mark IPC event.

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -754,14 +754,15 @@ defines whether pango markup shall be used for displaying this mode.
 This event consists of a single serialized map containing a property
 +change (string)+ which indicates the type of the change
 
-* +new+ - the window has become managed by i3
-* +close+ - the window has closed
-* +focus+ - the window has received input focus
-* +title+ - the window's title has changed
-* +fullscreen_mode+ - the window has entered or exited fullscreen mode
-* +move+ - the window has changed its position in the tree
-* +floating+ - the window has transitioned to or from floating
-* +urgent+ - the window has become urgent or lost its urgent status
+* +new+ – the window has become managed by i3
+* +close+ – the window has closed
+* +focus+ – the window has received input focus
+* +title+ – the window's title has changed
+* +fullscreen_mode+ – the window has entered or exited fullscreen mode
+* +move+ – the window has changed its position in the tree
+* +floating+ – the window has transitioned to or from floating
+* +urgent+ – the window has become urgent or lost its urgent status
+* +mark+ – a mark has been added to or removed from the window
 
 Additionally a +container (object)+ field will be present, which consists
 of the window's parent container. Be aware that for the "new" event, the

--- a/src/con.c
+++ b/src/con.c
@@ -617,6 +617,7 @@ void con_mark(Con *con, const char *mark, mark_mode_t mode) {
     mark_t *new = scalloc(1, sizeof(mark_t));
     new->name = sstrdup(mark);
     TAILQ_INSERT_TAIL(&(con->marks_head), new, marks);
+    ipc_send_window_event("mark", con);
 
     con->mark_changed = true;
 }
@@ -645,6 +646,8 @@ void con_unmark(Con *con, const char *name) {
                 FREE(mark->name);
                 TAILQ_REMOVE(&(current->marks_head), mark, marks);
                 FREE(mark);
+
+                ipc_send_window_event("mark", current);
             }
 
             current->mark_changed = true;
@@ -668,6 +671,8 @@ void con_unmark(Con *con, const char *name) {
             FREE(mark->name);
             TAILQ_REMOVE(&(current->marks_head), mark, marks);
             FREE(mark);
+
+            ipc_send_window_event("mark", current);
             break;
         }
     }

--- a/testcases/t/265-ipc-mark.t
+++ b/testcases/t/265-ipc-mark.t
@@ -1,0 +1,70 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests for the window::mark IPC event.
+# Ticket: #2501
+use i3test;
+
+my ($i3, $timer, $event, $mark);
+
+$i3 = i3(get_socket_path());
+$i3->connect()->recv;
+
+$i3->subscribe({
+    window => sub {
+        my ($event) = @_;
+        return unless defined $mark;
+        return unless $event->{change} eq 'mark';
+
+        $mark->send($event);
+    }
+})->recv;
+
+$timer = AnyEvent->timer(
+    after => 0.5,
+    cb => sub {
+        $mark->send(0);
+    }
+);
+
+###############################################################################
+# Marking a container triggers a 'mark' event.
+###############################################################################
+fresh_workspace;
+open_window;
+
+$mark = AnyEvent->condvar;
+cmd 'mark x';
+
+$event = $mark->recv;
+ok($event, 'window::mark event has been received');
+
+###############################################################################
+# Unmarking a container triggers a 'mark' event.
+###############################################################################
+fresh_workspace;
+open_window;
+cmd 'mark x';
+
+$mark = AnyEvent->condvar;
+cmd 'unmark x';
+
+$event = $mark->recv;
+ok($event, 'window::mark event has been received');
+
+###############################################################################
+
+done_testing;


### PR DESCRIPTION
This introduces a new type of 'window' event sent wit change:mark whenever
a mark on a window changes.

fixes #2501