### PR TITLE
Fix two memory leaks.

### DIFF
--- a/i3-msg/main.c
+++ b/i3-msg/main.c
@@ -206,7 +206,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (!payload)
-        payload = "";
+        payload = sstrdup("");
 
     int sockfd = socket(AF_LOCAL, SOCK_STREAM, 0);
     if (sockfd == -1)
@@ -221,6 +221,7 @@ int main(int argc, char *argv[]) {
 
     if (ipc_send_message(sockfd, strlen(payload), message_type, (uint8_t *)payload) == -1)
         err(EXIT_FAILURE, "IPC: write()");
+    free(payload);
 
     if (quiet)
         return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -403,12 +403,14 @@ int main(int argc, char *argv[]) {
         memset(&addr, 0, sizeof(struct sockaddr_un));
         addr.sun_family = AF_LOCAL;
         strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+        FREE(socket_path);
         if (connect(sockfd, (const struct sockaddr *)&addr, sizeof(struct sockaddr_un)) < 0)
             err(EXIT_FAILURE, "Could not connect to i3");
 
         if (ipc_send_message(sockfd, strlen(payload), I3_IPC_MESSAGE_TYPE_COMMAND,
                              (uint8_t *)payload) == -1)
             err(EXIT_FAILURE, "IPC: write()");
+        FREE(payload);
 
         uint32_t reply_length;
         uint32_t reply_type;
@@ -422,6 +424,7 @@ int main(int argc, char *argv[]) {
         if (reply_type != I3_IPC_MESSAGE_TYPE_COMMAND)
             errx(EXIT_FAILURE, "IPC: received reply of type %d but expected %d (COMMAND)", reply_type, I3_IPC_MESSAGE_TYPE_COMMAND);
         printf("%.*s\n", reply_length, reply);
+        FREE(reply);
         return 0;
     }
 


### PR DESCRIPTION
This still leaves

```
==27513==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 35 byte(s) in 1 object(s) allocated from:
    #0 0x7fbe4b50fe60 in __interceptor_malloc /build/gcc-multilib/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:62
    #1 0x7fbe47db5c37 in _IO_vasprintf (/usr/lib/libc.so.6+0x6fc37)
```

but that doesn't seem to come from us.