### PR TITLE
Properly initialize sigaction struct

### DIFF
--- a/src/sighandler.c
+++ b/src/sighandler.c
@@ -305,6 +305,8 @@ void handle_signal(int sig, siginfo_t *info, void *data) {
 
     struct sigaction action;
     action.sa_handler = SIG_DFL;
+    action.sa_flags = 0;
+    sigemptyset(&action.sa_mask);
     sigaction(sig, &action, NULL);
     raised_signal = sig;
 


### PR DESCRIPTION
The code in handle_signal() wasn't clearing the struct sigaction before passing it to sigaction().
This meant that we would block a random set of signals while executing the default handler, or jump to the uninitialized __sa_sigaction__ (instead of sa_handler).
Initialize properly as we do in setup_signal_handler().