### PR TITLE
`move` syntax clarification

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1921,7 +1921,8 @@ move <left|right|down|up> [<px> px]
 # Moves the container either to a specific location
 # or to the center of the screen. If 'absolute' is
 # used, it is moved to the center of all outputs.
-move [absolute] position [[<px> px] [<px> px]|center]
+move [absolute] position <pos_x> [px] <pos_y> [px]
+move [absolute] position center
 
 # Moves the container to the current position of the
 # mouse cursor. Only affects floating containers.


### PR DESCRIPTION
Both x and y position need to be specified. The notation `[<px> px] [<px> px]` is misleading, because neither the x- nor the y-coordinate are optional.