### PR TITLE
Report errors raised during error log creation

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -88,8 +88,13 @@ void init_logging(void) {
             fprintf(stderr, "Could not initialize errorlog\n");
         else {
             errorfile = fopen(errorfilename, "w");
-            if (fcntl(fileno(errorfile), F_SETFD, FD_CLOEXEC)) {
-                fprintf(stderr, "Could not set close-on-exec flag\n");
+            if (!errorfile) {
+                fprintf(stderr, "Could not initialize errorlog on %s: %s\n",
+                        errorfilename, strerror(errno));
+            } else {
+                if (fcntl(fileno(errorfile), F_SETFD, FD_CLOEXEC)) {
+                    fprintf(stderr, "Could not set close-on-exec flag\n");
+                }
             }
         }
     }


### PR DESCRIPTION
This PR fixes a null pointer dereference after `fopen` on the errorlog failed (in my case because of wrong permissions).