### PR TITLE
Make sure that parse_config input terminates with '\0'

### DIFF
--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -1025,7 +1025,7 @@ bool parse_file(const char *f, bool use_nagbar) {
     /* Then, allocate a new buffer and copy the file over to the new one,
      * but replace occurrences of our variables */
     char *walk = buf, *destwalk;
-    char *new = smalloc(stbuf.st_size + extra_bytes + 1);
+    char *new = scalloc(stbuf.st_size + extra_bytes + 1, 1);
     destwalk = new;
     while (walk < (buf + stbuf.st_size)) {
         /* Find the next variable */

--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -835,17 +835,17 @@ sub launch_with_config {
 
     my ($fh, $tmpfile) = tempfile("i3-cfg-for-$ENV{TESTNAME}-XXXXX", UNLINK => 1);
 
+    say $fh "ipc-socket $tmp_socket_path"
+        unless $args{dont_add_socket_path};
+
     if ($config ne '-default') {
-        say $fh $config;
+        print $fh $config;
     } else {
         open(my $conf_fh, '<', '@abs_top_srcdir@/testcases/i3-test.config')
             or $tester->BAIL_OUT("could not open default config: $!");
         local $/;
         say $fh scalar <$conf_fh>;
     }
-
-    say $fh "ipc-socket $tmp_socket_path"
-        unless $args{dont_add_socket_path};
 
     close($fh);
 

--- a/testcases/t/270-config-no-newline-end.t
+++ b/testcases/t/270-config-no-newline-end.t
@@ -1,0 +1,41 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Make sure that configs that end without a newline don't crash i3.
+# Ticket: #2934
+use i3test i3_autostart => 0;
+
+my $first_lines = <<'EOT';
+set $workspace1 workspace number 1
+set $workspace0 workspace eggs
+
+bindsym Mod4+1 $workspace1
+EOT
+
+# Intentionally don't add a trailing newline for the last line since this is
+# what triggered the bug.
+my $last_line = 'bindsym Mod4+0 $workspace0';
+my $config = "${first_lines}${last_line}";
+
+my $pid = launch_with_config($config);
+does_i3_live;
+
+my $i3 = i3(get_socket_path());
+my $ws = $i3->get_workspaces->recv;
+is($ws->[0]->{name}, 'eggs', 'last line processed correctly');
+
+exit_gracefully($pid);
+done_testing;


### PR DESCRIPTION
Fixes #2934