### PR TITLE
Bugfix: escape I3_VERSION when read from file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ AS_IF([test -d ${srcdir}/.git],
       ],
       [
         VERSION="$(cut -d '-' -f 1 ${srcdir}/I3_VERSION | cut -d ' ' -f 1)"
-        I3_VERSION="$(cat ${srcdir}/I3_VERSION)"
+        I3_VERSION="$(sed -e 's/@<:@\"?\\@:>@/\\&/g' ${srcdir}/I3_VERSION)"
         is_release="$(grep -q non-git ${srcdir}/I3_VERSION && echo no || echo yes)"
       ])
 AC_SUBST([I3_VERSION], [$I3_VERSION])


### PR DESCRIPTION
I3_VERSION is used as string literal in config.h, i.e.:

    #define I3_VERSION …

Where “…” is replaced with the contents of I3_VERSION.

For our travis builds, we persist the version number to I3_VERSION,
i.e.:

    $ cat I3_VERSION
    4.12-150-g8ddc187 (2016-10-25, branch "next")

Previously, config.h would end up with:

    #define I3_VERSION "4.12-150-g8ddc187 (2016-10-25, branch "next")"

Note the unquoted double quotes around “next”, which are invalid in
C string literals.

Hence, this commit uses sed to escape double quotes, question marks and
backslashes (see also http://stackoverflow.com/a/12208808/712014).

The @<:@ and @:>@ quadrigraphs that m4 expands to [ and ], respectively,
see also http://stackoverflow.com/a/2309394/712014