### PR TITLE
Fix changing of root workspace layout from stacked/tabbed

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -1639,12 +1639,14 @@ void con_set_layout(Con *con, layout_t layout) {
      * whole workspace into stacked/tabbed mode. To do this and still allow
      * intuitive operations (like level-up and then opening a new window), we
      * need to create a new split container. */
-    if (con->type == CT_WORKSPACE &&
-        (layout == L_STACKED || layout == L_TABBED)) {
+    if (con->type == CT_WORKSPACE) {
         if (con_num_children(con) == 0) {
-            DLOG("Setting workspace_layout to %d\n", layout);
-            con->workspace_layout = layout;
-        } else {
+            layout_t ws_layout = (layout == L_STACKED || layout == L_TABBED) ? layout : L_DEFAULT;
+            DLOG("Setting workspace_layout to %d\n", ws_layout);
+            con->workspace_layout = ws_layout;
+            DLOG("Setting layout to %d\n", layout);
+            con->layout = layout;
+        } else if (layout == L_STACKED || layout == L_TABBED) {
             DLOG("Creating new split container\n");
             /* 1: create a new split container */
             Con *new = con_new(NULL, NULL);

--- a/src/tree.c
+++ b/src/tree.c
@@ -383,7 +383,11 @@ void tree_split(Con *con, orientation_t orientation) {
 
     if (con->type == CT_WORKSPACE) {
         if (con_num_children(con) < 2) {
-            DLOG("Just changing orientation of workspace\n");
+            if (con_num_children(con) == 0) {
+                DLOG("Changing workspace_layout to L_DEFAULT\n");
+                con->workspace_layout = L_DEFAULT;
+            }
+            DLOG("Changing orientation of workspace\n");
             con->layout = (orientation == HORIZ) ? L_SPLITH : L_SPLITV;
             return;
         } else {

--- a/testcases/t/167-workspace_layout.t
+++ b/testcases/t/167-workspace_layout.t
@@ -145,6 +145,237 @@ is($x->input_focus, $second->id, 'second window focused');
 ok(@content == 1, 'one con at workspace level');
 is($content[0]->{layout}, 'stacked', 'layout stacked');
 
+#####################################################################
+# 8: when the workspace is empty check that its layout can be changed
+# from stacked to horizontal split using the 'layout splith' command.
+#####################################################################
+
+$tmp = fresh_workspace;
+
+cmd 'layout stacked';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+is($content[0]->{layout}, 'stacked', 'layout stacked');
+
+cmd '[id="' . $first->id . '"] kill';
+cmd '[id="' . $second->id . '"] kill';
+sync_with_i3;
+
+ok(@{get_ws_content($tmp)} == 0, 'workspace is empty');
+
+cmd 'layout splith';
+$first = open_window;
+$second = open_window;
+@content = @{get_ws_content($tmp)};
+ok(@content == 2, 'two containers opened');
+isnt($content[0]->{layout}, 'stacked', 'layout not stacked');
+isnt($content[1]->{layout}, 'stacked', 'layout not stacked');
+
+#####################################################################
+# 9: when the workspace is empty check that its layout can be changed
+# from stacked to vertical split using the 'layout splitv' command.
+#####################################################################
+
+$tmp = fresh_workspace;
+
+cmd 'layout stacked';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+is($content[0]->{layout}, 'stacked', 'layout stacked');
+
+cmd '[id="' . $first->id . '"] kill';
+cmd '[id="' . $second->id . '"] kill';
+sync_with_i3;
+
+ok(@{get_ws_content($tmp)} == 0, 'workspace is empty');
+
+cmd 'layout splitv';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+ok(@content == 2, 'two containers opened');
+isnt($content[0]->{layout}, 'stacked', 'layout not stacked');
+isnt($content[1]->{layout}, 'stacked', 'layout not stacked');
+
+#####################################################################
+# 10: when the workspace is empty check that its layout can be changed
+# from tabbed to horizontal split using the 'layout splith' command.
+#####################################################################
+
+$tmp = fresh_workspace;
+
+cmd 'layout tabbed';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+is($content[0]->{layout}, 'tabbed', 'layout tabbed');
+
+cmd '[id="' . $first->id . '"] kill';
+cmd '[id="' . $second->id . '"] kill';
+sync_with_i3;
+
+ok(@{get_ws_content($tmp)} == 0, 'workspace is empty');
+
+cmd 'layout splith';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+ok(@content == 2, 'two containers opened');
+isnt($content[0]->{layout}, 'tabbed', 'layout not tabbed');
+isnt($content[1]->{layout}, 'tabbed', 'layout not tabbed');
+
+#####################################################################
+# 11: when the workspace is empty check that its layout can be changed
+# from tabbed to vertical split using the 'layout splitv' command.
+#####################################################################
+
+$tmp = fresh_workspace;
+
+cmd 'layout tabbed';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+is($content[0]->{layout}, 'tabbed', 'layout tabbed');
+
+cmd '[id="' . $first->id . '"] kill';
+cmd '[id="' . $second->id . '"] kill';
+sync_with_i3;
+
+ok(@{get_ws_content($tmp)} == 0, 'workspace is empty');
+
+cmd 'layout splitv';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+ok(@content == 2, 'two containers opened');
+isnt($content[0]->{layout}, 'tabbed', 'layout not tabbed');
+isnt($content[1]->{layout}, 'tabbed', 'layout not tabbed');
+
+#####################################################################
+# 12: when the workspace is empty check that its layout can be changed
+# from stacked to horizontal split using the 'split horizontal' command.
+#####################################################################
+
+$tmp = fresh_workspace;
+
+cmd 'layout stacked';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+is($content[0]->{layout}, 'stacked', 'layout stacked');
+
+cmd '[id="' . $first->id . '"] kill';
+cmd '[id="' . $second->id . '"] kill';
+sync_with_i3;
+
+ok(@{get_ws_content($tmp)} == 0, 'workspace is empty');
+
+cmd 'split horizontal';
+$first = open_window;
+$second = open_window;
+@content = @{get_ws_content($tmp)};
+ok(@content == 2, 'two containers opened');
+isnt($content[0]->{layout}, 'stacked', 'layout not stacked');
+isnt($content[1]->{layout}, 'stacked', 'layout not stacked');
+
+#####################################################################
+# 13: when the workspace is empty check that its layout can be changed
+# from stacked to vertical split using the 'split vertical' command.
+#####################################################################
+
+$tmp = fresh_workspace;
+
+cmd 'layout stacked';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+is($content[0]->{layout}, 'stacked', 'layout stacked');
+
+cmd '[id="' . $first->id . '"] kill';
+cmd '[id="' . $second->id . '"] kill';
+sync_with_i3;
+
+ok(@{get_ws_content($tmp)} == 0, 'workspace is empty');
+
+cmd 'split vertical';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+ok(@content == 2, 'two containers opened');
+isnt($content[0]->{layout}, 'stacked', 'layout not stacked');
+isnt($content[1]->{layout}, 'stacked', 'layout not stacked');
+
+#####################################################################
+# 14: when the workspace is empty check that its layout can be changed
+# from tabbed to horizontal split using the 'split horizontal' command.
+#####################################################################
+
+$tmp = fresh_workspace;
+
+cmd 'layout tabbed';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+is($content[0]->{layout}, 'tabbed', 'layout tabbed');
+
+cmd '[id="' . $first->id . '"] kill';
+cmd '[id="' . $second->id . '"] kill';
+sync_with_i3;
+
+ok(@{get_ws_content($tmp)} == 0, 'workspace is empty');
+
+cmd 'split horizontal';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+ok(@content == 2, 'two containers opened');
+isnt($content[0]->{layout}, 'tabbed', 'layout not tabbed');
+isnt($content[1]->{layout}, 'tabbed', 'layout not tabbed');
+
+#####################################################################
+# 15: when the workspace is empty check that its layout can be changed
+# from tabbed to vertical split using the 'split vertical' command.
+#####################################################################
+
+$tmp = fresh_workspace;
+
+cmd 'layout tabbed';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+is($content[0]->{layout}, 'tabbed', 'layout tabbed');
+
+cmd '[id="' . $first->id . '"] kill';
+cmd '[id="' . $second->id . '"] kill';
+sync_with_i3;
+
+ok(@{get_ws_content($tmp)} == 0, 'workspace is empty');
+
+cmd 'split vertical';
+$first = open_window;
+$second = open_window;
+
+@content = @{get_ws_content($tmp)};
+ok(@content == 2, 'two containers opened');
+isnt($content[0]->{layout}, 'tabbed', 'layout not tabbed');
+isnt($content[1]->{layout}, 'tabbed', 'layout not tabbed');
+
+
 exit_gracefully($pid);
 
 done_testing;


### PR DESCRIPTION
Whenever the layout of an empty workspace is changed we need to update the [_workspace_layout_](https://github.com/i3/i3/blob/next/include/data.h#L681-L687) accordingly.
 
Fixes #2464. 