### PR TITLE
[wip] Tiling drag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -499,6 +499,7 @@ i3_SOURCES = \
 	include/shmlog.h \
 	include/sighandler.h \
 	include/startup.h \
+	include/tiling_drag.h \
 	include/tree.h \
 	include/util.h \
 	include/window.h \
@@ -540,6 +541,7 @@ i3_SOURCES = \
 	src/sd-daemon.c \
 	src/sighandler.c \
 	src/startup.c \
+	src/tiling_drag.c \
 	src/tree.c \
 	src/util.c \
 	src/version.c \

--- a/include/all.h
+++ b/include/all.h
@@ -64,6 +64,7 @@
 #include "cmdparse.h"
 #include "xcursor.h"
 #include "resize.h"
+#include "tiling_drag.h"
 #include "sighandler.h"
 #include "move.h"
 #include "output.h"

--- a/include/con.h
+++ b/include/con.h
@@ -261,9 +261,9 @@ void con_enable_fullscreen(Con *con, fullscreen_mode_t fullscreen_mode);
 void con_disable_fullscreen(Con *con);
 
 /**
- * Moves a container to the side of a target container. This makes the the
- * container and its target the only two children of a split container with
- * appropriate layout.
+ * Moves a container to the side of a target container. This makes the container
+ * and its target the only two children of a split container with appropriate
+ * layout.
  *
  */
 void con_move_to_side_of_con(Con *con, Con *target, direction_t direction);

--- a/include/con.h
+++ b/include/con.h
@@ -261,6 +261,14 @@ void con_enable_fullscreen(Con *con, fullscreen_mode_t fullscreen_mode);
 void con_disable_fullscreen(Con *con);
 
 /**
+ * Moves a container to the side of a target container. This makes the the
+ * container and its target the only two children of a split container with
+ * appropriate layout.
+ *
+ */
+void con_move_to_side_of_con(Con *con, Con *target, direction_t direction);
+
+/**
  * Moves the given container to the currently focused container on the given
  * workspace.
  *

--- a/include/move.h
+++ b/include/move.h
@@ -17,3 +17,13 @@
  *
  */
 void tree_move(Con *con, int direction);
+
+typedef enum { BEFORE,
+               AFTER } position_t;
+
+/**
+ * This function detaches 'con' from its parent and inserts it either before or
+ * after 'target'.
+ *
+ */
+void insert_con_into(Con *con, Con *target, position_t position);

--- a/include/move.h
+++ b/include/move.h
@@ -17,3 +17,15 @@
  *
  */
 void tree_move(Con *con, int direction);
+
+typedef enum { BEFORE,
+               AFTER } position_t;
+
+/*
+ * This function detaches 'con' from its parent and inserts it either before or
+ * after 'target'.
+ *
+ * TODO refactor me into con.c
+ *
+ */
+void insert_con_into(Con *con, Con *target, position_t position);

--- a/include/move.h
+++ b/include/move.h
@@ -17,13 +17,3 @@
  *
  */
 void tree_move(Con *con, int direction);
-
-typedef enum { BEFORE,
-               AFTER } position_t;
-
-/**
- * This function detaches 'con' from its parent and inserts it either before or
- * after 'target'.
- *
- */
-void insert_con_into(Con *con, Con *target, position_t position);

--- a/include/tiling_drag.h
+++ b/include/tiling_drag.h
@@ -1,0 +1,16 @@
+/*
+ * vim:ts=4:sw=4:expandtab
+ *
+ * i3 - an improved dynamic tiling window manager
+ * © 2009 Michael Stapelberg and contributors (see also: LICENSE)
+ *
+ * tiling_drag.h: Reposition tiled windows by dragging.
+ *
+ */
+#pragma once
+
+/**
+ * Initiates a mouse drag operation on a tiled window.
+ *
+ */
+void tiling_drag(Con *con, xcb_button_press_event_t *event);

--- a/src/click.c
+++ b/src/click.c
@@ -318,10 +318,14 @@ static int route_click(Con *con, xcb_button_press_event_t *event, const bool mod
             return 1;
     }
     /* 8: otherwise, check for border/decoration clicks and resize */
