### PR TITLE
Validate that a binding mode is not defined more than once.

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -32,8 +32,9 @@ static struct Mode *mode_from_name(const char *name, bool pango_markup) {
 
     /* Try to find the mode in the list of modes and return it */
     SLIST_FOREACH(mode, &modes, modes) {
-        if (strcmp(mode->name, name) == 0)
+        if (strcmp(mode->name, name) == 0) {
             return mode;
+        }
     }
 
     /* If the mode was not found, create a new one */

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -126,6 +126,15 @@ CFGFUN(enter_mode, const char *pango_markup, const char *modename) {
         ELOG("You cannot use the name %s for your mode\n", DEFAULT_BINDING_MODE);
         exit(1);
     }
+
+    struct Mode *mode;
+    SLIST_FOREACH(mode, &modes, modes) {
+        if (strcmp(mode->name, modename) == 0) {
+            ELOG("The binding mode with name \"%s\" is defined at least twice.\n", modename);
+            exit(1);
+        }
+    }
+
     DLOG("\t now in mode %s\n", modename);
     FREE(current_mode);
     current_mode = sstrdup(modename);


### PR DESCRIPTION
While defining the same mode usually wouldn't hurt and, in fact, the old behavior
allows to split the definition of a binding mode into several blocks, this
can lead to user errors where they accidentally define a mode twice and don't understand
why the mode behaves a certain way (this has been observed in real life :-)).

There's no good usecase for splitting a single binding mode into multiple blocks, thus
the new behavior is better.

fixes #2615