### PR TITLE
Rewrite the signal handler dialogs.

### DIFF
--- a/include/sighandler.h
+++ b/include/sighandler.h
@@ -3,10 +3,6 @@
  *
  * i3 - an improved dynamic tiling window manager
  * © 2009 Michael Stapelberg and contributors (see also: LICENSE)
- * © 2009 Jan-Erik Rediger
- *
- * sighandler.c: Interactive crash dialog upon SIGSEGV/SIGABRT/SIGFPE (offers
- *               to restart inplace).
  *
  */
 #pragma once
@@ -14,7 +10,8 @@
 #include <config.h>
 
 /**
- * Setup signal handlers to safely handle SIGSEGV and SIGFPE
+ * Configured a signal handler to gracefully handle crashes and allow the user
+ * to generate a backtrace and rescue their session.
  *
  */
 void setup_signal_handler(void);


### PR DESCRIPTION
This commit is a rewrite of the popup dialogs used when i3 crashes. We now
use our draw_util suite and both properly react to EXPOSE events and clean
up the windows when the handler exits.

As a side-effect, this fixes #2422