### PR TITLE
prevent multiple menu items per .desktop entry

### DIFF
--- a/i3-dmenu-desktop
+++ b/i3-dmenu-desktop
@@ -279,6 +279,7 @@ for my $app (keys %apps) {
         }
 
         $choices{$name} = $app;
+        next;
     }
 
     if ((scalar grep { $_ eq 'command' } @entry_types) > 0) {
@@ -310,9 +311,10 @@ for my $app (keys %apps) {
 
         # Don’t add “geany” if “Geany” is already present.
         my @keys = map { lc } keys %choices;
-        next if (scalar grep { $_ eq lc(basename($command)) } @keys) > 0;
-
-        $choices{basename($command)} = $app;
+        if (!(scalar grep { $_ eq lc(basename($command)) } @keys) > 0) {
+            $choices{basename($command)} = $app;
+        }
+        next;
     }
 
     if ((scalar grep { $_ eq 'filename' } @entry_types) > 0) {


### PR DESCRIPTION
If a .desktop entry is being added to the list of Menu items by its "Name" field, it should not be added again by its command or filename.
If it is being added by its command, it should not be added again by its filename.