### PR TITLE
Testsuite: avoid starting new i3 instances where possible

### DIFF
--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -46,6 +46,7 @@ our @EXPORT = qw(
     wait_for_map
     wait_for_unmap
     $x
+    kill_all_windows
 );
 
 =head1 NAME
@@ -897,6 +898,17 @@ Returns the content of the log file for the current test.
 sub get_i3_log {
     my $logfile = "$ENV{OUTDIR}/i3-log-for-$ENV{TESTNAME}";
     return slurp($logfile);
+}
+
+=head2 kill_all_windows
+
+Kills all windows to clean up between tests.
+
+=cut
+sub kill_all_windows {
+    # Sync in case not all windows are managed by i3 just yet.
+    sync_with_i3;
+    cmd '[title=".*"] kill';
 }
 
 =head1 AUTHOR

--- a/testcases/t/165-for_window.t
+++ b/testcases/t/165-for_window.t
@@ -112,6 +112,8 @@ wait_for_unmap $window;
 @content = @{get_ws_content($tmp)};
 cmp_ok(@content, '==', 0, 'no more nodes');
 
+kill_all_windows;
+
 ##############################################################
 # 2: match on the title, check if for_window is really executed
 # only once
@@ -151,6 +153,8 @@ wait_for_unmap $window;
 @content = @{get_ws_content($tmp)};
 cmp_ok(@content, '==', 0, 'no more nodes');
 
+kill_all_windows;
+
 ##############################################################
 # 3: match on the title, set border style *and* a mark
 ##############################################################
@@ -175,6 +179,8 @@ cmd qq|[con_mark="bleh"] focus|;
 
 @content = @{get_ws_content($tmp)};
 ok($content[0]->{focused}, 'first node focused');
+
+kill_all_windows;
 
 ##############################################################
 # 4: multiple criteria for the for_window command
@@ -211,6 +217,8 @@ wait_for_map $window;
 cmp_ok(@content, '==', 1, 'one node on this workspace now');
 is($content[0]->{border}, 'normal', 'no border');
 
+kill_all_windows;
+
 ##############################################################
 # 5: check that a class criterion does not match the instance
 ##############################################################
