### PR TITLE
Fix build outside repo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,8 +31,8 @@ AX_EXTEND_SRCDIR
 
 AS_IF([test -d ${srcdir}/.git],
       [
-        VERSION="$(git describe --tags --abbrev=0)"
-        I3_VERSION="$(git describe --tags --always) ($(git log --pretty=format:%cd --date=short -n1), branch \\\"$(git describe --tags --always --all | sed s:heads/::)\\\")"
+        VERSION="$(git -C ${srcdir} describe --tags --abbrev=0)"
+        I3_VERSION="$(git -C ${srcdir} describe --tags --always) ($(git -C ${srcdir} log --pretty=format:%cd --date=short -n1), branch \\\"$(git -C ${srcdir} describe --tags --always --all | sed s:heads/::)\\\")"
         # Mirrors what libi3/is_debug_build.c does:
         is_release=$(test $(echo "${I3_VERSION}" | cut -d '(' -f 1 | wc -m) -lt 10 && echo yes || echo no)
       ],

--- a/configure.ac
+++ b/configure.ac
@@ -154,8 +154,9 @@ else
 	print_BUILD_MANS=no
 fi
 
-git_dir=`git rev-parse --git-dir 2>/dev/null`
-if test -n "$git_dir"; then
+in_git_worktree=`git rev-parse --is-inside-work-tree 2>/dev/null`
+if "$in_git_worktree" == "true"; then
+	git_dir=`git rev-parse --git-dir 2>/dev/null`
 	srcdir=`dirname "$git_dir"`
 	exclude_dir=`pwd | sed "s,^$srcdir,,g"`
 	if ! grep -q "^$exclude_dir" "$git_dir/info/exclude"; then


### PR DESCRIPTION
The Autoconf script's logic wasn't accounting for building outside of the working tree w/ respect to version detection; this led to a build error.

`nmschulte@desmas-l:~/builds/i3$ ~/src/i3/configure`
![2017_01_09-19_58_40-721x351](https://cloud.githubusercontent.com/assets/8540239/21791075/13ac1796-d6a6-11e6-8239-f57586010953.png)

`nmschulte@desmas-l:~/builds/i3$ make`
![2017_01_09-19_58_48-721x351](https://cloud.githubusercontent.com/assets/8540239/21791074/13ab258e-d6a6-11e6-98b2-6829a1b32f80.png)

This also updates the auto build-dir exclusion logic to only apply if within the git working tree, and uses those semantic CLI options from `git rev-parse`, to improve legibility.