### PR TITLE
Fix the i3 crash caused by mark + restart commands

### DIFF
--- a/testcases/t/267-regress-mark-restart.t
+++ b/testcases/t/267-regress-mark-restart.t
@@ -1,0 +1,30 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Regression test to check if mark and restart commands crash i3
+#
+use i3test;
+
+cmd 'open';
+cmd 'mark foo';
+
+cmd 'restart';
+
+diag('Checking if i3 still lives');
+
+does_i3_live;
+
+done_testing;


### PR DESCRIPTION
This patch fixes the issue #2511(https://github.com/i3/i3/issues/2511).

1). Memorize the marks, but only call con_mark once the container has finished parsing. (Credit: This is @Airblader's patch.)

2). Add a test case 267-regress-mark-restart.t for regression test to check if mark and restart command crash i3.