### PR TITLE
Fix 'Mouse binding don't work'

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -474,8 +474,7 @@ void translate_keysyms(void) {
 
             xcb_keycode_t key = button;
             bind->keycode = key;
-            ADD_TRANSLATED_KEY(key, bind->event_state_mask);
-            continue;
+            DLOG("Binding Mouse button, Keycode = %d\n", key);
         }
 
         xkb_layout_index_t group = XCB_XKB_GROUP_1;


### PR DESCRIPTION
For mouse buttons we are not considering the masks. I changed to treat it as normal key.
Currently because of the default CapsLock mask, CapsLock specialized mouse click wont have effect. 
But do we need it?