-    else if ((dest == CLICK_BORDER || dest == CLICK_DECORATION) &&
-             is_left_or_right_click) {
+    else if (dest == CLICK_BORDER && is_left_or_right_click) {
         DLOG("Trying to resize (tiling)\n");
         tiling_resize(con, event, dest);
+    }
+    /* 9: otherwise, check for dragging a tiled window */
+    else if (dest == CLICK_DECORATION && is_left_or_right_click) {
+        DLOG("Trying to drag (tiling)\n");
+        tiling_drag(con, event);
     }
 
 done:

--- a/src/click.c
+++ b/src/click.c
@@ -317,15 +317,15 @@ static int route_click(Con *con, xcb_button_press_event_t *event, const bool mod
         if (floating_mod_on_tiled_client(con, event))
             return 1;
     }
-    /* 8: otherwise, check for border/decoration clicks and resize */
+    /* 8: floating modifier pressed, initiate a drag */
+    else if (dest == CLICK_INSIDE && mod_pressed && event->detail == XCB_BUTTON_INDEX_1) {
+        DLOG("Trying to drag (tiling)\n");
+        tiling_drag(con, event);
+    }
+    /* 9: otherwise, check for border/decoration clicks and resize */
     else if (dest == CLICK_BORDER && is_left_or_right_click) {
         DLOG("Trying to resize (tiling)\n");
         tiling_resize(con, event, dest);
-    }
-    /* 9: otherwise, check for dragging a tiled window */
-    else if (dest == CLICK_DECORATION && is_left_or_right_click) {
-        DLOG("Trying to drag (tiling)\n");
-        tiling_drag(con, event);
     }
 
 done:

--- a/src/con.c
+++ b/src/con.c
@@ -951,7 +951,7 @@ void con_disable_fullscreen(Con *con) {
     con_set_fullscreen_mode(con, CF_NONE);
 }
 
-bool _con_move_to_con(Con *con, Con *target, bool behind_focused, bool fix_coordinates, bool dont_warp, bool ignore_focus, bool insert_before) {
+static bool _con_move_to_con(Con *con, Con *target, bool behind_focused, bool fix_coordinates, bool dont_warp, bool ignore_focus, bool insert_before) {
     Con *orig_target = target;
 
     /* Prevent moving if this would violate the fullscreen focus restrictions. */

--- a/src/con.c
+++ b/src/con.c
@@ -71,7 +71,7 @@ Con *con_new(Con *parent, i3Window *window) {
     return new;
 }
 
-static void _con_attach(Con *con, Con *parent, Con *previous, bool ignore_focus) {
+static void _con_attach(Con *con, Con *parent, Con *previous, bool ignore_focus, bool insert_before) {
     con->parent = parent;
     Con *loop;
     Con *current = previous;
@@ -146,8 +146,13 @@ static void _con_attach(Con *con, Con *parent, Con *previous, bool ignore_focus)
         /* Insert the container after the tiling container, if found.
          * When adding to a CT_OUTPUT, just append one after another. */
         if (current && parent->type != CT_OUTPUT) {
-            DLOG("Inserting con = %p after con %p\n", con, current);
-            TAILQ_INSERT_AFTER(nodes_head, current, con, nodes);
+            if (insert_before) {
+                DLOG("Inserting con = %p before con %p\n", con, current);
+                TAILQ_INSERT_BEFORE(current, con, nodes);
+            } else {
+                DLOG("Inserting con = %p after con %p\n", con, current);
+                TAILQ_INSERT_AFTER(nodes_head, current, con, nodes);
+            }
         } else
             TAILQ_INSERT_TAIL(nodes_head, con, nodes);
     }
@@ -171,7 +176,7 @@ add_to_focus_head:
  *
  */
 void con_attach(Con *con, Con *parent, bool ignore_focus) {
-    _con_attach(con, parent, NULL, ignore_focus);
+    _con_attach(con, parent, NULL, ignore_focus, false);
 }
 
 /*
@@ -946,7 +951,7 @@ void con_disable_fullscreen(Con *con) {
     con_set_fullscreen_mode(con, CF_NONE);
 }
 
-static bool _con_move_to_con(Con *con, Con *target, bool behind_focused, bool fix_coordinates, bool dont_warp, bool ignore_focus) {
+bool _con_move_to_con(Con *con, Con *target, bool behind_focused, bool fix_coordinates, bool dont_warp, bool ignore_focus, bool insert_before) {
     Con *orig_target = target;
 
     /* Prevent moving if this would violate the fullscreen focus restrictions. */
@@ -1052,7 +1057,7 @@ static bool _con_move_to_con(Con *con, Con *target, bool behind_focused, bool fi
     /* 4: re-attach the con to the parent of this focused container */
     Con *parent = con->parent;
     con_detach(con);
-    _con_attach(con, target, behind_focused ? NULL : orig_target, !behind_focused);
+    _con_attach(con, target, behind_focused ? NULL : orig_target, !behind_focused, insert_before);
 
     /* 5: fix the percentages */
     con_fix_percent(parent);
@@ -1137,6 +1142,20 @@ static bool _con_move_to_con(Con *con, Con *target, bool behind_focused, bool fi
 }
 
 /*
+ * Moves a container to the side of a target container. This makes the the
+ * container and its target the only two children of a split container with
+ * appropriate layout.
+ *
+ */
+void con_move_to_side_of_con(Con *con, Con *target, direction_t direction) {
+    DLOG("Moving container to side of target: con = %p, target = %p, direction = %d\n", con, target, direction);
+
+    tree_split(target, (direction == D_LEFT || direction == D_RIGHT) ? HORIZ : VERT);
+    _con_move_to_con(con, target, false, false, false, false, direction == D_LEFT || direction == D_UP);
+    tree_flatten(croot);
+}
+
+/*
  * Moves the given container to the given mark.
  *
  */
@@ -1173,7 +1192,7 @@ bool con_move_to_mark(Con *con, const char *mark) {
         return false;
     }
 
-    return _con_move_to_con(con, target, false, true, false, false);
+    return _con_move_to_con(con, target, false, true, false, false, false);
 }
 
 /*
@@ -1206,7 +1225,7 @@ void con_move_to_workspace(Con *con, Con *workspace, bool fix_coordinates, bool 
     }
 
     Con *target = con_descend_focused(workspace);
-    _con_move_to_con(con, target, true, fix_coordinates, dont_warp, ignore_focus);
+    _con_move_to_con(con, target, true, fix_coordinates, dont_warp, ignore_focus, false);
 }
 
 /*

--- a/src/con.c
+++ b/src/con.c
@@ -532,9 +532,10 @@ bool con_inside_focused(Con *con) {
  */
 Con *con_by_window_id(xcb_window_t window) {
     Con *con;
-    TAILQ_FOREACH(con, &all_cons, all_cons)
-    if (con->window != NULL && con->window->id == window)
-        return con;
+    TAILQ_FOREACH(con, &all_cons, all_cons) {
+        if (con->window != NULL && con->window->id == window)
+            return con;
+    }
     return NULL;
 }
 
@@ -545,9 +546,10 @@ Con *con_by_window_id(xcb_window_t window) {
  */
 Con *con_by_frame_id(xcb_window_t frame) {
     Con *con;
-    TAILQ_FOREACH(con, &all_cons, all_cons)
-    if (con->frame.id == frame)
-        return con;
+    TAILQ_FOREACH(con, &all_cons, all_cons) {
+        if (con->frame.id == frame)
+            return con;
+    }
     return NULL;
 }
 

--- a/src/move.c
+++ b/src/move.c
@@ -9,15 +9,14 @@
  */
 #include "all.h"
 
-typedef enum { BEFORE,
-               AFTER } position_t;
-
 /*
  * This function detaches 'con' from its parent and inserts it either before or
  * after 'target'.
  *
+ * TODO refactor me into con.c
+ *
  */
-static void insert_con_into(Con *con, Con *target, position_t position) {
+void insert_con_into(Con *con, Con *target, position_t position) {
     Con *parent = target->parent;
     /* We need to preserve the old con->parent. While it might still be used to
      * insert the entry before/after it, we call the on_remove_child callback

--- a/src/move.c
+++ b/src/move.c
@@ -9,12 +9,15 @@
  */
 #include "all.h"
 
+typedef enum { BEFORE,
+               AFTER } position_t;
+
 /*
  * This function detaches 'con' from its parent and inserts it either before or
  * after 'target'.
  *
  */
-void insert_con_into(Con *con, Con *target, position_t position) {
+static void insert_con_into(Con *con, Con *target, position_t position) {
     Con *parent = target->parent;
     /* We need to preserve the old con->parent. While it might still be used to
      * insert the entry before/after it, we call the on_remove_child callback

--- a/src/move.c
+++ b/src/move.c
@@ -9,15 +9,12 @@
  */
 #include "all.h"
 
-typedef enum { BEFORE,
-               AFTER } position_t;
-
 /*
  * This function detaches 'con' from its parent and inserts it either before or
  * after 'target'.
  *
  */
-static void insert_con_into(Con *con, Con *target, position_t position) {
+void insert_con_into(Con *con, Con *target, position_t position) {
     Con *parent = target->parent;
     /* We need to preserve the old con->parent. While it might still be used to
      * insert the entry before/after it, we call the on_remove_child callback

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -126,7 +126,7 @@ static xcb_window_t create_drop_indicator(Rect rect) {
  *
  */
 void tiling_drag(Con *con, xcb_button_press_event_t *event) {
-    DLOG("con = %p\n", con);
+    DLOG("Start dragging tiled container: con = %p\n", con);
 
     /* Don't change focus while dragging. */
     x_mask_event_mask(~XCB_EVENT_MASK_ENTER_WINDOW);

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -19,7 +19,8 @@
 static Con *find_drop_target(uint32_t x, uint32_t y) {
     Con *con;
     TAILQ_FOREACH(con, &all_cons, all_cons) {
-        if (con->window != NULL && rect_contains(con->rect, x, y) &&
+        if (rect_contains(con->rect, x, y) &&
+            con_has_managed_window(con) &&
             !con_is_floating(con) &&
             workspace_is_visible(con_get_workspace(con)) &&
             !con_is_hidden(con))

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -1,0 +1,157 @@
+#undef I3__FILE__
+#define I3__FILE__ "tiling_drag.c"
+/*
+ * vim:ts=4:sw=4:expandtab
+ *
+ * i3 - an improved dynamic tiling window manager
+ * © 2009 Michael Stapelberg and contributors (see also: LICENSE)
+ *
+ * tiling_drag.c: Reposition tiled windows by dragging.
+ *
+ */
+#include "all.h"
+
+/*
+ * Returns the leaf container at the given coordinates or NULL if no such
+ * container exists.
+ *
+ */
+static Con *con_by_coordinates(uint32_t x, uint32_t y) {
+    Con *con;
+    TAILQ_FOREACH(con, &all_cons, all_cons)
+    if (con->window != NULL && rect_contains(con->rect, x, y))
+        return con;
+    return NULL;
+}
+
+struct callback_params {
+    xcb_window_t indicator;
+    Con **target;
+    direction_t *direction;
+};
+
+/*
+ * The callback that is executed on every mouse move while dragging. On each
+ * invocation we determin the drop target and the direction in which to insert
+ * the dragged container. The indicator window is updated to show the new
+ * position of the dragged container. The target container and direction are
+ * passed out using the callback params.
+ *
+ */
+DRAGGING_CB(drag_callback) {
+    const struct callback_params *params = extra;
+
+    Con *target = con_by_coordinates(new_x, new_y);
+    direction_t direction;
+
+    DLOG("new x = %d, y = %d, con = %p, target = %p\n", new_x, new_y, con, target);
+    if (target == NULL)
+        return;
+
+    /* If the target is the dragged container itself then we want to highlight
+     * the whole container. Otherwise we determine the direction of the nearest
+     * border and highlight only that half of the target container.
+     *
+     * TODO(MForster): Support dropping on containers with tabbed or stacked
+     * layout as well as on empty outputs.
+     */
+    Rect rect = target->rect;
+    if (target != con) {
+        uint32_t d_left = new_x - rect.x;
+        uint32_t d_top = new_y - rect.y;
+        uint32_t d_right = rect.x + rect.width - new_x;
+        uint32_t d_bottom = rect.y + rect.height - new_y;
+        uint32_t d_min = min(min(d_left, d_right), min(d_top, d_bottom));
+
+        if (d_left == d_min) {
+            rect.width /= 2;
+            direction = D_LEFT;
+        } else if (d_top == d_min) {
+            rect.height /= 2;
+            direction = D_UP;
+        } else if (d_right == d_min) {
+            /* This is done in three steps to get symmetric rounding behavior
+             * with the first two cases. */
+            rect.x += rect.width;
+            rect.width /= 2;
+            rect.x -= rect.width;
+            direction = D_RIGHT;
+        } else if (d_bottom == d_min) {
+            /* This is done in three steps to get symmetric rounding behavior
+             * with the first two cases. */
+            rect.y += rect.height;
+            rect.height /= 2;
+            rect.y -= rect.height;
+            direction = D_DOWN;
+        }
+    }
+
+    xcb_configure_window(conn, params->indicator,
+                         XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
+                         &(rect.x));
+    xcb_flush(conn);
+
+    *(params->target) = target;
+    *(params->direction) = direction;
+}
+
+/*
+ * Returns a new drop indicator window with the given initial coordinates.
+ *
+ */
+static xcb_window_t create_drop_indicator(Rect rect) {
+    uint32_t mask = 0;
+    uint32_t values[2];
+
+    mask = XCB_CW_BACK_PIXEL;
+    values[0] = config.client.focused.indicator.colorpixel;
+
+    mask |= XCB_CW_OVERRIDE_REDIRECT;
+    values[1] = 1;
+
+    xcb_window_t indicator = create_window(conn, rect, XCB_COPY_FROM_PARENT, XCB_COPY_FROM_PARENT,
+                                           XCB_WINDOW_CLASS_INPUT_OUTPUT, XCURSOR_CURSOR_MOVE, true, mask, values);
+    xcb_circulate_window(conn, XCB_CIRCULATE_RAISE_LOWEST, indicator);
+    xcb_flush(conn);
+
+    return indicator;
+}
+
+/*
+ * Initiates a mouse drag operation on a tiled window.
+ *
+ */
+void tiling_drag(Con *con, xcb_button_press_event_t *event) {
+    DLOG("con = %p\n", con);
+
+    /* Don't change focus while dragging. */
+    x_mask_event_mask(~XCB_EVENT_MASK_ENTER_WINDOW);
+    xcb_flush(conn);
+
+    /* Indicate drop location while dragging. This blocks until the drag is completed. */
+    Con *target;
+    direction_t direction;
+    const struct callback_params params = {create_drop_indicator(con->rect), &target, &direction};
+
+    drag_result_t drag_result = drag_pointer(con, event, XCB_NONE, BORDER_TOP, XCURSOR_CURSOR_MOVE, drag_callback, &params);
+
+    /* Dragging is done. We don't need the indicator window any more. */
+    xcb_destroy_window(conn, params.indicator);
+    xcb_flush(conn);
+
+    /* Move the container to the drop position. */
+    if (drag_result != DRAG_REVERT && target != NULL && target != con) {
+        orientation_t orientation = (direction == D_LEFT || direction == D_RIGHT) ? HORIZ : VERT;
+        position_t position = (direction == D_LEFT || direction == D_UP) ? BEFORE : AFTER;
+
+        DLOG("Moving dragged container: target = %p, orientation = %d, position = %d\n", target, orientation, position);
+
+        /* TODO(MForster): We shouldn't split unconditionally. This creates
+         * unnecessary chains of split containers. But for now splitting means
+         * that we don't have to deal with percentages. */
+        tree_split(target, orientation);
+
+        insert_con_into(con, target, position);
+        tree_render();
+    }
+}

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -114,7 +114,10 @@ static xcb_window_t create_drop_indicator(Rect rect) {
     values[1] = 1;
 
     xcb_window_t indicator = create_window(conn, rect, XCB_COPY_FROM_PARENT, XCB_COPY_FROM_PARENT,
-                                           XCB_WINDOW_CLASS_INPUT_OUTPUT, XCURSOR_CURSOR_MOVE, true, mask, values);
+                                           XCB_WINDOW_CLASS_INPUT_OUTPUT, XCURSOR_CURSOR_MOVE, false, mask, values);
+    /* Change the window class to "i3-drag", so that it can be matched in a
+     * compositor configuration. Note that the class needs to be changed before
+     * mapping the window. */
     xcb_change_property(conn,
                         XCB_PROP_MODE_REPLACE,
                         indicator,
@@ -123,6 +126,7 @@ static xcb_window_t create_drop_indicator(Rect rect) {
                         8,
                         (strlen("i3-drag") + 1) * 2,
                         "i3-drag\0i3-drag\0");
+    xcb_map_window(conn, indicator);
     xcb_circulate_window(conn, XCB_CIRCULATE_RAISE_LOWEST, indicator);
     xcb_flush(conn);
 

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -18,9 +18,10 @@
  */
 static Con *con_by_coordinates(uint32_t x, uint32_t y) {
     Con *con;
-    TAILQ_FOREACH(con, &all_cons, all_cons)
-    if (con->window != NULL && rect_contains(con->rect, x, y))
-        return con;
+    TAILQ_FOREACH(con, &all_cons, all_cons) {
+        if (con->window != NULL && rect_contains(con->rect, x, y))
+            return con;
+    }
     return NULL;
 }
 

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -115,6 +115,14 @@ static xcb_window_t create_drop_indicator(Rect rect) {
 
     xcb_window_t indicator = create_window(conn, rect, XCB_COPY_FROM_PARENT, XCB_COPY_FROM_PARENT,
                                            XCB_WINDOW_CLASS_INPUT_OUTPUT, XCURSOR_CURSOR_MOVE, true, mask, values);
+    xcb_change_property(conn,
+                        XCB_PROP_MODE_REPLACE,
+                        indicator,
+                        XCB_ATOM_WM_CLASS,
+                        XCB_ATOM_STRING,
+                        8,
+                        (strlen("i3-drag") + 1) * 2,
+                        "i3-drag\0i3-drag\0");
     xcb_circulate_window(conn, XCB_CIRCULATE_RAISE_LOWEST, indicator);
     xcb_flush(conn);
 

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -122,6 +122,46 @@ static xcb_window_t create_drop_indicator(Rect rect) {
 }
 
 /*
+ * Moves the dropped container to its new position. This makes the the container
+ * and its target the only two children of a split container with appropriate
+ * layout. If the parent container of the target has correct layout and no
+ * additional children, then no new split container is created.
+ *
+ */
+static void drop_con(Con *con, Con *target, direction_t direction) {
+    DLOG("Dropping container: con = %p, target = %p, direction = %d\n", con, target, direction);
+
+    /* Split the target's parent if we need to. */
+    orientation_t orientation = (direction == D_LEFT || direction == D_RIGHT) ? HORIZ : VERT;
+    if (con_orientation(target->parent) != orientation || con_num_children(target->parent) > 1) {
+        tree_split(target, orientation);
+    }
+
+    /* Detach the container from its old parent. */
+    Con *old_parent = con->parent;
+    Con *parent = target->parent;
+
+    con_detach(con);
+    con_fix_percent(con->parent);
+
+    /** Attach the container to the target's parent. */
+    con->parent = parent;
+    con->percent = target->percent = .5;
+
+    if (direction == D_LEFT || direction == D_UP) {
+        TAILQ_INSERT_BEFORE(target, con, nodes);
+        TAILQ_INSERT_HEAD(&(parent->focus_head), con, focused);
+    } else {
+        TAILQ_INSERT_AFTER(&(parent->nodes_head), target, con, nodes);
+        TAILQ_INSERT_HEAD(&(parent->focus_head), con, focused);
+    }
+
+    /* Clean up. */
+    CALL(old_parent, on_remove_child);
+    tree_flatten(croot);
+}
+
+/*
  * Initiates a mouse drag operation on a tiled window.
  *
  */
@@ -145,17 +185,7 @@ void tiling_drag(Con *con, xcb_button_press_event_t *event) {
 
     /* Move the container to the drop position. */
     if (drag_result != DRAG_REVERT && target != NULL && target != con) {
-        orientation_t orientation = (direction == D_LEFT || direction == D_RIGHT) ? HORIZ : VERT;
-        position_t position = (direction == D_LEFT || direction == D_UP) ? BEFORE : AFTER;
-
-        DLOG("Moving dragged container: target = %p, orientation = %d, position = %d\n", target, orientation, position);
-
-        /* TODO(MForster): We shouldn't split unconditionally. This creates
-         * unnecessary chains of split containers. But for now splitting means
-         * that we don't have to deal with percentages. */
-        tree_split(target, orientation);
-
-        insert_con_into(con, target, position);
+        drop_con(con, target, direction);
         tree_render();
     }
 }

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -42,7 +42,7 @@ DRAGGING_CB(drag_callback) {
     const struct callback_params *params = extra;
 
     Con *target = con_by_coordinates(new_x, new_y);
-    direction_t direction;
+    direction_t direction = 0;
 
     DLOG("new x = %d, y = %d, con = %p, target = %p\n", new_x, new_y, con, target);
     if (target == NULL)

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -12,14 +12,17 @@
 #include "all.h"
 
 /*
- * Returns the leaf container at the given coordinates or NULL if no such
- * container exists.
+ * Returns the visible leaf container at the given coordinates or NULL if no
+ * such container exists.
  *
  */
-static Con *con_by_coordinates(uint32_t x, uint32_t y) {
+static Con *find_drop_target(uint32_t x, uint32_t y) {
     Con *con;
     TAILQ_FOREACH(con, &all_cons, all_cons) {
-        if (con->window != NULL && rect_contains(con->rect, x, y))
+        if (con->window != NULL && rect_contains(con->rect, x, y) &&
+            con->floating < FLOATING_AUTO_ON &&
+            workspace_is_visible(con_get_workspace(con)) &&
+            !con_is_hidden(con))
             return con;
     }
     return NULL;
@@ -42,7 +45,7 @@ struct callback_params {
 DRAGGING_CB(drag_callback) {
     const struct callback_params *params = extra;
 
-    Con *target = con_by_coordinates(new_x, new_y);
+    Con *target = find_drop_target(new_x, new_y);
     direction_t direction = 0;
 
     DLOG("new x = %d, y = %d, con = %p, target = %p\n", new_x, new_y, con, target);

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -20,7 +20,7 @@ static Con *find_drop_target(uint32_t x, uint32_t y) {
     Con *con;
     TAILQ_FOREACH(con, &all_cons, all_cons) {
         if (con->window != NULL && rect_contains(con->rect, x, y) &&
-            con->floating < FLOATING_AUTO_ON &&
+            !con_is_floating(con) &&
             workspace_is_visible(con_get_workspace(con)) &&
             !con_is_hidden(con))
             return con;

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -129,7 +129,7 @@ void tiling_drag(Con *con, xcb_button_press_event_t *event) {
     xcb_flush(conn);
 
     /* Indicate drop location while dragging. This blocks until the drag is completed. */
-    Con *target;
+    Con *target = NULL;
     direction_t direction;
     const struct callback_params params = {create_drop_indicator(con->rect), &target, &direction};
 


### PR DESCRIPTION
A continuation of #2178 

TODO

- [ ] Support stacks and tabs
- [x] Don't always create new splits
- [ ] Drag onto the root window
- [x] Drop indicator for inner/outer regions
- [x] Implement outer region drop
- [ ] Initiate tiling drag from titlebar
- [ ] Emit move event properly on tiling drop
- [ ] Refactor `insert_con_into()` into con.c
- [ ] Configure color of drop indicator
- [ ] Bug: i3 crashes if a window closes while the dragging is indicating to drop it onto that window.
- [ ] Tests