### PR TITLE
i3bar: accept 'primary' for output config option

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1378,7 +1378,7 @@ directive multiple times.
 
 *Syntax*:
 ---------------
-output <output>
+output primary|<output>
 ---------------
 
 *Example*:
@@ -1400,7 +1400,19 @@ bar {
         statusline #ffffff
     }
 }
+
+# show bar on the primary monitor and on HDMI2
+bar {
+    output primary
+    output HDMI2
+    status_command i3status
+}
+
 -------------------------------
+Note that you might not have a primary output configured yet. To do so, run:
+-------------------------
+xrandr --output <output> --primary
+-------------------------
 
 === Tray output
 

--- a/i3bar/src/ipc.c
+++ b/i3bar/src/ipc.c
@@ -63,12 +63,18 @@ void got_subscribe_reply(char *reply) {
  *
  */
 void got_output_reply(char *reply) {
+    DLOG("Clearing old output configuration...\n");
+    i3_output *o_walk;
+    SLIST_FOREACH(o_walk, outputs, slist) {
+        destroy_window(o_walk);
+    }
+    FREE_SLIST(outputs, i3_output);
+
     DLOG("Parsing outputs JSON...\n");
     parse_outputs_json(reply);
     DLOG("Reconfiguring windows...\n");
     reconfig_windows(false);
 
-    i3_output *o_walk;
     SLIST_FOREACH(o_walk, outputs, slist) {
         kick_tray_clients(o_walk);
     }

--- a/i3bar/src/outputs.c
+++ b/i3bar/src/outputs.c
@@ -189,11 +189,12 @@ static int outputs_end_map_cb(void *params_) {
     if (config.num_outputs > 0) {
         bool handle_output = false;
         for (int c = 0; c < config.num_outputs; c++) {
-            if (strcasecmp(params->outputs_walk->name, config.outputs[c]) != 0)
-                continue;
-
-            handle_output = true;
-            break;
+            if (strcasecmp(params->outputs_walk->name, config.outputs[c]) == 0 ||
+                    (strcasecmp(config.outputs[c], "primary") == 0 &&
+                     params->outputs_walk->primary)) {
+                handle_output = true;
+                break;
+            }
         }
         if (!handle_output) {
             DLOG("Ignoring output \"%s\", not configured to handle it.\n",


### PR DESCRIPTION
This adds the previously adressed but unresolved feature to accept 'primary' as output option in the i3bar config.

fixes #2311 
@Airblader @acrisci 