### PR TITLE
i3bar: only restart child when command changed

### DIFF
--- a/i3bar/src/config.c
+++ b/i3bar/src/config.c
@@ -185,6 +185,7 @@ static int config_string_cb(void *params_, const unsigned char *val, size_t _len
 
     if (!strcmp(cur_key, "status_command")) {
         DLOG("command = %.*s\n", len, val);
+        FREE(config.command);
         sasprintf(&config.command, "%.*s", len, val);
         return 1;
     }

--- a/i3bar/src/ipc.c
+++ b/i3bar/src/ipc.c
@@ -113,7 +113,6 @@ void got_bar_config(char *reply) {
     init_colors(&(config.colors));
 
     start_child(config.command);
-    FREE(config.command);
 }
 
 /* Data structure to easily call the reply handlers later */
@@ -178,6 +177,7 @@ void got_bar_config_update(char *event) {
 
     /* update the configuration with the received settings */
     DLOG("Received bar config update \"%s\"\n", event);
+    char *old_command = sstrdup(config.command);
     bar_display_mode_t old_mode = config.hide_on_modifier;
     parse_config_json(event);
     if (old_mode != config.hide_on_modifier) {
@@ -189,9 +189,11 @@ void got_bar_config_update(char *event) {
     init_colors(&(config.colors));
 
     /* restart status command process */
-    kill_child();
-    start_child(config.command);
-    FREE(config.command);
+    if (strcmp(old_command, config.command) != 0) {
+        kill_child();
+        start_child(config.command);
+    }
+    free(old_command);
 
     draw_bars(false);
 }


### PR DESCRIPTION
this is a follow-up to
https://github.com/i3/i3/commit/98f202dd1b2782d11a713513f5dcca2f52daab73

fixes #2689

cc @jolange 