### PR TITLE
Revert "Use OVER operator for drawing text (#2908)"

### DIFF
--- a/libi3/font.c
+++ b/libi3/font.c
@@ -105,7 +105,7 @@ static void draw_text_pango(const char *text, size_t text_len,
         pango_layout_set_text(layout, text, text_len);
 
     /* Do the drawing */
-    cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
     cairo_set_source_rgb(cr, pango_font_red, pango_font_green, pango_font_blue);
     pango_cairo_update_layout(cr, layout);
     pango_layout_get_pixel_size(layout, NULL, &height);


### PR DESCRIPTION
This reverts commit 16160462a30f186f5b72bb551ba2188670d4e45c.