### PR TITLE
Fix 'rename workspace to tosomething'

### DIFF
--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -274,24 +274,28 @@ state RENAME:
       -> RENAME_WORKSPACE
 
 state RENAME_WORKSPACE:
-  old_name = 'to'
+  'to'
       -> RENAME_WORKSPACE_LIKELY_TO
   old_name = word
       -> RENAME_WORKSPACE_TO
 
 state RENAME_WORKSPACE_LIKELY_TO:
-  'to'
-      -> RENAME_WORKSPACE_NEW_NAME
+  'to '
+      -> RENAME_WORKSPACE_LIKELY_TO_NEW_NAME
   new_name = word
       -> call cmd_rename_workspace(NULL, $new_name)
 
-state RENAME_WORKSPACE_TO:
-  'to'
-      -> RENAME_WORKSPACE_NEW_NAME
-
-state RENAME_WORKSPACE_NEW_NAME:
+state RENAME_WORKSPACE_LIKELY_TO_NEW_NAME:
+  new_name = string
+      -> call cmd_rename_workspace("to", $new_name)
   end
       -> call cmd_rename_workspace(NULL, "to")
+
+state RENAME_WORKSPACE_TO:
+  'to'
+      -> RENAME_WORKSPACE_TO_NEW_NAME
+
+state RENAME_WORKSPACE_TO_NEW_NAME:
   new_name = string
       -> call cmd_rename_workspace($old_name, $new_name)
 

--- a/testcases/t/117-workspace.t
+++ b/testcases/t/117-workspace.t
@@ -279,6 +279,12 @@ is(focused_ws(), 'bla', 'now on workspace bla');
 cmd 'rename workspace to to';
 ok(!workspace_exists('bla'), 'workspace bla does not exist anymore');
 is(focused_ws(), 'to', 'now on workspace to');
+cmd 'rename workspace to bla';
+ok(!workspace_exists('to'), 'workspace to does not exist anymore');
+is(focused_ws(), 'bla', 'now on workspace bla');
+cmd 'rename workspace to tosomething';
+ok(!workspace_exists('bla'), 'workspace bla does not exist anymore');
+is(focused_ws(), 'tosomething', 'now on workspace tosomething');
 
 # 6: already existing workspace
 my $result = cmd 'rename workspace qux to 11: bar';


### PR DESCRIPTION
See the issue #2802.
Revise the state machine for the 'rename workspace' command.
These scenarios are considered:
    a). 'rename workspace to to bla'
        state transitions: RENAME -> RENAME_WORKSPACE -> RENAME_WORKSPACE_LIKELY_TO -> RENAME_WORKSPACE_LIKELY_TO_NEW_NAME
    b). 'rename workspace to tosomething'
        state transitions: RENAME -> RENAME_WORKSPACE -> RENAME_WORKSPACE_LIKELY_TO
    c). 'rename workspace to to'
        state transitions: RENAME -> RENAME_WORKSPACE -> RENAME_WORKSPACE_LIKELY_TO
    d). 'rename workspace to bla'
        state transitions: RENAME -> RENAME_WORKSPACE -> RENAME_WORKSPACE_LIKELY_TO
    e). 'rename workspace bla to foo'
        state transitions: RENAME -> RENAME_WORKSPACE -> RENAME_WORKSPACE_TO -> RENAME_WORKSPACE_TO_NEW_NAME