### PR TITLE
Add -name argument for Xephyr

### DIFF
--- a/testcases/lib/StartXServer.pm
+++ b/testcases/lib/StartXServer.pm
@@ -105,7 +105,7 @@ sub start_xserver {
     for (1 .. $parallel) {
         my $socket = fork_xserver($keep_xserver_output, $displaynum,
                 'Xephyr', ":$displaynum", '-screen', '1280x800',
-                '-nolisten', 'tcp');
+                '-nolisten', 'tcp', '-name', "i3test");
         push(@displays, ":$displaynum");
         push(@sockets_waiting, $socket);
         $displaynum++;


### PR DESCRIPTION
This way you can assign the test windows to an empty workspace to avoid
interacting with them:
`assign [instance="(?i)i3test"] workspace testing`

The value is configurable through complete-run.pl.