### PR TITLE
Fix memory leaks

### DIFF
--- a/src/display_version.c
+++ b/src/display_version.c
@@ -182,4 +182,7 @@ void display_running_version(void) {
 #endif
 
     yajl_free(handle);
+    free(reply);
+    free(pid_from_atom);
+    free(socket_path);
 }


### PR DESCRIPTION
Fix memory leaks when executing 'i3 --moreversion'.

=================================================================
==14852==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 159 byte(s) in 1 object(s) allocated from:
    #0 0x7fea40855602 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98602)
    #1 0x4c4c4a in smalloc ../../i3/libi3/safewrappers.c:24
    #2 0x4c3aee in ipc_recv_message ../../i3/libi3/ipc_recv_message.c:61
    #3 0x44dc2e in display_running_version ../../i3/src/display_version.c:94
    #4 0x472947 in main ../../i3/src/main.c:269
    #5 0x7fea3d0c982f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)

Direct leak of 39 byte(s) in 2 object(s) allocated from:
    #0 0x7fea40855602 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98602)
    #1 0x7fea3d11f7d7 in vasprintf (/lib/x86_64-linux-gnu/libc.so.6+0x767d7)

SUMMARY: AddressSanitizer: 198 byte(s) leaked in 3 allocation(s).