### PR TITLE
i3-msg: Return an exit code upon missing -t arg

### DIFF
--- a/i3-msg/main.c
+++ b/i3-msg/main.c
@@ -180,6 +180,8 @@ int main(int argc, char *argv[]) {
             printf("i3-msg " I3_VERSION "\n");
             printf("i3-msg [-s <socket>] [-t <type>] <message>\n");
             return 0;
+        } else if (o == '?') {
+            exit(EXIT_FAILURE);
         }
     }
 


### PR DESCRIPTION
If getopt() returns '?' (option with a missing argument), exit the program with an error code rather than continuing the execution.

Fix the issue #2804 (https://github.com/i3/i3/issues/2804).