### PR TITLE
Add KDE konsole terminal fallback to i3-sensible-terminal

### DIFF
--- a/i3-sensible-terminal
+++ b/i3-sensible-terminal
@@ -8,7 +8,7 @@
 # We welcome patches that add distribution-specific mechanisms to find the
 # preferred terminal emulator. On Debian, there is the x-terminal-emulator
 # symlink for example.
-for terminal in "$TERMINAL" x-terminal-emulator urxvt rxvt termit terminator Eterm aterm uxterm xterm gnome-terminal roxterm xfce4-terminal termite lxterminal mate-terminal terminology st qterminal lilyterm tilix terminix; do
+for terminal in "$TERMINAL" x-terminal-emulator urxvt rxvt termit terminator Eterm aterm uxterm xterm gnome-terminal roxterm xfce4-terminal termite lxterminal mate-terminal terminology st qterminal lilyterm tilix terminix konsole; do
     if command -v "$terminal" > /dev/null 2>&1; then
         exec "$terminal" "$@"
     fi

--- a/man/i3-sensible-terminal.man
+++ b/man/i3-sensible-terminal.man
@@ -43,6 +43,7 @@ It tries to start one of the following (in that order):
 * lilyterm
 * tilix
 * terminix
+* konsole
 
 Please don’t complain about the order: If the user has any preference, they will
 have $TERMINAL set or modified their i3 configuration file.


### PR DESCRIPTION
Seeing GNOME and Xfce have their default terminal implementations listed as fallbacks in the `i3-sensible-terminal` wrapper script, I figured we could also add KDE's Konsole.