### PR TITLE
Copy the entire window content on Expose events.

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -614,12 +614,9 @@ static void handle_expose_event(xcb_expose_event_t *event) {
     }
 
     /* Since we render to our surface on every change anyways, expose events
-     * only tell us that the X server lost (parts of) the window contents. We
-     * can handle that by copying the appropriate part from our surface to the
-     * window. */
+     * only tell us that the X server lost (parts of) the window contents. */
     draw_util_copy_surface(&(parent->frame_buffer), &(parent->frame),
-                           event->x, event->y, event->x, event->y,
-                           event->width, event->height);
+                           0, 0, 0, 0, parent->rect.width, parent->rect.height);
     xcb_flush(conn);
     return;
 }


### PR DESCRIPTION
With commit d58dbc3 we started ignoring Expose events in a sequence
except for the last one. Since we only copied the affected part of
the window in the Expose event handler, this caused incorrectly
rendered window decorations.

Instead of reverting to the old behavior, we now copy the entire window
content on this single, last event with the following rationale:
- It's cheaper to copy a larger chunk once than multiple smaller
  chunks doing one server roundtrip each.
- That's how we do it when rendering out decoration on decoration
  changes as well.

fixes #2683