### PR TITLE
Improve error messages for incorrect config lines starting with “set”

### DIFF
--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -17,7 +17,8 @@ state INITIAL:
   end ->
   error ->
   '#'                                      -> IGNORE_LINE
-  'set'                                    -> IGNORE_LINE
+  'set '                                   -> IGNORE_LINE
+  'set	'                                  -> IGNORE_LINE
   'set_from_resource'                      -> IGNORE_LINE
   bindtype = 'bindsym', 'bindcode', 'bind' -> BINDING
   'bar'                                    -> BARBRACE

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -937,7 +937,7 @@ bool parse_file(const char *f, bool use_nagbar) {
             continue;
         }
 
-        if (strcasecmp(key, "set") == 0) {
+        if (strcasecmp(key, "set") == 0 && *value != '\0') {
             char v_key[512];
             char v_value[4096] = {'\0'};
 

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -916,6 +916,7 @@ bool parse_file(const char *f, bool use_nagbar) {
         }
 
         /* sscanf implicitly strips whitespace. */
+        value[0] = '\0';
         const bool skip_line = (sscanf(buffer, "%511s %4095[^\n]", key, value) < 1 || strlen(key) < 3);
         const bool comment = (key[0] == '#');
         value[4095] = '\n';
@@ -938,7 +939,7 @@ bool parse_file(const char *f, bool use_nagbar) {
 
         if (strcasecmp(key, "set") == 0) {
             char v_key[512];
-            char v_value[4096];
+            char v_value[4096] = {'\0'};
 
             if (sscanf(value, "%511s %4095[^\n]", v_key, v_value) < 1) {
                 ELOG("Failed to parse variable specification '%s', skipping it.\n", value);
@@ -953,9 +954,9 @@ bool parse_file(const char *f, bool use_nagbar) {
             upsert_variable(&variables, v_key, v_value);
             continue;
         } else if (strcasecmp(key, "set_from_resource") == 0) {
-            char res_name[512];
+            char res_name[512] = {'\0'};
             char v_key[512];
-            char fallback[4096];
+            char fallback[4096] = {'\0'};
 
             /* Ensure that this string is terminated. For example, a user might
              * want a variable to be empty if the resource can't be found and

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -235,7 +235,7 @@ static void next_state(const cmdp_token *token) {
  *
  */
 static const char *start_of_line(const char *walk, const char *beginning) {
-    while (*walk != '\n' && *walk != '\r' && walk >= beginning) {
+    while (walk >= beginning && *walk != '\n' && *walk != '\r') {
         walk--;
     }
 

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -446,8 +446,7 @@ hide_edge_border both
 client.focused          #4c7899 #285577 #ffffff #2e9ef4
 EOT
 
-my $expected_all_tokens = "ERROR: CONFIG: Expected one of these tokens: <end>, '#', '" . join("', '", qw(
-        set
+my $expected_all_tokens = "ERROR: CONFIG: Expected one of these tokens: <end>, '#', '" . join("', '", 'set ', 'set	', qw(
         set_from_resource
         bindsym
         bindcode


### PR DESCRIPTION
fixes #2564