### PR TITLE
Added missing cases for workspace event

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -696,9 +696,9 @@ if ($is_event) {
 
 This event consists of a single serialized map containing a property
 +change (string)+ which indicates the type of the change ("focus", "init",
-"empty", "urgent"). A +current (object)+ property will be present with the
-affected workspace whenever the type of event affects a workspace (otherwise,
-it will be +null).
+"empty", "urgent", "reload", "rename", "restored"). A +current (object)+
+property will be present with the affected workspace whenever the type of event
+affects a workspace (otherwise, it will be +null).
 
 When the change is "focus", an +old (object)+ property will be present with the
 previous workspace.  When the first switch occurs (when i3 focuses the


### PR DESCRIPTION
The possible values "rename", "reload" and "restored" of the property
'change' from the workspace event were missing in the ipc documentation.
Because no events of those types contain an old workspace, this was trivial.