### PR TITLE
Query workspaces again in i3bar when an output change occured.

### DIFF
--- a/i3bar/src/ipc.c
+++ b/i3bar/src/ipc.c
@@ -79,6 +79,10 @@ void got_output_reply(char *reply) {
         kick_tray_clients(o_walk);
     }
 
+    if (!config.disable_ws) {
+        i3_send_msg(I3_IPC_MESSAGE_TYPE_GET_WORKSPACES, NULL);
+    }
+
     draw_bars(false);
 }
 


### PR DESCRIPTION
As of 2f0f8b1, i3bar will properly clean up on output change events.
However, this requires us to query the workspaces again to avoid a
display error in i3bar.

fixes #2740
fixes #2743