### PR TITLE
Use OVER operator for drawing text

### DIFF
--- a/libi3/font.c
+++ b/libi3/font.c
@@ -105,7 +105,7 @@ static void draw_text_pango(const char *text, size_t text_len,
         pango_layout_set_text(layout, text, text_len);
 
     /* Do the drawing */
-    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+    cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
     cairo_set_source_rgb(cr, pango_font_red, pango_font_green, pango_font_blue);
     pango_cairo_update_layout(cr, layout);
     pango_layout_get_pixel_size(layout, NULL, &height);


### PR DESCRIPTION
For opaque text, SOURCE is not any different from OVER. However, when
drawing color glyphs (which consist of RGBA pixels instead of strokes)
SOURCE's handling of alpha is not what we want.

I stumbled across this because cairo 1.15.8 seems to clear the surface
before drawing color emoji if the operator is SOURCE, deleting every-
thing drawn before. Arguably, the area outside the glyph bounds should
not be touched, but even if this is a cairo bug the problem of alpha
within the glyph remains.