### PR TITLE
Ensure colors are in hex

### DIFF
--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -112,13 +112,13 @@ __attribute__((format(printf, 1, 2))) static void set_statusline_error(const cha
     struct status_block *err_block = scalloc(1, sizeof(struct status_block));
     err_block->full_text = i3string_from_utf8("Error: ");
     err_block->name = sstrdup("error");
-    err_block->color = sstrdup("red");
+    err_block->color = sstrdup("#ff0000");
     err_block->no_separator = true;
 
     struct status_block *message_block = scalloc(1, sizeof(struct status_block));
     message_block->full_text = i3string_from_utf8(message);
     message_block->name = sstrdup("error_message");
-    message_block->color = sstrdup("red");
+    message_block->color = sstrdup("#ff0000");
     message_block->no_separator = true;
 
     TAILQ_INSERT_HEAD(&statusline_head, err_block, blocks);

--- a/libi3/draw_util.c
+++ b/libi3/draw_util.c
@@ -84,6 +84,11 @@ void draw_util_surface_set_size(surface_t *surface, int width, int height) {
  *
  */
 color_t draw_util_hex_to_color(const char *color) {
+    if (strlen(color) < 6 || color[0] != '#') {
+        ELOG("Could not parse color: %s\n", color);
+        return draw_util_hex_to_color("#A9A9A9");
+    }
+
     char alpha[2];
     if (strlen(color) == strlen("#rrggbbaa")) {
         alpha[0] = color[7];


### PR DESCRIPTION
i3bar error messages violate the i3bar protocol by specifying a color name (`"red"`) instead of a hex value. This causes memory errors in `draw_util_hex_to_color()`.

See #2829 for a full discussion.