### PR TITLE
Fix manpage on configuration lookup order

### DIFF
--- a/man/i3.man
+++ b/man/i3.man
@@ -170,10 +170,10 @@ Exits i3.
 
 When starting, i3 looks for configuration files in the following order:
 
-1. ~/.config/i3/config (or $XDG_CONFIG_HOME/i3/config if set)
-2. /etc/xdg/i3/config (or $XDG_CONFIG_DIRS/i3/config if set)
-3. ~/.i3/config
-4. /etc/i3/config
+1. ~/.i3/config
+2. ~/.config/i3/config (or $XDG_CONFIG_HOME/i3/config if set)
+3. /etc/i3/config
+4. /etc/xdg/i3/config (or $XDG_CONFIG_DIRS/i3/config if set)
 
 You can specify a custom path using the -c option.
 


### PR DESCRIPTION
The lookup order stated in the i3 manpage was is contratiction to the
actual lookup order, which was introduced with commit
https://github.com/i3/i3/commit/bfa12a581915d6a3de182fa6025fce108cac8eab.
Since that commit (6.5 years ago) the "traditional" paths took precedence
over XDG_CONFIG paths.