### PR TITLE
[WIP] Change golang ipc lib reference to one that is maintained.

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -861,7 +861,7 @@ C::
 C++::
 	* https://github.com/drmgc/i3ipcpp
 Go::
-	* https://github.com/proxypoke/i3ipc
+	* https://github.com/mdirkse/i3ipc-go
 JavaScript::
 	* https://github.com/acrisci/i3ipc-gjs
 Lua::


### PR DESCRIPTION
Hello i3 maintainers,
I recently started work on a [small golang utility for i3](https://github.com/mdirkse/i3wp) that's meant to replace a rather ugly bash script I wrote years ago. I wanted to use the IPC and the docs showed me the way to https://github.com/proxypoke/i3ipc. It seemed pretty complete until I noticed that the `version` call didn't return the `loaded_config_file_name` field. So I forked the project and created a pull request that added this field to the response.

While looking at the list of pull requests I noticed that one had been open since 2014 and [the most recent issue](https://github.com/proxypoke/i3ipc/issues/9) posed the very relevant question if the project was still maintained. As the last update is [from over 3 years ago](https://github.com/proxypoke/i3ipc/commit/de8f6bb6b583a14ca2164f0e1a8f9bea2c7e120e), I think we can safely say that the answer to that question is "no".

I propose that the i3 site changes its recommendation to [my fork](https://github.com/mdirkse/i3ipc-go) of the original library, one which I *will* maintain. The change shouldn't be made, however, before I do the following things:
- [x] Enable travisci (and get the builds green)
- [x] Update the library to reflect the latest version of the IPC data model
- [x] Fix issues reported by goreportcard.com
- [x] Add travisci, godoc and goreportcard buttons
- [x] Fix links to godoc (go.pkgdoc.org -> godoc.org)
- [x] Update docs where necessary to remove references to the old project
