### PR TITLE
travis: remove clang-analyze

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ script:
   - ./travis/skip-pkg.sh || docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 ${BASENAME_UBUNTU} ./travis/debian-build.sh deb/ubuntu-amd64/DIST
   - ./travis/skip-pkg.sh || docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 ${BASENAME_386} linux32 ./travis/debian-build.sh deb/debian-i386/DIST
   - ./travis/skip-pkg.sh || docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 ${BASENAME_UBUNTU_386} linux32 ./travis/debian-build.sh deb/ubuntu-i386/DIST
-  - ./travis/skip-pkg.sh || docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 ${BASENAME} ./travis/clang-analyze.sh
   - ./travis/skip-pkg.sh || docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 ${BASENAME} ./travis/docs.sh
   - ./travis/skip-pkg.sh || travis/prep-bintray.sh
 

--- a/travis/clang-analyze.sh
+++ b/travis/clang-analyze.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -e
-set -x
-
-mkdir -p deb/DIST-clang/build
-tar xf build/*.tar.bz2 -C deb/DIST-clang --strip-components=1
-(cd deb/DIST-clang/build && scan-build -o ../../CLANG ../configure && scan-build -o ../../CLANG --html-title="Analysis of i3 v$(git describe --tags)" make -j8)
-mv deb/CLANG/*/* deb/CLANG

--- a/travis/deploy-github-pages.sh
+++ b/travis/deploy-github-pages.sh
@@ -6,7 +6,6 @@ set -x
 GITVERSION=$(git describe --tags)
 
 mkdir build.i3wm.org
-cp -r deb/CLANG build.i3wm.org/clang-analyze
 cp -r deb/COPY-DOCS build.i3wm.org/docs
 cd build.i3wm.org
 echo build.i3wm.org > CNAME


### PR DESCRIPTION
• The output currently contains a large number of false-positives and — AFAICT —
  no actual issues.

• Upstream shows little interest in addressing the long-standing issues with the
  TAILQ macros, so the false-positive situation probably won’t change soon:
  https://bugs.llvm.org/show_bug.cgi?id=18222

Currently, we largely spend travis CPU cycles on this, for no additional value.