### PR TITLE
Update testsuite docs

### DIFF
--- a/docs/testsuite
+++ b/docs/testsuite
@@ -114,7 +114,18 @@ machines without a powerful video card.
 
 .Example invocation of complete-run.pl+
 ---------------------------------------
-$ cd ~/i3/testcases
+$ cd ~/i3
+
+$ autoreconf -fi
+
+$ mkdir -p build && cd build
+
+$ ../configure
+
+$ make -j8
+# output omitted because it is very long
+
+$ cd testcases
 
 $ ./complete-run.pl
 # output omitted because it is very long
@@ -159,6 +170,41 @@ $ ./complete-run.pl --parallel=1 --keep-xserver-output
 
 This will show the output of Xephyr, which is the X server implementation we
 use for testing.
+
+===== make command: make check
+Make check runs the i3 testsuite.
+You can still use ./testcases/complete-run.pl to get the interactive progress output.
+
+.Example invocation of make check+
+---------------------------------------
+$ cd ~/i3
+
+$ autoreconf -fi
+
+$ mkdir -p build && cd build
+
+$ ../configure
+
+$ make -j8
+# output omitted because it is very long
+
+$ make check
+# output omitted because it is very long
+PASS: testcases/complete-run.pl
+============================================================================
+Testsuite summary for i3 4.13
+============================================================================
+# TOTAL: 1
+# PASS:  1
+# SKIP:  0
+# XFAIL: 0
+# FAIL:  0
+# XPASS: 0
+# ERROR: 0
+============================================================================
+
+$ less test-suite.log
+----------------------------------------
 
 ==== Coverage testing
 


### PR DESCRIPTION
After moved to autotools, the method to run the i3 testsuite is changed.
Update the testsuite document to reflect the change.