### PR TITLE
Support to get the primary output

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1922,7 +1922,7 @@ output::
 ----------------------------------------------
 focus left|right|down|up
 focus parent|child|floating|tiling|mode_toggle
-focus output left|right|up|down|<output>
+focus output left|right|up|down|primary|<output>
 ----------------------------------------------
 
 *Examples*:
@@ -1944,7 +1944,16 @@ bindsym $mod+x focus output right
 
 # Focus the big output
 bindsym $mod+x focus output HDMI-2
+
+# Focus the primary output
+bindsym $mod+x focus output primary
 -------------------------------------------------
+
+-------------------------------
+Note that you might not have a primary output configured yet. To do so, run:
+-------------------------
+xrandr --output <output> --primary
+-------------------------
 
 === Moving containers
 
@@ -2162,8 +2171,8 @@ To move a container to another RandR output (addressed by names like +LVDS1+ or
 
 *Syntax*:
 ------------------------------------------------------------
-move container to output left|right|down|up|current|<output>
-move workspace to output left|right|down|up|current|<output>
+move container to output left|right|down|up|current|primary|<output>
+move workspace to output left|right|down|up|current|primary|<output>
 ------------------------------------------------------------
 
 *Examples*:
@@ -2174,7 +2183,16 @@ bindsym $mod+x move workspace to output right
 
 # Put this window on the presentation output.
 bindsym $mod+x move container to output VGA1
+
+# Put this window on the primary output.
+bindsym $mod+x move container to output primary
 --------------------------------------------------------
+
+-------------------------------
+Note that you might not have a primary output configured yet. To do so, run:
+-------------------------
+xrandr --output <output> --primary
+-------------------------
 
 === Moving containers/windows to marks
 

--- a/src/randr.c
+++ b/src/randr.c
@@ -45,10 +45,13 @@ static Output *get_output_by_id(xcb_randr_output_t id) {
  */
 Output *get_output_by_name(const char *name) {
     Output *output;
-    TAILQ_FOREACH(output, &outputs, outputs)
-    if (output->active &&
-        strcasecmp(output->name, name) == 0)
-        return output;
+    bool get_primary = (strcasecmp("primary", name) == 0);
+    TAILQ_FOREACH(output, &outputs, outputs) {
+        if ((output->primary && get_primary) ||
+            (output->active && strcasecmp(output->name, name) == 0)) {
+            return output;
+        }
+    }
 
     return NULL;
 }


### PR DESCRIPTION
This makes `primary` output available for assign or move commands.
Fix the issue #2764(https://github.com/i3/i3/issues/2764).