### PR TITLE
Don't exit() on redefined binding mode.

### DIFF
--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -124,14 +124,13 @@ CFGFUN(mode_binding, const char *bindtype, const char *modifiers, const char *ke
 CFGFUN(enter_mode, const char *pango_markup, const char *modename) {
     if (strcasecmp(modename, DEFAULT_BINDING_MODE) == 0) {
         ELOG("You cannot use the name %s for your mode\n", DEFAULT_BINDING_MODE);
-        exit(1);
+        return;
     }
 
     struct Mode *mode;
     SLIST_FOREACH(mode, &modes, modes) {
         if (strcmp(mode->name, modename) == 0) {
             ELOG("The binding mode with name \"%s\" is defined at least twice.\n", modename);
-            exit(1);
         }
     }
 


### PR DESCRIPTION
Doing a hard exit() is a rather harsh action for something i3 can handle
perfectly fine and is only meant to be a check to make debugging easier
for users in certain situations.