### PR TITLE
i3bar: ensure get_buffer does not leak memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 dist: trusty
+# TODO: remove “group” once trusty kernel is no longer affected by
+# https://github.com/google/sanitizers/issues/837
+group: deprecated-2017Q3
 services:
   - docker
 language: c

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -333,10 +333,12 @@ static unsigned char *get_buffer(ev_io *watcher, int *ret_buffer_len) {
                 break;
             }
             ELOG("read() failed!: %s\n", strerror(errno));
+            FREE(buffer);
             exit(EXIT_FAILURE);
         }
         if (n == 0) {
             ELOG("stdin: received EOF\n");
+            FREE(buffer);
             *ret_buffer_len = -1;
             return NULL;
         }


### PR DESCRIPTION
This fixes an AddressSanitizer warning which recently popped up.

related to #2907