### PR TITLE
Consider RandR 1.5's monitors' output names in addition to monitor names

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -869,6 +869,18 @@ The 'output' is the name of the RandR output you attach your screen to. On a
 laptop, you might have VGA1 and LVDS1 as output names. You can see the
 available outputs by running +xrandr --current+.
 
+If your X server supports RandR 1.5 or newer, i3 will use RandR monitor objects
+instead of output objects. Run +xrandr --listmonitors+ to see a list. Usually,
+a monitor object contains exactly one output, and has the same name as the
+output; but should that not be the case, you may specify the name of either the
+monitor or the output in i3's configuration. For example, the Dell UP2414Q uses
+two scalers internally, so its output names might be “DP1” and “DP2”, but the
+monitor name is “Dell UP2414Q”.
+
+(Note that even if you specify the name of an output which doesn't span the
+entire monitor, i3 will still use the entire area of the containing monitor
+rather than that of just the output's.)
+
 If you use named workspaces, they must be quoted:
 
 *Examples*:

--- a/include/data.h
+++ b/include/data.h
@@ -349,6 +349,13 @@ struct Autostart {
     autostarts_always;
 };
 
+struct output_name {
+    char *name;
+
+    SLIST_ENTRY(output_name)
+    names;
+};
+
 /**
  * An Output is a physical output on your graphics driver. Outputs which
  * are currently in use have (output->active == true). Each output has a
@@ -370,8 +377,11 @@ struct xoutput {
     bool to_be_disabled;
     bool primary;
 
-    /** Name of the output */
-    char *name;
+    /** List of names for the output.
+     * An output always has at least one name; the first name is
+     * considered the primary one. */
+    SLIST_HEAD(names_head, output_name)
+    names_head;
 
     /** Pointer to the Con which represents this output */
     Con *con;

--- a/include/output.h
+++ b/include/output.h
@@ -25,6 +25,12 @@ Con *output_get_content(Con *output);
 Output *get_output_from_string(Output *current_output, const char *output_str);
 
 /**
+ * Retrieves the primary name of an output.
+ *
+ */
+char *output_primary_name(Output *output);
+
+/**
  * Returns the output for the given con.
  *
  */

--- a/src/con.c
+++ b/src/con.c
@@ -1264,7 +1264,7 @@ void con_move_to_output(Con *con, Output *output) {
     Con *ws = NULL;
     GREP_FIRST(ws, output_get_content(output->con), workspace_is_visible(child));
     assert(ws != NULL);
-    DLOG("Moving con %p to output %s\n", con, output->name);
+    DLOG("Moving con %p to output %s\n", con, output_primary_name(output));
     con_move_to_workspace(con, ws, false, false, false);
 }
 

--- a/src/fake_outputs.c
+++ b/src/fake_outputs.c
@@ -49,7 +49,7 @@ void fake_outputs_init(const char *output_spec) {
         } else {
             new_output = scalloc(1, sizeof(Output));
             sasprintf(&(new_output->name), "fake-%d", num_screens);
-            DLOG("Created new fake output %s (%p)\n", new_output->name, new_output);
+            DLOG("Created new fake output %s (%p)\n", output_primary_name(new_output), new_output);
             new_output->active = true;
             new_output->rect.x = x;
             new_output->rect.y = y;

--- a/src/fake_outputs.c
+++ b/src/fake_outputs.c
@@ -47,8 +47,11 @@ void fake_outputs_init(const char *output_spec) {
             new_output->rect.width = min(new_output->rect.width, width);
             new_output->rect.height = min(new_output->rect.height, height);
         } else {
+            struct output_name *output_name = scalloc(1, sizeof(struct output_name));
             new_output = scalloc(1, sizeof(Output));
-            sasprintf(&(new_output->name), "fake-%d", num_screens);
+            sasprintf(&(output_name->name), "fake-%d", num_screens);
+            SLIST_INIT(&(new_output->names_head));
+            SLIST_INSERT_HEAD(&(new_output->names_head), output_name, names);
             DLOG("Created new fake output %s (%p)\n", output_primary_name(new_output), new_output);
             new_output->active = true;
             new_output->rect.x = x;

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -388,7 +388,7 @@ static void handle_configure_request(xcb_configure_request_event_t *event) {
             Con *current_output = con_get_output(con);
             Output *target = get_output_containing(x, y);
             if (target != NULL && current_output != target->con) {
-                DLOG("Dock client is requested to be moved to output %s, moving it there.\n", target->name);
+                DLOG("Dock client is requested to be moved to output %s, moving it there.\n", output_primary_name(target));
                 Match *match;
                 Con *nc = con_for_window(target->con, con->window, &match);
                 DLOG("Dock client will be moved to container %p.\n", nc);

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -579,6 +579,11 @@ static void dump_bar_bindings(yajl_gen gen, Barconfig *config) {
     y(array_close);
 }
 
+static char *canonicalize_output_name(char *name) {
+    Output *output = get_output_by_name(name, false);
+    return output ? output_primary_name(output) : name;
+}
+
 static void dump_bar_config(yajl_gen gen, Barconfig *config) {
     y(map_open);
 
@@ -588,8 +593,13 @@ static void dump_bar_config(yajl_gen gen, Barconfig *config) {
     if (config->num_outputs > 0) {
         ystr("outputs");
         y(array_open);
-        for (int c = 0; c < config->num_outputs; c++)
-            ystr(config->outputs[c]);
+        for (int c = 0; c < config->num_outputs; c++) {
+            /* Convert monitor names (RandR ≥ 1.5) or output names
+             * (RandR < 1.5) into monitor names. This way, existing
+             * configs which use output names transparently keep
+             * working. */
+            ystr(canonicalize_output_name(config->outputs[c]));
+        }
         y(array_close);
     }
 
@@ -599,7 +609,7 @@ static void dump_bar_config(yajl_gen gen, Barconfig *config) {
 
         struct tray_output_t *tray_output;
         TAILQ_FOREACH(tray_output, &(config->tray_outputs), tray_outputs) {
-            ystr(tray_output->output);
+            ystr(canonicalize_output_name(tray_output->output));
         }
 
         y(array_close);

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -829,7 +829,7 @@ IPC_HANDLER(get_outputs) {
         y(map_open);
 
         ystr("name");
-        ystr(output->name);
+        ystr(output_primary_name(output));
 
         ystr("active");
         y(bool, output->active);

--- a/src/main.c
+++ b/src/main.c
@@ -687,7 +687,7 @@ int main(int argc, char *argv[]) {
         TAILQ_FOREACH(con, &(croot->nodes_head), nodes) {
             Output *output;
             TAILQ_FOREACH(output, &outputs, outputs) {
-                if (output->active || strcmp(con->name, output->name) != 0)
+                if (output->active || strcmp(con->name, output_primary_name(output)) != 0)
                     continue;
 
                 /* This will correctly correlate the output with its content

--- a/src/manage.c
+++ b/src/manage.c
@@ -219,7 +219,7 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
         LOG("This window is of type dock\n");
         Output *output = get_output_containing(geom->x, geom->y);
         if (output != NULL) {
-            DLOG("Starting search at output %s\n", output->name);
+            DLOG("Starting search at output %s\n", output_primary_name(output));
             search_at = output->con;
         }
 

--- a/src/output.c
+++ b/src/output.c
@@ -44,6 +44,14 @@ Output *get_output_from_string(Output *current_output, const char *output_str) {
     return get_output_by_name(output_str, true);
 }
 
+/*
+ * Retrieves the primary name of an output.
+ *
+ */
+char *output_primary_name(Output *output) {
+    return output->name;
+}
+
 Output *get_output_for_con(Con *con) {
     Con *output_con = con_get_output(con);
     if (output_con == NULL) {

--- a/src/output.c
+++ b/src/output.c
@@ -49,7 +49,7 @@ Output *get_output_from_string(Output *current_output, const char *output_str) {
  *
  */
 char *output_primary_name(Output *output) {
-    return output->name;
+    return SLIST_FIRST(&output->names_head)->name;
 }
 
 Output *get_output_for_con(Con *con) {

--- a/src/randr.c
+++ b/src/randr.c
@@ -48,9 +48,17 @@ Output *get_output_by_name(const char *name, const bool require_active) {
     Output *output;
     bool get_primary = (strcasecmp("primary", name) == 0);
     TAILQ_FOREACH(output, &outputs, outputs) {
-        if ((output->primary && get_primary) ||
-            ((!require_active || output->active) && strcasecmp(output_primary_name(output), name) == 0)) {
+        if (output->primary && get_primary) {
             return output;
+        }
+        if (require_active && !output->active) {
+            continue;
+        }
+        struct output_name *output_name;
+        SLIST_FOREACH(output_name, &output->names_head, names) {
+            if (strcasecmp(output_name->name, name) == 0) {
+                return output;
+            }
         }
     }
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -537,7 +537,7 @@ static bool _tree_next(Con *con, char way, orientation_t orientation, bool wrap)
 
         if (!current_output)
             return false;
-        DLOG("Current output is %s\n", current_output->name);
+        DLOG("Current output is %s\n", output_primary_name(current_output));
 
         /* Try to find next output */
         direction_t direction;
@@ -555,7 +555,7 @@ static bool _tree_next(Con *con, char way, orientation_t orientation, bool wrap)
         next_output = get_output_next(direction, current_output, CLOSEST_OUTPUT);
         if (!next_output)
             return false;
-        DLOG("Next output is %s\n", next_output->name);
+        DLOG("Next output is %s\n", output_primary_name(next_output));
 
         /* Find visible workspace on next output */
         Con *workspace = NULL;

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -188,7 +188,7 @@ Con *create_workspace_on_output(Output *output, Con *content) {
         struct Workspace_Assignment *assignment;
         TAILQ_FOREACH(assignment, &ws_assignments, ws_assignments) {
             if (strcmp(assignment->name, target_name) != 0 ||
-                strcmp(assignment->output, output->name) == 0)
+                strcmp(assignment->output, output_primary_name(output)) == 0)
                 continue;
 
             assigned = true;
@@ -935,7 +935,7 @@ bool workspace_move_to_output(Con *ws, const char *name) {
         bool used_assignment = false;
         struct Workspace_Assignment *assignment;
         TAILQ_FOREACH(assignment, &ws_assignments, ws_assignments) {
-            if (assignment->output == NULL || strcmp(assignment->output, current_output->name) != 0)
+            if (assignment->output == NULL || strcmp(assignment->output, output_primary_name(current_output)) != 0)
                 continue;
 
             /* check if this workspace is already attached to the tree */

--- a/src/xinerama.c
+++ b/src/xinerama.c
@@ -55,7 +55,10 @@ static void query_screens(xcb_connection_t *conn) {
             s->rect.height = min(s->rect.height, screen_info[screen].height);
         } else {
             s = scalloc(1, sizeof(Output));
-            sasprintf(&(s->name), "xinerama-%d", num_screens);
+            struct output_name *output_name = scalloc(1, sizeof(struct output_name));
+            sasprintf(&output_name->name, "xinerama-%d", num_screens);
+            SLIST_INIT(&s->names_head);
+            SLIST_INSERT_HEAD(&s->names_head, output_name, names);
             DLOG("Created new Xinerama screen %s (%p)\n", output_primary_name(s), s);
             s->active = true;
             s->rect.x = screen_info[screen].x_org;

--- a/src/xinerama.c
+++ b/src/xinerama.c
@@ -56,7 +56,7 @@ static void query_screens(xcb_connection_t *conn) {
         } else {
             s = scalloc(1, sizeof(Output));
             sasprintf(&(s->name), "xinerama-%d", num_screens);
-            DLOG("Created new Xinerama screen %s (%p)\n", s->name, s);
+            DLOG("Created new Xinerama screen %s (%p)\n", output_primary_name(s), s);
             s->active = true;
             s->rect.x = screen_info[screen].x_org;
             s->rect.y = screen_info[screen].y_org;

--- a/testcases/lib/SocketActivation.pm
+++ b/testcases/lib/SocketActivation.pm
@@ -145,7 +145,12 @@ sub activate_i3 {
         if ($args{inject_randr15}) {
             # See comment in $args{strace} branch.
             $cmd = 'test.inject_randr15 --getmonitors_reply="' .
-                   $args{inject_randr15} . '" -- ' .
+                   $args{inject_randr15} . '" ' .
+                   ($args{inject_randr15_outputinfo}
+                    ? '--getoutputinfo_reply="' .
+                      $args{inject_randr15_outputinfo} . '" '
+                    : '') .
+                   '-- ' .
                    'sh -c "export LISTEN_PID=\$\$; ' . $cmd . '"';
         }
 

--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -864,6 +864,7 @@ sub launch_with_config {
         dont_create_temp_dir => $args{dont_create_temp_dir},
         validate_config => $args{validate_config},
         inject_randr15 => $args{inject_randr15},
+        inject_randr15_outputinfo => $args{inject_randr15_outputinfo},
     );
 
     # If we called i3 with -C, we wait for it to exit and then return as


### PR DESCRIPTION
Fixes #2909. 

I suggest reviewing commit by commit.

TODO:
- [x] Replace `OUTPUT_NAME` macro with `output_primary_name` function
- [x] ~~Add IPC field for alternative output names~~
- [x] ~~Make i3bar use the new IPC field~~
- [x] Update documentation
- [x] Add test?