@@ -226,6 +234,8 @@ $window = open_window(
 @content = @{get_ws_content($tmp)};
 cmp_ok(@content, '==', 1, 'one node on this workspace now');
 is($content[0]->{border}, 'normal', 'normal border, not matched');
+
+kill_all_windows;
 
 ##############################################################
 # 6: check that the 'instance' criterion works
@@ -243,6 +253,8 @@ $window = open_window(
 cmp_ok(@content, '==', 1, 'one node on this workspace now');
 is($content[0]->{border}, 'none', 'no border');
 
+kill_all_windows;
+
 ##############################################################
 # 7: check that invalid criteria don’t end up matching all windows
 ##############################################################
@@ -258,6 +270,8 @@ $window = open_window(
 @content = @{get_ws_content($tmp)};
 cmp_ok(@content, '==', 1, 'one node on this workspace now');
 is($content[0]->{border}, 'normal', 'normal border');
+
+kill_all_windows;
 
 ##############################################################
 # 8: check that the role criterion works properly
@@ -286,6 +300,8 @@ $window = open_window(
 @content = @{get_ws_content($tmp)};
 cmp_ok(@content, '==', 1, 'one node on this workspace now');
 is($content[0]->{border}, 'none', 'no border (window_role)');
+
+kill_all_windows;
 
 ##############################################################
 # 9: another test for the window_role, but this time it changes
@@ -320,6 +336,8 @@ sync_with_i3;
 cmp_ok(@content, '==', 1, 'one node on this workspace now');
 is($content[0]->{border}, 'none', 'no border (window_role 2)');
 
+kill_all_windows;
+
 ##############################################################
 # 10: check that the criterion 'window_type' works
 ##############################################################
@@ -332,6 +350,8 @@ while (my ($window_type, $atom) = each %window_types) {
     my @nodes = @{get_ws($tmp)->{floating_nodes}};
     cmp_ok(@nodes, '==', 1, 'one floating container on this workspace');
     is_deeply($nodes[0]->{nodes}[0]->{marks}, [ "branded-$window_type" ], "mark set (window_type = $atom)");
+
+    kill_all_windows;
 }
 
 ##############################################################
@@ -354,6 +374,8 @@ while (my ($window_type, $atom) = each %window_types) {
     my @nodes = @{get_ws($tmp)->{floating_nodes}};
     cmp_ok(@nodes, '==', 1, 'one floating container on this workspace');
     is_deeply($nodes[0]->{nodes}[0]->{marks}, [ "branded-$window_type" ], "mark set (window_type = $atom)");
+
+    kill_all_windows;
 }
 
 ##############################################################
@@ -366,6 +388,8 @@ $window = open_window;
 @nodes = @{get_ws('trigger')->{floating_nodes}};
 cmp_ok(@nodes, '==', 1, 'one floating container on this workspace');
 is_deeply($nodes[0]->{nodes}[0]->{marks}, [ 'triggered' ], "mark set for workspace criterion");
+
+kill_all_windows;
 
 ##############################################################
 

--- a/testcases/t/165-for_window_tilingfloating.t
+++ b/testcases/t/165-for_window_tilingfloating.t
@@ -1,0 +1,49 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+use i3test i3_autostart => 0;
+use X11::XCB qw(PROP_MODE_REPLACE);
+
+##############################################################
+# 13: check that the tiling / floating criteria work.
+##############################################################
+
+my $config = <<"EOT";
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+for_window [tiling] mark tiled
+for_window [floating] mark floated
+EOT
+
+my $pid = launch_with_config($config);
+my $tmp = fresh_workspace;
+
+open_window;
+open_floating_window;
+
+my @nodes = @{get_ws($tmp)->{nodes}};
+cmp_ok(@nodes, '==', 1, 'one tiling container on this workspace');
+is_deeply($nodes[0]->{marks}, [ 'tiled' ], "mark set for 'tiling' criterion");
+
+@nodes = @{get_ws($tmp)->{floating_nodes}};
+cmp_ok(@nodes, '==', 1, 'one floating container on this workspace');
+is_deeply($nodes[0]->{nodes}[0]->{marks}, [ 'floated' ], "mark set for 'floating' criterion");
+
+exit_gracefully($pid);
+
+##############################################################
+
+done_testing;

--- a/testcases/t/265-swap.t
+++ b/testcases/t/265-swap.t
@@ -45,6 +45,7 @@ open_window;
 cmd "swap container with con_id 1";
 
 does_i3_live;
+kill_all_windows;
 
 ###############################################################################
 # Swap 2 windows in different workspaces using con_id
@@ -59,6 +60,8 @@ open_window;
 
 cmd "swap container with con_id $A";
 is(get_focused($ws), $A, 'A is now focused');
+
+kill_all_windows;
 
 ###############################################################################
 # Swap two containers next to each other.
@@ -81,6 +84,8 @@ $nodes = get_ws_content($ws);
 is($nodes->[0]->{window}, $B->{id}, 'B is on the left');
 is($nodes->[1]->{window}, $A->{id}, 'A is on the right');
 is(get_focused($ws), $expected_focus, 'B is still focused');
+
+kill_all_windows;
 
 ###############################################################################
 # Swap two containers with different parents.
@@ -112,6 +117,8 @@ is($nodes->[0]->{nodes}->[0]->{window}, $B->{id}, 'B is on the top left');
 is($nodes->[1]->{nodes}->[1]->{window}, $A->{id}, 'A is on the bottom right');
 is(get_focused($ws), $expected_focus, 'B is still focused');
 
+kill_all_windows;
+
 ###############################################################################
 # Swap two containers with different parents.
 # In this test, the focus head of the left v-split container is _not_ A.
@@ -141,6 +148,8 @@ $nodes = get_ws_content($ws);
 is($nodes->[0]->{nodes}->[0]->{window}, $B->{id}, 'B is on the top left');
 is($nodes->[1]->{nodes}->[1]->{window}, $A->{id}, 'A is on the bottom right');
 is(get_focused($ws), $expected_focus, 'B is still focused');
+
+kill_all_windows;
 
 ###############################################################################
 # Swap two containers with one being on a different workspace.
@@ -177,6 +186,8 @@ $nodes = get_ws_content($ws2);
 is($nodes->[1]->{window}, $A->{id}, 'A is on ws2:right');
 is(get_focused($ws2), $expected_focus, 'A is focused');
 
+kill_all_windows;
+
 ###############################################################################
 # Swap two non-focused containers within the same workspace.
 #
@@ -204,6 +215,8 @@ $nodes = get_ws_content($ws);
 is($nodes->[0]->{nodes}->[0]->{window}, $B->{id}, 'B is on the top left');
 is($nodes->[1]->{nodes}->[1]->{window}, $A->{id}, 'A is on the bottom right');
 is(get_focused($ws), $expected_focus, 'F is still focused');
+
+kill_all_windows;
 
 ###############################################################################
 # Swap two non-focused containers which are both on different workspaces.
@@ -244,6 +257,8 @@ is($nodes->[0]->{window}, $A->{id}, 'A is on the second workspace');
 
 is(get_focused($ws3), $expected_focus, 'F is still focused');
 
+kill_all_windows;
+
 ###############################################################################
 # Swap two non-focused containers with one being on a different workspace.
 #
@@ -277,6 +292,8 @@ $nodes = get_ws_content($ws2);
 is($nodes->[0]->{window}, $A->{id}, 'A is on the left of the second workspace');
 is(get_focused($ws2), $expected_focus, 'F is still focused');
 
+kill_all_windows;
+
 ###############################################################################
 # 1. A container cannot be swapped with its parent.
 # 2. A container cannot be swapped with one of its children.
@@ -300,6 +317,8 @@ is($result->[0]->{success}, 0, 'B cannot be swappd with its parent');
 
 $result = cmd '[con_mark=A] swap container with mark B';
 is($result->[0]->{success}, 0, 'A cannot be swappd with one of its children');
+
+kill_all_windows;
 
 ###############################################################################
 # Swapping two containers preserves the geometry of the container they are
@@ -330,6 +349,8 @@ cmd '[con_mark=B] swap container with mark A';
 $nodes = get_ws_content($ws);
 cmp_float($nodes->[0]->{percent}, 0.25, 'B has 25% width');
 cmp_float($nodes->[1]->{percent}, 0.75, 'A has 75% width');
+
+kill_all_windows;
 
 ###############################################################################
 # Swapping containers not sharing the same parent preserves the geometry of
@@ -375,6 +396,8 @@ $nodes = get_ws_content($ws);
 cmp_float($nodes->[0]->{nodes}->[0]->{percent}, 0.25, 'B has 25% height');
 cmp_float($nodes->[1]->{nodes}->[0]->{percent}, 0.75, 'A has 75% height');
 
+kill_all_windows;
+
 ###############################################################################
 # Swapping containers moves the urgency hint correctly.
 ###############################################################################
@@ -397,6 +420,8 @@ is(get_ws($ws1)->{urgent}, 1, 'the first workspace is marked urgent');
 @urgent = grep { $_->{urgent} } @{get_ws_content($ws2)};
 is(@urgent, 0, 'A is not marked urgent');
 is(get_ws($ws2)->{urgent}, 0, 'the second workspace is not marked urgent');
+
+kill_all_windows;
 
 ###############################################################################
 

--- a/testcases/t/265-swap.t
+++ b/testcases/t/265-swap.t
@@ -32,25 +32,23 @@ my ($nodes, $expected_focus, $A, $B, $F);
 my ($result);
 my @urgent;
 
+$pid = launch_with_config($config);
+
 ###############################################################################
 # Invalid con_id should not crash i3
 # See issue #2895.
 ###############################################################################
 
-$pid = launch_with_config($config);
 $ws = fresh_workspace;
 
 open_window;
 cmd "swap container with con_id 1";
 
 does_i3_live;
-exit_gracefully($pid);
 
 ###############################################################################
 # Swap 2 windows in different workspaces using con_id
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 $ws = fresh_workspace;
 open_window;
@@ -62,8 +60,6 @@ open_window;
 cmd "swap container with con_id $A";
 is(get_focused($ws), $A, 'A is now focused');
 
-exit_gracefully($pid);
-
 ###############################################################################
 # Swap two containers next to each other.
 # Focus should stay on B because both windows are on the focused workspace.
@@ -73,7 +69,6 @@ exit_gracefully($pid);
 # | A | B |    Focus Stacks:
 # +---+---+        H1: B, A
 ###############################################################################
-$pid = launch_with_config($config);
 $ws = fresh_workspace;
 
 $A = open_window(wm_class => 'mark_A');
@@ -87,8 +82,6 @@ is($nodes->[0]->{window}, $B->{id}, 'B is on the left');
 is($nodes->[1]->{window}, $A->{id}, 'A is on the right');
 is(get_focused($ws), $expected_focus, 'B is still focused');
 
-exit_gracefully($pid);
-
 ###############################################################################
 # Swap two containers with different parents.
 # In this test, the focus head of the left v-split container is A.
@@ -100,7 +93,6 @@ exit_gracefully($pid);
 # | Y | B |        V1: A, Y
 # +---+---+        V2: B, X
 ###############################################################################
-$pid = launch_with_config($config);
 $ws = fresh_workspace;
 
 $A = open_window(wm_class => 'mark_A');
@@ -120,8 +112,6 @@ is($nodes->[0]->{nodes}->[0]->{window}, $B->{id}, 'B is on the top left');
 is($nodes->[1]->{nodes}->[1]->{window}, $A->{id}, 'A is on the bottom right');
 is(get_focused($ws), $expected_focus, 'B is still focused');
 
-exit_gracefully($pid);
-
 ###############################################################################
 # Swap two containers with different parents.
 # In this test, the focus head of the left v-split container is _not_ A.
@@ -133,7 +123,6 @@ exit_gracefully($pid);
 # | Y | B |        V1: Y, A
 # +---+---+        V2: B, X
 ###############################################################################
-$pid = launch_with_config($config);
 $ws = fresh_workspace;
 
 $A = open_window(wm_class => 'mark_A');
@@ -153,8 +142,6 @@ is($nodes->[0]->{nodes}->[0]->{window}, $B->{id}, 'B is on the top left');
 is($nodes->[1]->{nodes}->[1]->{window}, $A->{id}, 'A is on the bottom right');
 is(get_focused($ws), $expected_focus, 'B is still focused');
 
-exit_gracefully($pid);
-
 ###############################################################################
 # Swap two containers with one being on a different workspace.
 # The focused container is B.
@@ -171,8 +158,6 @@ exit_gracefully($pid);
 # | Y | B |    Focus Stacks:
 # +---+---+        H2: B, Y
 ###############################################################################
-$pid = launch_with_config($config);
-
 $ws1 = fresh_workspace;
 $A = open_window(wm_class => 'mark_A');
 $expected_focus = get_focused($ws1);
@@ -192,8 +177,6 @@ $nodes = get_ws_content($ws2);
 is($nodes->[1]->{window}, $A->{id}, 'A is on ws2:right');
 is(get_focused($ws2), $expected_focus, 'A is focused');
 
-exit_gracefully($pid);
-
 ###############################################################################
 # Swap two non-focused containers within the same workspace.
 #
@@ -203,7 +186,6 @@ exit_gracefully($pid);
 # | X | B |        V1: A, X
 # +---+---+        V2: F, B
 ###############################################################################
-$pid = launch_with_config($config);
 $ws = fresh_workspace;
 
 $A = open_window(wm_class => 'mark_A');
@@ -222,8 +204,6 @@ $nodes = get_ws_content($ws);
 is($nodes->[0]->{nodes}->[0]->{window}, $B->{id}, 'B is on the top left');
 is($nodes->[1]->{nodes}->[1]->{window}, $A->{id}, 'A is on the bottom right');
 is(get_focused($ws), $expected_focus, 'F is still focused');
-
-exit_gracefully($pid);
 
 ###############################################################################
 # Swap two non-focused containers which are both on different workspaces.
@@ -244,8 +224,6 @@ exit_gracefully($pid);
 # | F |
 # +---+
 ###############################################################################
-$pid = launch_with_config($config);
-
 $ws1 = fresh_workspace;
 $A = open_window(wm_class => 'mark_A');
 
@@ -266,8 +244,6 @@ is($nodes->[0]->{window}, $A->{id}, 'A is on the second workspace');
 
 is(get_focused($ws3), $expected_focus, 'F is still focused');
 
-exit_gracefully($pid);
-
 ###############################################################################
 # Swap two non-focused containers with one being on a different workspace.
 #
@@ -283,7 +259,6 @@ exit_gracefully($pid);
 # | B | F |    Focus Stacks:
 # +---+---+        H2: F, B
 ###############################################################################
-$pid = launch_with_config($config);
 
 $ws1 = fresh_workspace;
 $A = open_window(wm_class => 'mark_A');
@@ -302,8 +277,6 @@ $nodes = get_ws_content($ws2);
 is($nodes->[0]->{window}, $A->{id}, 'A is on the left of the second workspace');
 is(get_focused($ws2), $expected_focus, 'F is still focused');
 
-exit_gracefully($pid);
-
 ###############################################################################
 # 1. A container cannot be swapped with its parent.
 # 2. A container cannot be swapped with one of its children.
@@ -315,8 +288,6 @@ exit_gracefully($pid);
 # |   | B |
 # +---+---+
 ###############################################################################
-$pid = launch_with_config($config);
-
 $ws = fresh_workspace;
 open_window;
 open_window;
@@ -329,8 +300,6 @@ is($result->[0]->{success}, 0, 'B cannot be swappd with its parent');
 
 $result = cmd '[con_mark=A] swap container with mark B';
 is($result->[0]->{success}, 0, 'A cannot be swappd with one of its children');
-
-exit_gracefully($pid);
 
 ###############################################################################
 # Swapping two containers preserves the geometry of the container they are
@@ -346,8 +315,6 @@ exit_gracefully($pid);
 # | B |   A   |
 # +---+-------+
 ###############################################################################
-$pid = launch_with_config($config);
-
 $ws = fresh_workspace;
 $A = open_window(wm_class => 'mark_A');
 $B = open_window(wm_class => 'mark_B');
@@ -363,8 +330,6 @@ cmd '[con_mark=B] swap container with mark A';
 $nodes = get_ws_content($ws);
 cmp_float($nodes->[0]->{percent}, 0.25, 'B has 25% width');
 cmp_float($nodes->[1]->{percent}, 0.75, 'A has 75% width');
-
-exit_gracefully($pid);
 
 ###############################################################################
 # Swapping containers not sharing the same parent preserves the geometry of
@@ -388,7 +353,6 @@ exit_gracefully($pid);
 # |   |  X  |
 # +---+-----+
 ###############################################################################
-$pid = launch_with_config($config);
 $ws = fresh_workspace;
 
 $A = open_window(wm_class => 'mark_A');
@@ -411,12 +375,9 @@ $nodes = get_ws_content($ws);
 cmp_float($nodes->[0]->{nodes}->[0]->{percent}, 0.25, 'B has 25% height');
 cmp_float($nodes->[1]->{nodes}->[0]->{percent}, 0.75, 'A has 75% height');
 
-exit_gracefully($pid);
-
 ###############################################################################
 # Swapping containers moves the urgency hint correctly.
 ###############################################################################
-$pid = launch_with_config($config);
 
 $ws1 = fresh_workspace;
 $A = open_window(wm_class => 'mark_A');
@@ -437,8 +398,8 @@ is(get_ws($ws1)->{urgent}, 1, 'the first workspace is marked urgent');
 is(@urgent, 0, 'A is not marked urgent');
 is(get_ws($ws2)->{urgent}, 0, 'the second workspace is not marked urgent');
 
-exit_gracefully($pid);
-
 ###############################################################################
+
+exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/529-net-wm-desktop.t
+++ b/testcases/t/529-net-wm-desktop.t
@@ -66,7 +66,14 @@ sub open_window_with_net_wm_desktop {
                 pack('L', $idx),
             );
         },
+	dont_map => 1,
     );
+
+    # We don’t wait for MapNotify and instead sync with i3 so that we don’t need
+    # to encounter the full timeout of 4s when opening a window on a non-visible
+    # workspace.
+    $window->map;
+    sync_with_i3;
 
     return $window;
 }
@@ -80,9 +87,7 @@ sub kill_windows {
 
 ###############################################################################
 
-my ($config, $config_mm, $pid, $con);
-
-$config = <<EOT;
+my $config = <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -91,41 +96,24 @@ bar {
 }
 EOT
 
-$config_mm = <<EOT;
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-
-workspace "0" output "fake-0"
-workspace "1" output "fake-0"
-workspace "2" output "fake-0"
-workspace "10" output "fake-1"
-workspace "11" output "fake-1"
-workspace "12" output "fake-1"
-
-fake-outputs 1024x768+0+0,1024x768+1024+0
-EOT
+my $pid = launch_with_config($config);
 
 ###############################################################################
 # Upon managing a window which does not set _NET_WM_DESKTOP, the property is
 # set on the window.
 ###############################################################################
 
-$pid = launch_with_config($config);
-
 cmd 'workspace 1';
-$con = open_window;
+my $con = open_window;
 
 is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set upon managing a window');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # Upon managing a window which sets _NET_WM_DESKTOP, the window is moved to
 # the specified desktop.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 cmd 'workspace 0';
 open_window;
@@ -140,14 +128,11 @@ is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP still has the correct value');
 is_num_children('1', 2, 'The window was moved to workspace 1');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # Upon managing a window which sets _NET_WM_DESKTOP to the appropriate value,
 # the window is made sticky and floating.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 cmd 'workspace 0';
 $con = open_window_with_net_wm_desktop(0xFFFFFFFF);
@@ -157,14 +142,11 @@ is(@{get_ws('0')->{floating_nodes}}, 1, 'The window is floating');
 ok(get_ws('0')->{floating_nodes}->[0]->{nodes}->[0]->{sticky}, 'The window is sticky');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when the window is moved to another workspace
 # on the same output.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 cmd 'workspace 0';
 open_window;
@@ -178,14 +160,11 @@ cmd 'move window to workspace 1';
 is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated when moving the window');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when the floating window is moved to another
 # workspace on the same output.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 cmd 'workspace 0';
 open_window;
@@ -200,34 +179,10 @@ cmd 'move window to workspace 1';
 is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated when moving the window');
 
 kill_windows;
-exit_gracefully($pid);
-
-###############################################################################
-# _NET_WM_DESKTOP is updated when the window is moved to another workspace
-# on another output.
-###############################################################################
-
-$pid = launch_with_config($config_mm);
-
-cmd 'workspace 0';
-open_window;
-cmd 'workspace 10';
-open_window;
-cmd 'workspace 0';
-$con = open_window;
-
-cmd 'move window to workspace 10';
-
-is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated when moving the window');
-
-kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # _NET_WM_DESKTOP is removed when the window is withdrawn.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 $con = open_window;
 is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set (sanity check)');
@@ -238,14 +193,11 @@ wait_for_unmap($con);
 is(get_net_wm_desktop($con), undef, '_NET_WM_DESKTOP is removed');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # A _NET_WM_DESKTOP client message sent to the root window moves a window
 # to the correct workspace.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 cmd 'workspace 0';
 open_window;
@@ -263,14 +215,11 @@ is_num_children('1', 2, 'The window is now on workspace 1');
 is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # A _NET_WM_DESKTOP client message sent to the root window can make a window
 # sticky.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 cmd 'workspace 0';
 $con = open_window;
@@ -282,14 +231,11 @@ is(@{get_ws('0')->{floating_nodes}}, 1, 'The window is floating');
 ok(get_ws('0')->{floating_nodes}->[0]->{nodes}->[0]->{sticky}, 'The window is sticky');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when a new workspace with a lower number is
 # opened and closed.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 cmd 'workspace 1';
 $con = open_window;
@@ -299,13 +245,10 @@ cmd 'workspace 0';
 is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when a window is made sticky by command.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 cmd 'workspace 0';
 $con = open_window;
@@ -316,13 +259,10 @@ cmd 'sticky enable';
 is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP is updated');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when a window is made sticky by client message.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 cmd 'workspace 0';
 $con = open_window;
@@ -343,13 +283,10 @@ sync_with_i3;
 is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP is updated');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when a window is moved to the scratchpad.
 ###############################################################################
-
-$pid = launch_with_config($config);
 
 cmd 'workspace 0';
 $con = open_window;
@@ -363,8 +300,9 @@ cmd 'scratchpad show';
 is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set sanity check)');
 
 kill_windows;
-exit_gracefully($pid);
 
 ###############################################################################
+
+exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/529-net-wm-desktop.t
+++ b/testcases/t/529-net-wm-desktop.t
@@ -78,13 +78,6 @@ sub open_window_with_net_wm_desktop {
     return $window;
 }
 
-# We need to kill all windows in between tests since they survive the i3 restart
-# and will interfere with the following tests.
-sub kill_windows {
-    sync_with_i3;
-    cmd '[title="Window.*"] kill';
-}
-
 ###############################################################################
 
 my $config = <<EOT;
@@ -108,7 +101,7 @@ my $con = open_window;
 
 is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set upon managing a window');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # Upon managing a window which sets _NET_WM_DESKTOP, the window is moved to
@@ -127,7 +120,7 @@ $con = open_window_with_net_wm_desktop(1);
 is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP still has the correct value');
 is_num_children('1', 2, 'The window was moved to workspace 1');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # Upon managing a window which sets _NET_WM_DESKTOP to the appropriate value,
@@ -141,7 +134,7 @@ is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP still has the correct 
 is(@{get_ws('0')->{floating_nodes}}, 1, 'The window is floating');
 ok(get_ws('0')->{floating_nodes}->[0]->{nodes}->[0]->{sticky}, 'The window is sticky');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when the window is moved to another workspace
@@ -159,7 +152,7 @@ cmd 'move window to workspace 1';
 
 is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated when moving the window');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when the floating window is moved to another
@@ -178,7 +171,7 @@ cmd 'move window to workspace 1';
 
 is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated when moving the window');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # _NET_WM_DESKTOP is removed when the window is withdrawn.
@@ -192,7 +185,7 @@ wait_for_unmap($con);
 
 is(get_net_wm_desktop($con), undef, '_NET_WM_DESKTOP is removed');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # A _NET_WM_DESKTOP client message sent to the root window moves a window
@@ -214,7 +207,7 @@ is_num_children('0', 1, 'The window is no longer on workspace 0');
 is_num_children('1', 2, 'The window is now on workspace 1');
 is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # A _NET_WM_DESKTOP client message sent to the root window can make a window
@@ -230,7 +223,7 @@ is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP is updated');
 is(@{get_ws('0')->{floating_nodes}}, 1, 'The window is floating');
 ok(get_ws('0')->{floating_nodes}->[0]->{nodes}->[0]->{sticky}, 'The window is sticky');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when a new workspace with a lower number is
@@ -244,7 +237,7 @@ is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set sanity check)');
 cmd 'workspace 0';
 is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when a window is made sticky by command.
