### PR TITLE
Fix read of uninitialized memory

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -981,7 +981,7 @@ int *bindings_get_buttons_to_grab(void) {
         }
 
         /* Avoid duplicates. */
-        for (int i = 0; i < num_max; i++) {
+        for (int i = 0; i < num; i++) {
             if (buffer[i] == button)
                 continue;
         }


### PR DESCRIPTION
Previous code was reading whole array, it was "slower" and it
read uninitialized memory