### PR TITLE
Create a new split container when switching a workspace container to split layout

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -1756,7 +1756,7 @@ void con_set_layout(Con *con, layout_t layout) {
             con->workspace_layout = ws_layout;
             DLOG("Setting layout to %d\n", layout);
             con->layout = layout;
-        } else if (layout == L_STACKED || layout == L_TABBED) {
+        } else if (layout == L_STACKED || layout == L_TABBED || layout == L_SPLITV || layout == L_SPLITH) {
             DLOG("Creating new split container\n");
             /* 1: create a new split container */
             Con *new = con_new(NULL, NULL);

--- a/src/con.c
+++ b/src/con.c
@@ -1848,6 +1848,10 @@ void con_toggle_layout(Con *con, const char *toggle_mode) {
                  * change to the opposite split layout. */
                 if (parent->layout != L_SPLITH && parent->layout != L_SPLITV) {
                     layout = parent->last_split_layout;
+                    /* In case last_split_layout was not initialized… */
+                    if (layout == L_DEFAULT) {
+                        layout = L_SPLITH;
+                    }
                 } else {
                     layout = (parent->layout == L_SPLITH) ? L_SPLITV : L_SPLITH;
                 }


### PR DESCRIPTION
The behavior before 52ce8c8 was to do it regardless of what layout we're
switching to.

Fixes #2846

Like I said in the issue thread, I need to check things out a bit more if tests are wanted, but I'm leaving this here in the meantime.