@@ -258,7 +251,7 @@ is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set sanity check)');
 cmd 'sticky enable';
 is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP is updated');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when a window is made sticky by client message.
@@ -282,7 +275,7 @@ sync_with_i3;
 
 is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP is updated');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 # _NET_WM_DESKTOP is updated when a window is moved to the scratchpad.
@@ -299,7 +292,7 @@ is(get_net_wm_desktop($con), 0xFFFFFFFF, '_NET_WM_DESKTOP is updated');
 cmd 'scratchpad show';
 is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set sanity check)');
 
-kill_windows;
+kill_all_windows;
 
 ###############################################################################
 

--- a/testcases/t/529-net-wm-desktop_mm.t
+++ b/testcases/t/529-net-wm-desktop_mm.t
@@ -1,0 +1,75 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests for _NET_WM_DESKTOP.
+# Ticket: #2153
+use i3test i3_autostart => 0;
+use X11::XCB qw(:all);
+
+sub get_net_wm_desktop {
+    sync_with_i3;
+
+    my ($con) = @_;
+    my $cookie = $x->get_property(
+        0,
+        $con->{id},
+        $x->atom(name => '_NET_WM_DESKTOP')->id,
+        $x->atom(name => 'CARDINAL')->id,
+        0,
+        1
+    );
+
+    my $reply = $x->get_property_reply($cookie->{sequence});
+    return undef if $reply->{length} != 1;
+
+    return unpack("L", $reply->{value});
+}
+
+my $config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+workspace "0" output "fake-0"
+workspace "1" output "fake-0"
+workspace "2" output "fake-0"
+workspace "10" output "fake-1"
+workspace "11" output "fake-1"
+workspace "12" output "fake-1"
+
+fake-outputs 1024x768+0+0,1024x768+1024+0
+EOT
+
+###############################################################################
+# _NET_WM_DESKTOP is updated when the window is moved to another workspace
+# on another output.
+###############################################################################
+
+my $pid = launch_with_config($config);
+
+cmd 'workspace 0';
+open_window;
+cmd 'workspace 10';
+open_window;
+cmd 'workspace 0';
+my $con = open_window;
+
+cmd 'move window to workspace 10';
+
+is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated when moving the window');
+
+exit_gracefully($pid);
+
+done_testing;


### PR DESCRIPTION
This significantly reduces the time required to run the testsuite.