### PR TITLE
Add .editorconfig (see editorconfig.org)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{c,h}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true


### PR DESCRIPTION
This file uses the same settings which we currently have in our vim modeline,
but can be picked up by many different editors without having to add and
maintain editor-specific modelines in all of our source files.