### PR TITLE
add title_vertical_margin configuration

### DIFF
--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -57,6 +57,7 @@ CFGFUN(force_display_urgency_hint, const long duration_ms);
 CFGFUN(focus_on_window_activation, const char *mode);
 CFGFUN(show_marks, const char *value);
 CFGFUN(hide_edge_borders, const char *borders);
+CFGFUN(title_vertical_margin, const long margin_height);
 CFGFUN(assign, const char *workspace);
 CFGFUN(no_focus);
 CFGFUN(ipc_socket, const char *path);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -130,6 +130,11 @@ struct Config {
      * By default, this is disabled. */
     hide_edge_borders_mode_t hide_edge_borders;
 
+    /** The amount of vertical buffer ("margin") to include when calculating the
+     * title bar height for a contianer; this is added to the determined font
+     * height. */
+    int title_vertical_margin;
+
     /** By default, a workspace bar is drawn at the bottom of the screen.
      * If you want to have a more fancy bar, it is recommended to replace
      * the whole bar by dzen2, for example using the i3-wsbar script which

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -30,6 +30,7 @@ state INITIAL:
   'workspace_layout'                       -> WORKSPACE_LAYOUT
   windowtype = 'new_window', 'new_float'   -> NEW_WINDOW
   'hide_edge_borders'                      -> HIDE_EDGE_BORDERS
+  'title_vertical_margin'                  -> TITLE_VERTICAL_MARGIN
   'for_window'                             -> FOR_WINDOW
   'assign'                                 -> ASSIGN
   'no_focus'                               -> NO_FOCUS
@@ -130,6 +131,11 @@ state HIDE_EDGE_BORDERS:
       -> call cfg_hide_edge_borders($hide_borders)
   hide_borders = '1', 'yes', 'true', 'on', 'enable', 'active'
       -> call cfg_hide_edge_borders($hide_borders)
+
+# title_vertical_margin <margin_height>
+state TITLE_VERTICAL_MARGIN:
+  margin_height = number
+      -> call cfg_title_vertical_margin(&margin_height)
 
 # for_window <criteria> command
 state FOR_WINDOW:

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -245,6 +245,10 @@ CFGFUN(hide_edge_borders, const char *borders) {
         config.hide_edge_borders = HEBM_NONE;
 }
 
+CFGFUN(title_vertical_margin, const long margin_height) {
+    config.title_vertical_margin = logical_px(margin_height);
+}
+
 CFGFUN(focus_follows_mouse, const char *value) {
     config.disable_focus_follows_mouse = !eval_boolstr(value);
 }

--- a/src/render.c
+++ b/src/render.c
@@ -23,7 +23,7 @@ static void render_con_dockarea(Con *con, Con *child, render_params *p);
  * Returns the height for the decorations
  */
 int render_deco_height(void) {
-    int deco_height = config.font.height + 4;
+    int deco_height = config.font.height + (config.title_vertical_margin > 0 ? config.title_vertical_margin : 4);
     if (config.font.height & 0x01)
         ++deco_height;
     return deco_height;


### PR DESCRIPTION
for #2734, allows to specify the additional vertical margin over the font height used when rendering titlebars

I'm sure this will need work before, if ever, it goes in.  beyond just the concept, these need consideration:
- [ ] userguide update
- [ ] parser tests
- [ ] review of config parser state modifications
- [ ] overflow/upper limit on titlebar height
