### PR TITLE
[WIP/RFC] Handle a case of a soon to be gone window calling XSetInputFocus

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -38,7 +38,7 @@ bool event_is_ignored(const int sequence, const int response_type);
  * event type.
  *
  */
-void handle_event(int type, xcb_generic_event_t *event);
+void handle_event(int type, xcb_generic_event_t* event, bool need_new_timestamp);
 
 /**
  * Sets the appropriate atoms for the property handlers after the atoms were
@@ -46,6 +46,15 @@ void handle_event(int type, xcb_generic_event_t *event);
  *
  */
 void property_handlers_init(void);
+
+/**
+ * These two functions implement an event queue, that can be used when
+ * we synchronously have to wait for a specific event in the middle of
+ * business logic, but we don't want to drop the events that are in
+ * front of it in the event queue.
+ */
+void queue_event(xcb_generic_event_t*);
+xcb_generic_event_t* pop_event();
 
 #if 0
 /**

--- a/src/ewmh.c
+++ b/src/ewmh.c
@@ -311,8 +311,8 @@ void ewmh_setup_hints(void) {
         0,                           /* border */
         XCB_WINDOW_CLASS_INPUT_ONLY, /* window class */
         XCB_COPY_FROM_PARENT,        /* visual */
-        XCB_CW_OVERRIDE_REDIRECT,
-        (uint32_t[]){1});
+        XCB_CW_EVENT_MASK | XCB_CW_OVERRIDE_REDIRECT,
+        (uint32_t[]){1, XCB_EVENT_MASK_PROPERTY_CHANGE});
     xcb_change_property(conn, XCB_PROP_MODE_REPLACE, ewmh_window, A__NET_SUPPORTING_WM_CHECK, XCB_ATOM_WINDOW, 32, 1, &ewmh_window);
     xcb_change_property(conn, XCB_PROP_MODE_REPLACE, ewmh_window, A__NET_WM_NAME, A_UTF8_STRING, 8, strlen("i3"), "i3");
     xcb_change_property(conn, XCB_PROP_MODE_REPLACE, root, A__NET_SUPPORTING_WM_CHECK, XCB_ATOM_WINDOW, 32, 1, &ewmh_window);

--- a/src/floating.c
+++ b/src/floating.c
@@ -697,7 +697,7 @@ static void xcb_drag_check_cb(EV_P_ ev_check *w, int revents) {
             case XCB_KEY_PRESS:
                 DLOG("A key was pressed during drag, reverting changes.\n");
                 dragloop->result = DRAG_REVERT;
-                handle_event(type, event);
+                handle_event(type, event, false);
                 break;
 
             case XCB_UNMAP_NOTIFY: {
@@ -713,7 +713,7 @@ static void xcb_drag_check_cb(EV_P_ ev_check *w, int revents) {
                     }
                 }
 
-                handle_event(type, event);
+                handle_event(type, event, false);
                 break;
             }
 
@@ -725,7 +725,7 @@ static void xcb_drag_check_cb(EV_P_ ev_check *w, int revents) {
 
             default:
                 DLOG("Passing to original handler\n");
-                handle_event(type, event);
+                handle_event(type, event, false);
                 break;
         }
 

--- a/testcases/t/534-setinputfocus-and-exit.t
+++ b/testcases/t/534-setinputfocus-and-exit.t
@@ -1,0 +1,49 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Test for the startup notification protocol.
+#
+
+use i3test;
+
+######################################################################
+# 1) initiate startup, create window which uses setinputfocus
+######################################################################
+
+my $first_ws = fresh_workspace;
+my $win = open_window();
+
+# This is what Emacs is doing in some cases, e.g. if you run:
+#   emacs -Q --eval '(progn (x-focus-frame nil) (kill-emacs))'
+# After this command, your i3 is completely screwed and you need your
+# mouse to get back to work, nothing to do with your keyboard
+# anymore...
+X11::XCB::set_input_focus($x, X11::XCB::INPUT_FOCUS_PARENT, $win->id, X11::XCB::TIME_CURRENT_TIME);
+# Otherwise the test is a little bit flaky.  I tried to wait for
+# FOCUS_IN event, but somehow it's not enough...
+sleep(0.2);
+is($x->input_focus, $win->id, 'focus is on the new window');
+
+######################################################################
+# 2) close the app that owns the window
+######################################################################
+
+cmd 'kill';
+wait_for_unmap($win);
+sync_with_i3;
+isnt($x->input_focus, 0, 'focus falls back to the EWMH window');
+
+done_testing;


### PR DESCRIPTION
This is a rare case happening mostly for emacs-helm users.  It
can be reproduced without any special emacs configuration using
the x-focus-frame function and then immediately quitting emacs.

The problem was that in this case emacs calls XSetInputFocus with
revert to parent setting, which afterwards at the exit of emacs causes
keyboard focus to be lost and not set to the ewmh support window.

About my proposed patch: I know it's big and disgusting, but the whole test
set runs without error and I also added a new testcase.

Actually, changing back the last_timestamp to XCB_CURRENT_TIME
around the ewmh_window focusing in x.c is enough to make the bug gone, but
according to the git log there are other problems if we use XCB_CURRENT_TIME
for ewmh_window focusing.

Therefore I have set out to fix the actual bug that is being triggered by emacs.

Why my patch grew this big, is because when I detect the unmapping event that
can trigger this bug, I have to get a new xserver timestamp.  And the only way to
do this (at least this is how openbox is doing it) is to set a property and wait for
the resulting event.  But while I'm waiting for the event, I have to queue up the
events that otherwise would be lost forever and then reapply them at the beginning
of the queue.

Another option would be to introduce a new global variable called something like
"should_we_use_current_time_for_focusing_after_unmap" and set this to true
before tree_render in handle_unmap_notify_event and set back to false afterwards.
That will be definitely a much more easy to review changeset, if you are not worried
about the additional global variable.

Another option would be, that I make the "pushbackable event queue" a separate
refactoring that implements a "look_for_specific_event_in_queue_without_popping"
function.  Once we have this refactoring, the actual bugfix changeset will be nice.

I'd like to ask for your kind input regarding this and a discussion around which way
should we go from here.