### PR TITLE
Allow specifying a different config file when reloading

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -238,7 +238,7 @@ void cmd_exit(I3_CMD);
  * Implementation of 'reload'.
  *
  */
-void cmd_reload(I3_CMD);
+void cmd_reload(I3_CMD, const char* config_file);
 
 /**
  * Implementation of 'restart'.

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -18,7 +18,7 @@ state INITIAL:
   'exec' -> EXEC
   'exit' -> call cmd_exit()
   'restart' -> call cmd_restart()
-  'reload' -> call cmd_reload()
+  'reload' -> RELOAD
   'shmlog' -> SHMLOG
   'debuglog' -> DEBUGLOG
   'border' -> BORDER
@@ -70,6 +70,13 @@ state EXEC:
       ->
   command = string
       -> call cmd_exec($nosn, $command)
+
+# reload [config_file]
+state RELOAD:
+  end
+    -> call cmd_reload($config_file)
+  config_file = string
+    -> call cmd_reload($config_file)
 
 # shmlog <size>|toggle|on|off
 state SHMLOG:

--- a/src/commands.c
+++ b/src/commands.c
@@ -1569,11 +1569,11 @@ void cmd_exit(I3_CMD) {
  * Implementation of 'reload'.
  *
  */
-void cmd_reload(I3_CMD) {
+void cmd_reload(I3_CMD, const char* config_file) {
     LOG("reloading\n");
     kill_nagbar(&config_error_nagbar_pid, false);
     kill_nagbar(&command_error_nagbar_pid, false);
-    load_configuration(conn, NULL, true);
+    load_configuration(conn, config_file, true);
     x_set_i3_atoms();
     /* Send an IPC event just in case the ws names have changed */
     ipc_send_workspace_event("reload", NULL, NULL);


### PR DESCRIPTION
This pr adds an optional "config_file" parameter to the "reload"
command, to reload i3 with a different config file than the one it was
started with.