### PR TITLE
Only react on the last Expose event in a series of events.

### DIFF
--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -966,7 +966,10 @@ int main(int argc, char *argv[]) {
                 break;
 
             case XCB_EXPOSE:
-                handle_expose();
+                if (((xcb_expose_event_t *)event)->count == 0) {
+                    handle_expose();
+                }
+
                 break;
         }
 

--- a/i3-input/main.c
+++ b/i3-input/main.c
@@ -525,7 +525,10 @@ int main(int argc, char *argv[]) {
                 break;
 
             case XCB_EXPOSE:
-                handle_expose(NULL, conn, (xcb_expose_event_t *)event);
+                if (((xcb_expose_event_t *)event)->count == 0) {
+                    handle_expose(NULL, conn, (xcb_expose_event_t *)event);
+                }
+
                 break;
         }
 

--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -596,7 +596,10 @@ int main(int argc, char *argv[]) {
 
         switch (type) {
             case XCB_EXPOSE:
-                handle_expose(conn, (xcb_expose_event_t *)event);
+                if (((xcb_expose_event_t *)event)->count == 0) {
+                    handle_expose(conn, (xcb_expose_event_t *)event);
+                }
+
                 break;
 
             case XCB_BUTTON_PRESS:

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -1147,8 +1147,11 @@ void xcb_chk_cb(struct ev_loop *loop, ev_check *watcher, int revents) {
                 handle_visibility_notify((xcb_visibility_notify_event_t *)event);
                 break;
             case XCB_EXPOSE:
-                /* Expose-events happen, when the window needs to be redrawn */
-                redraw_bars();
+                if (((xcb_expose_event_t *)event)->count == 0) {
+                    /* Expose-events happen, when the window needs to be redrawn */
+                    redraw_bars();
+                }
+
                 break;
             case XCB_BUTTON_PRESS:
                 /* Button press events are mouse buttons clicked on one of our bars */

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -1477,7 +1477,10 @@ void handle_event(int type, xcb_generic_event_t *event) {
             break;
 
         case XCB_EXPOSE:
-            handle_expose_event((xcb_expose_event_t *)event);
+            if (((xcb_expose_event_t *)event)->count == 0) {
+                handle_expose_event((xcb_expose_event_t *)event);
+            }
+
             break;
 
         case XCB_MOTION_NOTIFY:

--- a/src/restore_layout.c
+++ b/src/restore_layout.c
@@ -360,7 +360,10 @@ static void configure_notify(xcb_configure_notify_event_t *event) {
 static void restore_handle_event(int type, xcb_generic_event_t *event) {
     switch (type) {
         case XCB_EXPOSE:
-            expose_event((xcb_expose_event_t *)event);
+            if (((xcb_expose_event_t *)event)->count == 0) {
+                expose_event((xcb_expose_event_t *)event);
+            }
+
             break;
         case XCB_CONFIGURE_NOTIFY:
             configure_notify((xcb_configure_notify_event_t *)event);


### PR DESCRIPTION
Thanks to @psychon for pointing this out during the review of PR #2624.
This commit extends this change to all other occurences of Expose events
within i3.