### PR TITLE
docs/ipc: Fix typo

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -795,7 +795,7 @@ same as a +GET_BAR_CONFIG+ reply for the bar with the given id.
 === binding event
 
 This event consists of a single serialized map reporting on the details of a
-binding that ran a command because of user input. The +change (sring)+ field
+binding that ran a command because of user input. The +change (string)+ field
 indicates what sort of binding event was triggered (right now it will always be
 +"run"+ but may be expanded in the future).
 


### PR DESCRIPTION
This fixes a `sring` typo.