### PR TITLE
Move SYSCONFDIR definition to makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -215,6 +215,7 @@ asciidoc_MANS =
 endif
 
 AM_CPPFLAGS = \
+	-DSYSCONFDIR="\"$(sysconfdir)\"" \
 	-I$(top_builddir)/parser \
 	-I$(top_srcdir)/include \
 	@AX_EXTEND_SRCDIR_CPPFLAGS@

--- a/configure.ac
+++ b/configure.ac
@@ -59,8 +59,6 @@ AX_CHECK_ENABLE_DEBUG([yes], , [UNUSED_NDEBUG], [$is_release])
 
 AC_PROG_CC_C99
 
-AC_DEFINE_UNQUOTED(SYSCONFDIR, "`eval echo $sysconfdir`", [Location of system configuration files])
-
 # For strnlen() and vasprintf().
 AC_USE_SYSTEM_EXTENSIONS
 


### PR DESCRIPTION
Official autoconf docs contraindicate the use of the $sysconfdir
variable in configure.ac. For reference:

https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/Installation-Directory-Variables.html

The macro SYSCONFDIR (ordinarilly set to "/etc") is required to find
a system configuration file installed with i3. In some build setups,
this may not be defined properly in when the configure script is
compiled.

Instead, define this variable in AM_CPPFLAGS as the documentation
indicates.

fixes #2832