### PR TITLE
simplify tests which use launch_with_config precisely once

### DIFF
--- a/testcases/lib/SocketActivation.pm
+++ b/testcases/lib/SocketActivation.pm
@@ -49,6 +49,11 @@ sub activate_i3 {
         die "could not fork()";
     }
     if ($pid == 0) {
+        # Start a process group so that in the parent, we can kill the entire
+        # process group and immediately kill i3bar and any other child
+        # processes.
+        setpgrp;
+
         $ENV{LISTEN_PID} = $$;
         $ENV{LISTEN_FDS} = 1;
         delete $ENV{DESKTOP_STARTUP_ID};

--- a/testcases/lib/TestWorker.pm
+++ b/testcases/lib/TestWorker.pm
@@ -47,12 +47,9 @@ sub worker {
 
         $worker->{ipc} = $ipc_child;
 
+        # Preload the i3test module: reduces user CPU from 25s to 18s
         require i3test;
-        # TODO: recycle $x
-        # unfortunately this fails currently with:
-        # Could not get reply for: xcb_intern_atom_reply at X11/XCB/Atom.pm line 22.
 
-        # $i3test::x = bless $x, 'i3test::X11';
         worker_wait($worker, $outdir);
         exit 23;
 
@@ -86,11 +83,11 @@ sub worker_wait {
 
         exit unless $file;
 
-        die "tried to launch nonexistend testfile $file: $!\n"
+        die "tried to launch nonexistent testfile $file: $!\n"
             unless -e $file;
 
         # start a new and self contained process:
-        # whatever happens in the testfile should *NOT* effect us.
+        # whatever happens in the testfile should *NOT* affect us.
 
         my $pid = fork // die "could not fork: $!";
         if ($pid == 0) {

--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -100,14 +100,8 @@ my $i3_pid;
 my $i3_autostart;
 
 END {
-
-    # testcases which start i3 manually should always call exit_gracefully
-    # on their own. Let’s see, whether they really did.
-    if (! $i3_autostart) {
-        return unless $i3_pid;
-
-        $tester->ok(undef, 'testcase called exit_gracefully()');
-    }
+    # Skip the remaining cleanup for testcases which set i3_autostart => 0:
+    return if !defined($i3_pid) && !$i3_autostart;
 
     # don't trigger SIGCHLD handler
     local $SIG{CHLD};

--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -793,14 +793,7 @@ sub get_socket_path {
     if ($cache && defined($_cached_socket_path)) {
         return $_cached_socket_path;
     }
-
-    my $atom = $x->atom(name => 'I3_SOCKET_PATH');
-    my $cookie = $x->get_property(0, $x->get_root_window(), $atom->id, GET_PROPERTY_TYPE_ANY, 0, 256);
-    my $reply = $x->get_property_reply($cookie->{sequence});
-    my $socketpath = $reply->{value};
-    if ($socketpath eq "/tmp/nested-$ENV{DISPLAY}") {
-        $socketpath .= '-activation';
-    }
+    my $socketpath = i3test::Util::get_socket_path($x);
     $_cached_socket_path = $socketpath;
     return $socketpath;
 }

--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -126,7 +126,7 @@ END {
         exit_gracefully($i3_pid, "/tmp/nested-$ENV{DISPLAY}");
 
     } else {
-        kill(9, $i3_pid)
+        kill(-9, $i3_pid)
             or $tester->BAIL_OUT("could not kill i3");
 
         waitpid $i3_pid, 0;
@@ -138,8 +138,9 @@ sub import {
     my $pkg = caller;
 
     $i3_autostart = delete($args{i3_autostart}) // 1;
+    my $i3_config = delete($args{i3_config}) // '-default';
 
-    my $cv = launch_with_config('-default', dont_block => 1)
+    my $cv = launch_with_config($i3_config, dont_block => 1)
         if $i3_autostart;
 
     my $test_more_args = '';

--- a/testcases/lib/i3test/Util.pm
+++ b/testcases/lib/i3test/Util.pm
@@ -5,9 +5,13 @@ use strict;
 use warnings;
 use v5.10;
 
+use X11::XCB qw(GET_PROPERTY_TYPE_ANY);
+use X11::XCB::Connection;
+
 use Exporter qw(import);
 our @EXPORT = qw(
     slurp
+    get_socket_path
 );
 
 =encoding utf-8
@@ -36,6 +40,25 @@ sub slurp {
     };
 
     return $content;
+}
+
+=head2 get_socket_path([X11::XCB::Connection])
+
+Gets the socket path from the C<I3_SOCKET_PATH> atom stored on the X11 root
+window.
+
+=cut
+sub get_socket_path {
+    my ($x) = @_;
+    $x //= X11::XCB::Connection->new();
+    my $atom = $x->atom(name => 'I3_SOCKET_PATH');
+    my $cookie = $x->get_property(0, $x->get_root_window(), $atom->id, GET_PROPERTY_TYPE_ANY, 0, 256);
+    my $reply = $x->get_property_reply($cookie->{sequence});
+    my $socketpath = $reply->{value};
+    if ($socketpath eq "/tmp/nested-$ENV{DISPLAY}") {
+        $socketpath .= '-activation';
+    }
+    return $socketpath;
 }
 
 =head1 AUTHOR

--- a/testcases/lib/i3test/XTEST.pm
+++ b/testcases/lib/i3test/XTEST.pm
@@ -5,7 +5,8 @@ use strict;
 use warnings;
 use v5.10;
 
-use i3test i3_autostart => 0;
+use Test::More;
+use i3test::Util qw(get_socket_path);
 use lib qw(@abs_top_srcdir@/AnyEvent-I3/blib/lib);
 use AnyEvent::I3;
 use ExtUtils::PkgConfig;

--- a/testcases/t/000-load-deps.t
+++ b/testcases/t/000-load-deps.t
@@ -11,7 +11,6 @@ BEGIN {
         IPC::Run
         ExtUtils::PkgConfig
         Inline
-        Test::More
     );
     for my $dep (@deps) {
         use_ok($dep) or BAIL_OUT(qq|The Perl module "$dep" could not be loaded. Please see http://build.i3wm.org/docs/testsuite.html#_installing_the_dependencies|);

--- a/testcases/t/156-fullscreen-focus.t
+++ b/testcases/t/156-fullscreen-focus.t
@@ -18,22 +18,16 @@
 # the time of launching the new one. Also make sure that focusing containers
 # in other workspaces work even when there is a fullscreen container.
 #
-use i3test i3_autostart => 0;
-
-# Screen setup looks like this:
-# +----+----+
-# | S1 | S2 |
-# +----+----+
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-
-my $pid = launch_with_config($config);
-
-my $i3 = i3(get_socket_path());
+# Screen setup looks like this:
+# +----+----+
+# | S1 | S2 |
+# +----+----+
 
 my $tmp = fresh_workspace;
 
@@ -330,7 +324,5 @@ cmd "move to workspace prev";
 verify_move(2, 'prevented move to workspace by position');
 
 # TODO: Tests for "move to output" and "move workspace to output".
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/186-regress-assign-focus-parent.t
+++ b/testcases/t/186-regress-assign-focus-parent.t
@@ -19,16 +19,12 @@
 # Wrong behaviour manifested itself up to (including) commit
 # f78caf8c5815ae7a66de9e4b734546fd740cc19d
 #
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 assign [title="testcase"] targetws
 EOT
-
-my $pid = launch_with_config($config);
 
 my $i3 = i3(get_socket_path(0));
 
@@ -50,7 +46,5 @@ cmd 'focus parent';
 
 open_window(name => "testcase");
 is_num_children('targetws', 3, 'new window opened next to last one');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/199-ipc-mode-event.t
+++ b/testcases/t/199-ipc-mode-event.t
@@ -15,9 +15,7 @@
 #   (unless you are already familiar with Perl)
 #
 # Verifies that the IPC 'mode' event is sent when modes are changed.
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -29,8 +27,6 @@ mode "with spaces" {
     bindsym Mod1+y nop bar
 }
 EOT
-
-my $pid = launch_with_config($config);
 
 my $i3 = i3(get_socket_path(0));
 $i3->connect->recv;
@@ -51,7 +47,5 @@ my $t;
 $t = AnyEvent->timer(after => 0.5, cb => sub { $cv->send(0); });
 
 ok($cv->recv, 'Mode event received');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/200-urgency-timer.t
+++ b/testcases/t/200-urgency-timer.t
@@ -20,20 +20,13 @@
 #
 
 use List::Util qw(first);
-use i3test i3_autostart => 0;
-use Time::HiRes qw(sleep);
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 force_display_urgency_hint 500ms
 EOT
-my $pid = launch_with_config($config);
+use Time::HiRes qw(sleep);
 
 #####################################################################
 # Initial setup: one window on ws1, empty ws2
@@ -144,7 +137,5 @@ sync_with_i3;
 
 sleep(0.6);
 is(count_total_urgent(get_ws($tmp3)), 0, "no more urgent windows on workspace $tmp3");
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/207-shmlog.t
+++ b/testcases/t/207-shmlog.t
@@ -14,7 +14,7 @@
 # • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
 #   (unless you are already familiar with Perl)
 #
-use i3test i3_autostart => 0;
+use i3test;
 use IPC::Run qw(run);
 use File::Temp;
 
@@ -22,14 +22,8 @@ use File::Temp;
 # 1: test that shared memory logging does not work yet
 ################################################################################
 
-my $config = <<EOT;
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-EOT
-
-# NB: launch_with_config sets --shmlog-size=0 because the logfile gets
-# redirected via stdout redirection anyways.
-my $pid = launch_with_config($config);
+# NB: launch_with_config (called in i3test) sets --shmlog-size=0 because the
+# logfile gets redirected via stdout redirection anyways.
 
 my $stdout;
 my $stderr;
@@ -81,7 +75,5 @@ run [ 'i3-dump-log' ],
 
 like($stderr, qr#^i3-dump-log: ERROR: i3 is running, but SHM logging is not enabled\.#,
     'shm logging not enabled');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/208-regress-floating-criteria.t
+++ b/testcases/t/208-regress-floating-criteria.t
@@ -18,17 +18,13 @@
 # criteria for windows on non-visible workspaces.
 # Ticket: #1027
 # Bug still in: 4.5.1-90-g6582da9
-use i3test i3_autostart => 0;
-
-my $config = <<'EOT';
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 assign [class="^special$"] → mail
 for_window [class="^special$"] floating enable, floating disable
 EOT
-
-my $pid = launch_with_config($config);
 
 my $window = open_window(
     name => 'Borderless window',
@@ -42,7 +38,5 @@ sync_with_i3;
 cmd '[class="^special$"] focus';
 
 does_i3_live;
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/211-regress-urgency-assign.t
+++ b/testcases/t/211-regress-urgency-assign.t
@@ -20,7 +20,12 @@
 #
 # Ticket: #1086
 # Bug still in: 4.6-62-g7098ef6
-use i3test i3_autostart => 0;
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+assign [class="special"] nonvisible
+EOT
 
 sub open_special {
     my %args = @_;
@@ -38,14 +43,6 @@ sub open_special {
     return $window;
 }
 
-my $config = <<EOT;
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-
-assign [class="special"] nonvisible
-EOT
-my $pid = launch_with_config($config);
-
 my $tmp = fresh_workspace;
 
 ok((scalar grep { $_ eq 'nonvisible' } @{get_workspace_names()}) == 0,
@@ -59,7 +56,5 @@ ok((scalar grep { $_ eq 'nonvisible' } @{get_workspace_names()}) > 0,
 
 my @urgent = grep { $_->{urgent} } @{get_ws_content('nonvisible')};
 isnt(@urgent, 0, 'urgent window(s) found on destination workspace');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/222-regress-dock-resize.t
+++ b/testcases/t/222-regress-dock-resize.t
@@ -18,17 +18,10 @@
 # client.
 # Ticket: #1201
 # Bug still in: 4.7.2-107-g9b03be6
-use i3test i3_autostart => 0;
-
-my $config = <<'EOT';
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 EOT
-
-my $pid = launch_with_config($config);
-
-my $i3 = i3(get_socket_path());
-$i3->connect()->recv;
 
 my $window = open_window(
     wm_class => 'special',
@@ -38,7 +31,5 @@ my $window = open_window(
 cmd('[class="special"] resize grow height 160 px or 16 ppt');
 
 does_i3_live;
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/230-floating-fullscreen-restart.t
+++ b/testcases/t/230-floating-fullscreen-restart.t
@@ -18,16 +18,13 @@
 # and that they keep their geometry.
 # Ticket: #1263
 # Bug still in: 4.7.2-200-g570b572
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 for_window [instance=__i3-test-window] floating enable, border pixel 1
 EOT
 
-my $pid = launch_with_config($config);
 my $tmp = fresh_workspace;
 
 my $window = open_window(wm_class => '__i3-test-window');
@@ -45,7 +42,5 @@ cmd 'restart';
 $floating_win = $nodes->{floating_nodes}->[0]->{nodes}->[0];
 is($floating_win->{fullscreen_mode}, 1, 'floating window still in fullscreen mode');
 is_deeply($floating_win->{geometry}, $old_geometry, 'floating window geometry still the same');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/233-regress-manage-focus-unmapped.t
+++ b/testcases/t/233-regress-manage-focus-unmapped.t
@@ -19,17 +19,13 @@
 # which can lead to complications
 # Ticket: #1283
 # Bug still in: 4.8-24-g60070de
-use i3test i3_autostart => 0;
-
-my $config = <<'EOT';
+use i3test i3_config => <<'EOT';
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 for_window [class="^special_kill$"] kill
 for_window [class="^special_scratchpad$"] move scratchpad
 EOT
-
-my $pid = launch_with_config($config);
 
 my $win = open_window;
 
@@ -52,7 +48,5 @@ sync_with_i3;
 
 is($x->input_focus, $win->{id},
     'an assignment that kills a window should not disturb focus');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/237-regress-assign-focus.t
+++ b/testcases/t/237-regress-assign-focus.t
@@ -18,9 +18,7 @@
 # assigned to an invisible workspace) will not crash i3.
 # Ticket: #1338
 # Bug still in: 4.8-91-g294d52e
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -28,15 +26,11 @@ assign [title=".*"] 1
 for_window [title=".*"] layout tabbed, focus
 EOT
 
-my $pid = launch_with_config($config);
-
 # Switch away from workspace 1
 my $tmp = fresh_workspace;
 
 my $win = open_window;
 
 does_i3_live;
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/241-consistent-center.t
+++ b/testcases/t/241-consistent-center.t
@@ -18,17 +18,13 @@
 # Decorations are disabled to avoid floating_enable's logic which shifts
 # windows upwards dependent on their decoration height.
 #
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 new_window none
 new_float none
 EOT
-
-my $pid = launch_with_config($config);
 
 #####################################################################
 # Open a floating window, verifying that its initial position is
@@ -100,7 +96,5 @@ sync_with_i3;
 my $child = $fourth->rect;
 is($new->{x}, $child->{x}, 'x coordinates match');
 is($new->{y}, $child->{y}, 'y coordinates match');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/244-new-workspace-floating-enable-center.t
+++ b/testcases/t/244-new-workspace-floating-enable-center.t
@@ -17,17 +17,13 @@
 # Ensures that 'move workspace $new, floating enable' on a marked window
 # leaves the window centered on the new workspace.
 # Bug still in: 4.10.2-137-ga4f0ed6
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 new_window none
 new_float none
 EOT
-
-my $pid = launch_with_config($config);
 
 #####################################################################
 # Open a tiled window, and then simultaneously move it to another
@@ -47,7 +43,5 @@ is(int($pos->{x} + $pos->{width} / 2), int($x->root->rect->width / 2),
     'x coordinates match');
 is(int($pos->{y} + $pos->{height} / 2), int($x->root->rect->height / 2),
     'y coordinates match');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/248-regress-urgency-clear.t
+++ b/testcases/t/248-regress-urgency-clear.t
@@ -18,7 +18,12 @@
 # to focus_on_window_activation=urgent), hence the application not clearing it.
 # Ticket: #1825
 # Bug still in: 4.10.3-253-g03799dd
-use i3test i3_autostart => 0;
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+focus_on_window_activation urgent
+EOT
 
 sub send_net_active_window {
     my ($id) = @_;
@@ -35,15 +40,6 @@ sub send_net_active_window {
     $x->send_event(0, $x->get_root_window(), X11::XCB::EVENT_MASK_SUBSTRUCTURE_REDIRECT, $msg);
 }
 
-my $config = <<'EOT';
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-
-focus_on_window_activation urgent
-EOT
-
-my $pid = launch_with_config($config);
-my $i3 = i3(get_socket_path(0));
 my $ws = fresh_workspace;
 my $first = open_window;
 my $second = open_window;
@@ -63,7 +59,5 @@ is($x->input_focus, $second->id, 'second window focused again');
 cmd '[urgent=latest] focus';
 sync_with_i3;
 is($x->input_focus, $second->id, 'second window still focused');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/254-move-to-output-with-criteria.t
+++ b/testcases/t/254-move-to-output-with-criteria.t
@@ -17,16 +17,12 @@
 # Verifies that "move container to output" works correctly when
 # used with command criteria.
 # Bug still in: 4.10.4-349-gee5db87
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 800x600+0+0,800x600+800+0,800x600+0+600,800x600+800+600
 EOT
-
-my $pid = launch_with_config($config);
 
 my $ws_top_left = fresh_workspace(output => 0);
 my $ws_top_right = fresh_workspace(output => 1);
@@ -44,7 +40,5 @@ is_num_children($ws_top_left, 0, 'no containers on the upper left workspace');
 is_num_children($ws_top_right, 1, 'one container on the upper right workspace');
 is_num_children($ws_bottom_left, 0, 'no containers on the lower left workspace');
 is_num_children($ws_bottom_right, 1, 'one container on the lower right workspace');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/257-keypress-group1-fallback.t
+++ b/testcases/t/257-keypress-group1-fallback.t
@@ -19,7 +19,14 @@
 # Ticket: #2062
 # Bug still in: 4.11-103-gc8d51b4
 # Bug introduced with commit 0e5180cae9e9295678e3f053042b559e82cb8c98
-use i3test i3_autostart => 0;
+use i3test
+    i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+bindsym Print nop Print
+bindsym Mod4+Return nop Mod4+Return
+EOT
 use i3test::XTEST;
 use ExtUtils::PkgConfig;
 
@@ -28,16 +35,6 @@ SKIP: {
         ExtUtils::PkgConfig->atleast_version('xcb-xkb', '1.11');
     skip "setxkbmap not found", 1 if
         system(q|setxkbmap -print >/dev/null|) != 0;
-
-my $config = <<EOT;
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-
-bindsym Print nop Print
-bindsym Mod4+Return nop Mod4+Return
-EOT
-
-my $pid = launch_with_config($config);
 
 start_binding_capture;
 
@@ -91,8 +88,6 @@ is(scalar @i3test::XTEST::binding_events, 4, 'Received exactly 4 binding events'
 
 # Disable the grp:alt_shift_toggle option, as we use Alt+Shift in other testcases.
 system(q|setxkbmap us -option|);
-
-exit_gracefully($pid);
 
 }
 

--- a/testcases/t/258-keypress-release.t
+++ b/testcases/t/258-keypress-release.t
@@ -19,15 +19,7 @@
 # Ticket: #2002
 # Bug still in: 4.11-103-gc8d51b4
 # Bug introduced with commit bf3cd41b5ddf1e757515ab5fbf811be56e5f69cc
-use i3test i3_autostart => 0;
-use i3test::XTEST;
-use ExtUtils::PkgConfig;
-
-SKIP: {
-    skip "libxcb-xkb too old (need >= 1.11)", 1 unless
-        ExtUtils::PkgConfig->atleast_version('xcb-xkb', '1.11');
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -38,8 +30,12 @@ bindsym --release Control+Print nop Control+Print
 bindsym Mod1+b nop Mod1+b
 bindsym --release Mod1+Shift+b nop Mod1+Shift+b release
 EOT
+use i3test::XTEST;
+use ExtUtils::PkgConfig;
 
-my $pid = launch_with_config($config);
+SKIP: {
+    skip "libxcb-xkb too old (need >= 1.11)", 1 unless
+        ExtUtils::PkgConfig->atleast_version('xcb-xkb', '1.11');
 
 start_binding_capture;
 
@@ -89,8 +85,6 @@ is(listen_for_binding(
 
 sync_with_i3;
 is(scalar @i3test::XTEST::binding_events, 4, 'Received exactly 4 binding events');
-
-exit_gracefully($pid);
 
 }
 

--- a/testcases/t/263-config-reload-reverts-bind-mode.t
+++ b/testcases/t/263-config-reload-reverts-bind-mode.t
@@ -18,17 +18,13 @@
 # binding mode.
 # Ticket: #2228
 # Bug still in: 4.11-262-geb631ce
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 mode "othermode" {
 }
 EOT
-
-my $pid = launch_with_config($config);
 
 cmd 'mode othermode';
 
@@ -50,7 +46,5 @@ my $t;
 $t = AnyEvent->timer(after => 0.5, cb => sub { $cv->send(0); });
 
 ok($cv->recv, 'Mode event received');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/264-dock-criteria.t
+++ b/testcases/t/264-dock-criteria.t
@@ -16,14 +16,10 @@
 #
 # Verifies that command or config criteria does not match dock clients
 # Bug still in: 4.12-38-ge690e3d
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 for_window [class="dock"] move workspace current
 EOT
-
-my $pid = launch_with_config($config);
 
 my $ws = fresh_workspace();
 
@@ -67,5 +63,4 @@ is(get_dock_clients, 2, "created second docked client");
 is_num_children($ws, 0, 'no container on the current workspace');
 
 
-exit_gracefully($pid);
 done_testing;

--- a/testcases/t/264-dock-criteria.t
+++ b/testcases/t/264-dock-criteria.t
@@ -19,6 +19,11 @@
 use i3test i3_config => <<EOT;
 # i3 config file (v4)
 for_window [class="dock"] move workspace current
+
+bar {
+    # Disable i3bar, which is also a dock client.
+    i3bar_command :
+}
 EOT
 
 my $ws = fresh_workspace();

--- a/testcases/t/271-for_window_tilingfloating.t
+++ b/testcases/t/271-for_window_tilingfloating.t
@@ -14,21 +14,18 @@
 # • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
 #   (unless you are already familiar with Perl)
 #
-use i3test i3_autostart => 0;
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+for_window [tiling] mark tiled
+for_window [floating] mark floated
+EOT
 use X11::XCB qw(PROP_MODE_REPLACE);
 
 ##############################################################
 # 13: check that the tiling / floating criteria work.
 ##############################################################
 
-my $config = <<"EOT";
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-for_window [tiling] mark tiled
-for_window [floating] mark floated
-EOT
-
-my $pid = launch_with_config($config);
 my $tmp = fresh_workspace;
 
 open_window;
@@ -41,8 +38,6 @@ is_deeply($nodes[0]->{marks}, [ 'tiled' ], "mark set for 'tiling' criterion");
 @nodes = @{get_ws($tmp)->{floating_nodes}};
 cmp_ok(@nodes, '==', 1, 'one floating container on this workspace');
 is_deeply($nodes[0]->{nodes}[0]->{marks}, [ 'floated' ], "mark set for 'floating' criterion");
-
-exit_gracefully($pid);
 
 ##############################################################
 

--- a/testcases/t/272-regress-focus-assign.t
+++ b/testcases/t/272-regress-focus-assign.t
@@ -17,7 +17,11 @@
 # Regression: Checks if focus is stolen when a window is managed which is
 # assigned to an invisible workspace
 #
-use i3test i3_autostart => 0;
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+assign [class="special"] targetws
+EOT
 
 sub open_special {
     my %args = @_;
@@ -37,14 +41,6 @@ sub open_special {
 #####################################################################
 # start a window and see that it does not get assigned with an empty config
 #####################################################################
-
-my $config = <<EOT;
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-assign [class="special"] targetws
-EOT
-
-my $pid = launch_with_config($config);
 
 my $tmp = fresh_workspace;
 
@@ -69,8 +65,6 @@ $window = open_special(
 ok(@{get_ws_content($tmp)} == 0, 'special window not on current workspace');
 ok(@{get_ws_content('targetws')} == 1, 'special window on targetws');
 ok(get_ws($tmp)->{focused}, 'current workspace still focused');
-
-exit_gracefully($pid);
 
 $window->destroy;
 

--- a/testcases/t/279-regress-default-floating-border.t
+++ b/testcases/t/279-regress-default-floating-border.t
@@ -18,17 +18,13 @@
 # not applied when the default tiling border is set to a pixel value.
 # Ticket: #1305
 # Bug still in: 4.8-62-g7381b50
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 new_window pixel 5
 new_float normal
 EOT
-
-my $pid = launch_with_config($config);
 
 my $ws = fresh_workspace;
 
@@ -37,7 +33,5 @@ my $float_window = open_floating_window;
 my @floating = @{get_ws($ws)->{floating_nodes}};
 
 is($floating[0]->{nodes}[0]->{border}, 'normal', 'default floating border is `normal`');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/280-wm-class-change-handler.t
+++ b/testcases/t/280-wm-class-change-handler.t
@@ -19,16 +19,12 @@
 # in criteria selection
 # Ticket: #1052
 # Bug still in: 4.8-73-g6bf7f8e
-use i3test i3_autostart => 0;
-use X11::XCB qw(PROP_MODE_REPLACE);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 for_window [class="Special"] mark special_class_mark
 EOT
-
-my $pid = launch_with_config($config);
+use X11::XCB qw(PROP_MODE_REPLACE);
 
 sub change_window_class {
     my ($window, $class, $length) = @_;
@@ -72,7 +68,5 @@ $con = @{get_ws_content($ws)}[0];
 
 is($con->{window_properties}->{class}, 'a',
     'Non-null-terminated strings should be handled correctly');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/281-regress-reload-bindsym.t
+++ b/testcases/t/281-regress-reload-bindsym.t
@@ -16,9 +16,7 @@
 #
 # Test that the binding event works properly
 # Ticket: #1210
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -30,16 +28,9 @@ SKIP: {
 
     skip 'xdotool is required to test the binding event. `[apt-get install|pacman -S] xdotool`', 1 if $?;
 
-    my $pid = launch_with_config($config);
-
-    my $i3 = i3(get_socket_path());
-    $i3->connect->recv;
-
     qx(xdotool key r);
 
     does_i3_live;
-
-    exit_gracefully($pid);
 
 }
 done_testing;

--- a/testcases/t/282-tabbed-floating-disable-crash.t
+++ b/testcases/t/282-tabbed-floating-disable-crash.t
@@ -18,15 +18,11 @@
 # unfocused window within a tabbed container.
 # Ticket: #1484
 # Bug still in: 4.9.1-124-g856e1f9
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 workspace_layout tabbed
 EOT
-
-my $pid = launch_with_config($config);
 
 open_window;
 open_window;
@@ -38,7 +34,5 @@ cmd 'mark foo, focus parent, focus parent';
 cmd '[con_mark=foo] floating enable, floating disable';
 
 does_i3_live;
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/286-root-window-mouse-binding.t
+++ b/testcases/t/286-root-window-mouse-binding.t
@@ -17,18 +17,15 @@
 # Verifies that mouse bindings work on the root window if
 # --whole-window is set.
 # Ticket: #2115
-use i3test i3_autostart => 0;
-use i3test::XTEST;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 workspace_auto_back_and_forth no
 bindsym --whole-window button4 workspace special
 EOT
+use i3test::XTEST;
 
-my $pid = launch_with_config($config);
 fresh_workspace;
 
 xtest_button_press(4, 50, 50);
@@ -36,7 +33,5 @@ xtest_button_release(4, 50, 50);
 sync_with_i3;
 
 is(focused_ws(), 'special', 'the binding was triggered');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/291-swap.t
+++ b/testcases/t/291-swap.t
@@ -16,9 +16,7 @@
 #
 # Tests the swap command.
 # Ticket: #917
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -26,13 +24,10 @@ for_window[class="mark_A"] mark A
 for_window[class="mark_B"] mark B
 EOT
 
-my ($pid);
 my ($ws, $ws1, $ws2, $ws3);
 my ($nodes, $expected_focus, $A, $B, $F);
 my ($result);
 my @urgent;
-
-$pid = launch_with_config($config);
 
 ###############################################################################
 # Invalid con_id should not crash i3
@@ -424,7 +419,5 @@ is(get_ws($ws2)->{urgent}, 0, 'the second workspace is not marked urgent');
 kill_all_windows;
 
 ###############################################################################
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/500-multi-monitor.t
+++ b/testcases/t/500-multi-monitor.t
@@ -17,15 +17,12 @@
 # Tests that the provided X-Server to the t/5??-*.t tests is actually providing
 # multiple monitors.
 #
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-my $pid = launch_with_config($config);
 
 my $i3 = i3(get_socket_path());
 
@@ -39,6 +36,5 @@ my @outputs = map { $_->{name} } @{$tree->{nodes}};
 is_deeply(\@outputs, [ '__i3', 'fake-0', 'fake-1' ],
           'multi-monitor outputs ok');
 
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/501-scratchpad.t
+++ b/testcases/t/501-scratchpad.t
@@ -18,17 +18,12 @@
 # ticket #596, bug present until up to commit
 # 89dded044b4fffe78f9d70778748fabb7ac533e9.
 #
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-my $pid = launch_with_config($config);
-
-my $i3 = i3(get_socket_path());
 
 ################################################################################
 # Open a workspace on the second output, put a window to scratchpad, display
@@ -112,7 +107,5 @@ $first = fresh_workspace(output => 1);
 $second = fresh_workspace(output => 0);
 
 verify_scratchpad_switch($first, $second);
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/502-focus-output.t
+++ b/testcases/t/502-focus-output.t
@@ -16,16 +16,13 @@
 #
 # Verifies the 'focus output' command works properly.
 
-use i3test i3_autostart => 0;
-use List::Util qw(first);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-my $pid = launch_with_config($config);
+use List::Util qw(first);
 
 my $tmp = fresh_workspace;
 my $i3 = i3(get_socket_path());
@@ -88,7 +85,5 @@ is(focused_output, 'fake-1', 'focus on second output');
 
 cmd 'focus output fake-0';
 is(focused_output, 'fake-0', 'focus on first output');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/503-workspace.t
+++ b/testcases/t/503-workspace.t
@@ -17,15 +17,12 @@
 # Tests whether 'workspace next_on_output' and the like work correctly.
 #
 use List::Util qw(first);
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-my $pid = launch_with_config($config);
 
 ################################################################################
 # Setup workspaces so that they stay open (with an empty container).
@@ -99,7 +96,5 @@ sync_with_i3;
 
 cmd 'workspace prev_on_output';
 is(focused_ws, '2', 'workspace 2 focused');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/504-move-workspace-to-output.t
+++ b/testcases/t/504-move-workspace-to-output.t
@@ -17,19 +17,14 @@
 # Tests whether the 'move workspace <ws> to [output] <output>' command works
 #
 use List::Util qw(first);
-use i3test i3_autostart => 0;
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-my $pid = launch_with_config($config);
+
+# TODO: get rid of smartmatch in this test
 
 ################################################################################
 # Setup workspaces so that they stay open (with an empty container).
@@ -181,5 +176,4 @@ ok($ws1 ~~ @$x0, 'ws1 on fake-0');
 
 ################################################################################
 
-exit_gracefully($pid);
 done_testing;

--- a/testcases/t/504-move-workspace-to-output.t
+++ b/testcases/t/504-move-workspace-to-output.t
@@ -22,6 +22,11 @@ use i3test i3_config => <<EOT;
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
+
+bar {
+    # Disable i3bar.
+    i3bar_command :
+}
 EOT
 
 # TODO: get rid of smartmatch in this test

--- a/testcases/t/505-scratchpad-resolution.t
+++ b/testcases/t/505-scratchpad-resolution.t
@@ -17,17 +17,12 @@
 # Verifies that scratchpad windows don’t move due to floating point caulcation
 # errors when repeatedly hiding/showing, no matter what display resolution.
 #
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 683x768+0+0,1024x768+683+0
 EOT
-my $pid = launch_with_config($config);
-
-my $i3 = i3(get_socket_path());
 
 sync_with_i3;
 $x->root->warp_pointer(0, 0);
@@ -83,7 +78,5 @@ sync_with_i3;
 
 my $third = fresh_workspace(output => 1);
 verify_scratchpad_doesnt_move($third);
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/507-workspace-move-crash.t
+++ b/testcases/t/507-workspace-move-crash.t
@@ -19,19 +19,12 @@
 # Bug still in: 4.3-78-g66b389c
 #
 use List::Util qw(first);
-use i3test i3_autostart => 0;
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-my $pid = launch_with_config($config);
 
 ################################################################################
 # Setup workspaces so that they stay open (with an empty container).
@@ -42,7 +35,5 @@ is(focused_ws, '1', 'starting on workspace 1');
 cmd 'move workspace to output fake-1';
 
 does_i3_live;
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/509-workspace_layout.t
+++ b/testcases/t/509-workspace_layout.t
@@ -17,27 +17,20 @@
 # Tests whether workspace_layout is properly set after startup.
 #
 use List::Util qw(first);
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0
 workspace_layout tabbed
 EOT
-my $pid = launch_with_config($config);
 
 ################################################################################
 # Test that workspace_layout is properly set
 ################################################################################
 
-
 is(focused_ws, '1', 'starting on workspace 1');
 my $ws = get_ws(1);
 is($ws->{workspace_layout}, 'tabbed', 'workspace layout is "tabbed"');
-
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/510-focus-across-outputs.t
+++ b/testcases/t/510-focus-across-outputs.t
@@ -17,19 +17,12 @@
 # Tests that switching workspaces via 'focus $dir' never leaves a floating
 # window focused.
 #
-use i3test i3_autostart => 0;
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0,1024x768+0+768,1024x768+1024+768
 EOT
-my $pid = launch_with_config($config);
 
 my $s0_ws = fresh_workspace;
 my $first = open_window;
@@ -143,7 +136,5 @@ is($x->input_focus, $sixth->id, 'sixth window focused');
 cmd "workspace $s2_ws";
 cmd 'focus up';
 is($x->input_focus, $second->id, 'second window focused');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/511-scratchpad-configure-request.t
+++ b/testcases/t/511-scratchpad-configure-request.t
@@ -17,20 +17,12 @@
 # Tests that ConfigureRequests don’t make windows fall out of the scratchpad.
 # Ticket: #898
 # Bug still in: 4.4-15-g770ead6
-use i3test i3_autostart => 0;
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-
-my $pid = launch_with_config($config);
 
 my $left_ws = fresh_workspace(output => 0);
 my $right_ws = fresh_workspace(output => 1);
@@ -48,7 +40,5 @@ my $ws = get_ws($left_ws);
 is(scalar @{$ws->{floating_nodes}}, 0, 'scratchpad window still in scratchpad after ConfigureRequest');
 $ws = get_ws($right_ws);
 is(scalar @{$ws->{floating_nodes}}, 0, 'scratchpad window still in scratchpad after ConfigureRequest');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/512-move-wraps.t
+++ b/testcases/t/512-move-wraps.t
@@ -18,20 +18,12 @@
 # E.g. when you have a container on the right output and you move it to the
 # right, it should appear on the left output.
 # Bug still in: 4.4-106-g3cd4b8c
-use i3test i3_autostart => 0;
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-
-my $pid = launch_with_config($config);
 
 my $right = fresh_workspace(output => 1);
 my $left = fresh_workspace(output => 0);
@@ -50,7 +42,5 @@ cmd 'move container to output right';
 
 is_num_children($left, 1, 'one container on left workspace');
 is_num_children($right, 0, 'no containers on right workspace');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/513-move-workspace.t
+++ b/testcases/t/513-move-workspace.t
@@ -15,21 +15,13 @@
 #   (unless you are already familiar with Perl)
 #
 # Tests whether moving workspaces between outputs works correctly.
-use i3test i3_autostart => 0;
-use List::Util qw(first);
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-
-my $pid = launch_with_config($config);
+use List::Util qw(first);
 
 sub workspaces_per_screen {
     my $i3 = i3(get_socket_path());
@@ -91,7 +83,5 @@ cmd '[id="' . $win1->id . '"] focus';
 
 ($nodes, $focus) = get_ws_content('5');
 is($nodes->[1]->{window}, $win1->id, 'window 1 on workspace 5 after moving');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/514-ipc-workspace-multi-monitor.t
+++ b/testcases/t/514-ipc-workspace-multi-monitor.t
@@ -17,19 +17,11 @@
 # Ticket: #990
 # Bug still in: 4.5.1-23-g82b5978
 
-use i3test i3_autostart => 0;
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-
-my $pid = launch_with_config($config);
 
 my $i3 = i3(get_socket_path());
 
@@ -72,7 +64,5 @@ my $current_ws = get_ws(focused_ws);
 ok($event, 'Workspace "focus" event received');
 is($event->{current}->{id}, $current_ws->{id}, 'Event gave correct current workspace');
 is($event->{old}->{id}, $old_ws->{id}, 'Event gave correct old workspace');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/515-create-workspace.t
+++ b/testcases/t/515-create-workspace.t
@@ -17,9 +17,7 @@
 # Tests that new workspace names are taken from the config,
 # then from the first free number starting with 1.
 #
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -27,14 +25,11 @@ fake-outputs 1024x768+0+0,1024x768+1024+0
 
 bindsym 1 workspace 1: eggs
 EOT
-my $pid = launch_with_config($config);
 
 my $i3 = i3(get_socket_path());
 my $ws = $i3->get_workspaces->recv;
 
 is($ws->[0]->{name}, '1: eggs', 'new workspace uses config name');
 is($ws->[1]->{name}, '2', 'naming continues with next free number');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/516-move.t
+++ b/testcases/t/516-move.t
@@ -16,13 +16,7 @@
 #
 # Tests if a simple 'move <direction>' command will move containers across outputs.
 #
-use i3test i3_autostart => 0;
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -34,7 +28,9 @@ workspace right-bottom output fake-2
 workspace left-bottom output fake-3
 EOT
 
-my $pid = launch_with_config($config);
+# Ensure the pointer is at (0, 0) so that we really start on the first
+# (the left) workspace.
+$x->root->warp_pointer(0, 0);
 
 #####################################################################
 # Try to move a single window across outputs in each direction
@@ -100,7 +96,5 @@ cmd('focus up; move up');
 is(scalar @{get_ws_content('left-top')}, 1, 'moved some window to left-bottom workspace');
 $compare_window = shift @{get_ws_content('left-top')};
 is($social_window->name, $compare_window->{name}, 'moved correct window to left-bottom workspace');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/517-regress-move-direction-ipc.t
+++ b/testcases/t/517-regress-move-direction-ipc.t
@@ -18,9 +18,7 @@
 # ipc event required for i3bar to be properly updated and redrawn.
 #
 # Bug still in: 4.6-195-g34232b8
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -28,8 +26,6 @@ fake-outputs 1024x768+0+0,1024x768+1024+0
 workspace ws-left output fake-0
 workspace ws-right output fake-1
 EOT
-
-my $pid = launch_with_config($config);
 
 my $i3 = i3(get_socket_path());
 $i3->connect()->recv;
@@ -77,7 +73,5 @@ $event = $focus->recv;
 ok($event, 'moving from workspace with one window triggered focus ipc event');
 is($event->{current}->{name}, 'ws-right', 'focus event gave the right workspace');
 is(@{$event->{current}->{nodes}}, 2, 'focus event gave the right number of windows on the workspace');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/518-interpret-workspace-numbers.t
+++ b/testcases/t/518-interpret-workspace-numbers.t
@@ -18,9 +18,7 @@
 # assign any workspace of that number to the specified output.
 # Ticket: #1238
 # Bug still in: 4.7.2-147-g3760a48
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -32,7 +30,6 @@ workspace 2:override output fake-1
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
 
-my $pid = launch_with_config($config);
 my $i3 = i3(get_socket_path());
 $i3->connect->recv;
 
@@ -71,7 +68,5 @@ cmd 'workspace "1:override"';
 is(get_output_for_workspace('1:override'), 'fake-0',
     'Assignment rules should not be affected by the order assignments are declared')
     or diag 'Since workspace "1:override" is assigned by name to fake-0, it should open on fake-0';
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/519-mouse-warping.t
+++ b/testcases/t/519-mouse-warping.t
@@ -11,21 +11,16 @@
 # • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
 #   (unless you are already familiar with Perl)
 
-use i3test i3_autostart => 0;
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 fake-outputs 1024x768+0+0,1024x768+1024+0
 mouse_warping none
 EOT
-my $pid = launch_with_config($config);
 
-my $i3 = i3(get_socket_path());
+# Ensure the pointer is at (0, 0) so that we really start on the first
+# (the left) workspace.
+$x->root->warp_pointer(0, 0);
 
 ######################################################
 # Open one workspace with one window on both outputs #
@@ -47,6 +42,4 @@ $x->root->warp_pointer(0, 0);
 # Ensure focus is still on workspace 2
 is(focused_ws, '2', 'warped mouse cursor to (0, 0), focus still in workspace 2');
 
-# Exit gracefully
-exit_gracefully($pid);
 done_testing;

--- a/testcases/t/520-regress-focus-direction-floating.t
+++ b/testcases/t/520-regress-focus-direction-floating.t
@@ -17,9 +17,7 @@
 # Ensure that `focus [direction]` will focus an existing floating con when no
 # tiling con exists on the output in [direction] when focusing across outputs
 # Bug still in: 4.7.2-204-g893dbae
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -31,8 +29,6 @@ mouse_warping none
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
 
-my $pid = launch_with_config($config);
-
 cmd 'workspace ws_left';
 my $win = open_window();
 
@@ -42,7 +38,5 @@ cmd 'focus left';
 
 is($x->input_focus, $win->id,
     'Focusing across outputs with `focus [direction]` should focus an existing floating con when no tiling con exists on the output in [direction].');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/521-ewmh-desktop-viewport.t
+++ b/testcases/t/521-ewmh-desktop-viewport.t
@@ -18,9 +18,7 @@
 # properly on the root window. We interpret this as a list of x/y coordinate
 # pairs for the upper left corner of the respective outputs of the workspaces
 # Ticket: #1241
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -29,8 +27,6 @@ workspace 1 output fake-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-
-my $pid = launch_with_config($config);
 
 sub get_desktop_viewport {
     # Make sure that i3 pushed its changes to X11 before querying.
@@ -89,7 +85,5 @@ cmd 'workspace 0';
 
 is_deeply(\@desktop_viewport, \@expected_viewport,
     'it should be updated when a workspace is emptied');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/522-rename-assigned-workspace.t
+++ b/testcases/t/522-rename-assigned-workspace.t
@@ -19,9 +19,7 @@
 # are renamed to an assigned name.
 # Ticket: #1473
 
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 fake-outputs 1024x768+0+0,1024x768+1024+0
@@ -32,7 +30,6 @@ workspace 3:foo output fake-1
 workspace baz output fake-1
 EOT
 
-my $pid = launch_with_config($config);
 my $i3 = i3(get_socket_path());
 $i3->connect->recv;
 
@@ -85,6 +82,4 @@ cmd 'rename workspace to baz';
 is(get_output_for_workspace('baz'), 'fake-1',
     'Renaming the workspace to a number and name should move it to the assigned output');
 
-
-exit_gracefully($pid);
 done_testing;

--- a/testcases/t/523-move-position-center.t
+++ b/testcases/t/523-move-position-center.t
@@ -18,9 +18,7 @@
 # the appropriate output.
 # Ticket: #1211
 # Bug still in: 4.9.1-108-g037cb31
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -29,8 +27,6 @@ fake-outputs 1024x768+0+0,1024x768+1024+0
 workspace left output fake-0
 workspace right output fake-1
 EOT
-
-my $pid = launch_with_config($config);
 
 #####################################################################
 # Verify that 'move position center' on a floating window does not
@@ -57,7 +53,5 @@ sync_with_i3;
 
 is(scalar @{get_ws('left')->{floating_nodes}}, 0, 'no floating nodes on left ws');
 is(scalar @{get_ws('right')->{floating_nodes}}, 1, 'one floating node on right ws');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/524-move.t
+++ b/testcases/t/524-move.t
@@ -19,9 +19,7 @@
 # Ticket: #1603
 # Bug still in: 4.10.1-40-g0ad097e
 use List::Util qw(first);
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -34,8 +32,6 @@ workspace left-bottom output fake-3
 
 workspace_layout stacked
 EOT
-
-my $pid = launch_with_config($config);
 
 #####################################################################
 # Create two windows in the upper left workspace and move them
@@ -93,7 +89,5 @@ is_num_children('left-top', 1, 'one child on left-top');
 cmd '[class="first"] move up';
 is_num_children('left-bottom', 0, 'no children on left-bottom');
 is_num_children('left-top', 2, 'two children on left-top');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/526-reconfigure-dock.t
+++ b/testcases/t/526-reconfigure-dock.t
@@ -16,9 +16,14 @@
 #
 # Test reconfiguration of dock clients.
 # Ticket: #1883
-use i3test i3_autostart => 0;
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
-my ($config, $pid, $window, $rect);
+fake-outputs 1024x768+0+0,1024x768+1024+0
+EOT
+
+my ($window, $rect);
 my (@docks);
 
 ###############################################################################
@@ -26,14 +31,6 @@ my (@docks);
 #    client is reconfigured to be positioned on screen B, then the client is
 #    moved to the correct position.
 ###############################################################################
-
-$config = <<EOT;
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-
-fake-outputs 1024x768+0+0,1024x768+1024+0
-EOT
-$pid = launch_with_config($config);
 
 $window = open_window({
         window_type => $x->atom(name => '_NET_WM_WINDOW_TYPE_DOCK')
@@ -49,8 +46,6 @@ sync_with_i3;
 is(@docks, 1, 'there is still exactly one dock');
 
 is($docks[0]->{rect}->{x}, 1024, 'dock client has moved to the other screen');
-
-exit_gracefully($pid);
 
 ###############################################################################
 

--- a/testcases/t/526-reconfigure-dock.t
+++ b/testcases/t/526-reconfigure-dock.t
@@ -21,6 +21,11 @@ use i3test i3_config => <<EOT;
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
+
+bar {
+    # Disable i3bar, which is also a dock client.
+    i3bar_command :
+}
 EOT
 
 my ($window, $rect);

--- a/testcases/t/528-workspace-next-prev-reversed.t
+++ b/testcases/t/528-workspace-next-prev-reversed.t
@@ -17,7 +17,12 @@
 # Tests whether 'workspace next' works correctly.
 #
 use List::Util qw(first);
-use i3test i3_autostart => 0;
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+fake-outputs 1024x768+0+0,1024x768+1024+0
+EOT
 
 sub assert_next {
     my ($expected) = @_;
@@ -42,14 +47,6 @@ sub assert_prev {
 
     is(focused_ws, $expected, "workspace $expected focused");
 }
-
-my $config = <<EOT;
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-
-fake-outputs 1024x768+0+0,1024x768+1024+0
-EOT
-my $pid = launch_with_config($config);
 
 sync_with_i3;
 $x->root->warp_pointer(0, 0);
@@ -123,7 +120,5 @@ assert_prev('3');
 assert_prev('2');
 assert_prev('1');
 
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/529-net-wm-desktop.t
+++ b/testcases/t/529-net-wm-desktop.t
@@ -16,7 +16,14 @@
 #
 # Tests for _NET_WM_DESKTOP.
 # Ticket: #2153
-use i3test i3_autostart => 0;
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+bar {
+    status_command i3status
+}
+EOT
 use X11::XCB qw(:all);
 
 ###############################################################################
@@ -77,19 +84,6 @@ sub open_window_with_net_wm_desktop {
 
     return $window;
 }
-
-###############################################################################
-
-my $config = <<EOT;
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-
-bar {
-    status_command i3status
-}
-EOT
-
-my $pid = launch_with_config($config);
 
 ###############################################################################
 # Upon managing a window which does not set _NET_WM_DESKTOP, the property is
@@ -295,7 +289,5 @@ is(get_net_wm_desktop($con), 0, '_NET_WM_DESKTOP is set sanity check)');
 kill_all_windows;
 
 ###############################################################################
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/530-bug-2229.t
+++ b/testcases/t/530-bug-2229.t
@@ -16,9 +16,7 @@
 #
 # Ticket: #2229
 # Bug still in: 4.11-262-geb631ce
-use i3test i3_autostart => 0;
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -26,7 +24,6 @@ fake-outputs 400x400+0+0,400x400+400+0
 workspace_auto_back_and_forth no
 EOT
 
-my $pid = launch_with_config($config);
 my $i3 = i3(get_socket_path());
 
 # Set it up such that workspace 3 is on the left output and
@@ -43,8 +40,7 @@ cmd 'move workspace to output left';
 # ensure that workspace 3 has now vanished
 my $get_ws = $i3->get_workspaces->recv;
 my @ws_names = map { $_->{name} } @$get_ws;
+# TODO get rid of smartmatch
 ok(!('3' ~~ @ws_names), 'workspace 3 has been closed');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/531-fullscreen-on-given-output.t
+++ b/testcases/t/531-fullscreen-on-given-output.t
@@ -16,17 +16,13 @@
 #
 # Tests that fullscreen windows appear on the output indicated by
 # their geometry
-use i3test i3_autostart => 0;
-use List::Util qw(first);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 fake-outputs 1024x768+0+0,1024x768+1024+0
 EOT
-
-my $pid = launch_with_config($config);
+use List::Util qw(first);
 
 # Helper functions
 sub fullscreen($) {
@@ -69,7 +65,5 @@ my $node2 = find_window($tree->{nodes}, $win_on_second_output->{id});
 
 is($node1->{fullscreen_mode}, 1, "first window is fullscreen");
 is($node2->{fullscreen_mode}, 1, "second window is fullscreen");
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/534-dont-warp.t
+++ b/testcases/t/534-dont-warp.t
@@ -18,13 +18,7 @@
 # over an unfocused workspace.
 # Ticket: #2681
 # Bug still in: 4.13-210-g80c23afa
-use i3test i3_autostart => 0;
-
-# Ensure the pointer is at (0, 0) so that we really start on the first
-# (the left) workspace.
-$x->root->warp_pointer(0, 0);
-
-my $config = <<EOT;
+use i3test i3_config => <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -32,8 +26,6 @@ fake-outputs 1024x768+0+0,1024x768+1024+0
 
 focus_follows_mouse no
 EOT
-
-my $pid = launch_with_config($config);
 
 cmd 'focus output fake-0';
 my $s0_ws = fresh_workspace;
@@ -55,7 +47,5 @@ my $cookie = $x->query_pointer($dropdown->{id});
 my $reply = $x->query_pointer_reply($cookie->{sequence});
 cmp_ok($reply->{root_x}, '<', 1024, 'pointer still on fake-0');
 cmp_ok($reply->{root_y}, '<', 768, 'pointer still on fake-0');
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/535-workspace-next-prev.t
+++ b/testcases/t/535-workspace-next-prev.t
@@ -17,7 +17,12 @@
 # Tests whether 'workspace next' works correctly.
 #
 use List::Util qw(first);
-use i3test i3_autostart => 0;
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+fake-outputs 1024x768+0+0,1024x768+1024+0
+EOT
 
 sub assert_next {
     my ($expected) = @_;
@@ -42,14 +47,6 @@ sub assert_prev {
 
     is(focused_ws, $expected, "workspace $expected focused");
 }
-
-my $config = <<EOT;
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-
-fake-outputs 1024x768+0+0,1024x768+1024+0
-EOT
-my $pid = launch_with_config($config);
 
 sync_with_i3;
 $x->root->warp_pointer(0, 0);
@@ -123,7 +120,5 @@ assert_prev('3');
 assert_prev('2');
 assert_prev('1');
 
-
-exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/536-net-wm-desktop_mm.t
+++ b/testcases/t/536-net-wm-desktop_mm.t
@@ -16,7 +16,19 @@
 #
 # Tests for _NET_WM_DESKTOP.
 # Ticket: #2153
-use i3test i3_autostart => 0;
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+workspace "0" output "fake-0"
+workspace "1" output "fake-0"
+workspace "2" output "fake-0"
+workspace "10" output "fake-1"
+workspace "11" output "fake-1"
+workspace "12" output "fake-1"
+
+fake-outputs 1024x768+0+0,1024x768+1024+0
+EOT
 use X11::XCB qw(:all);
 
 sub get_net_wm_desktop {
@@ -38,26 +50,10 @@ sub get_net_wm_desktop {
     return unpack("L", $reply->{value});
 }
 
-my $config = <<EOT;
-# i3 config file (v4)
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-
-workspace "0" output "fake-0"
-workspace "1" output "fake-0"
-workspace "2" output "fake-0"
-workspace "10" output "fake-1"
-workspace "11" output "fake-1"
-workspace "12" output "fake-1"
-
-fake-outputs 1024x768+0+0,1024x768+1024+0
-EOT
-
 ###############################################################################
 # _NET_WM_DESKTOP is updated when the window is moved to another workspace
 # on another output.
 ###############################################################################
-
-my $pid = launch_with_config($config);
 
 cmd 'workspace 0';
 open_window;
@@ -69,7 +65,5 @@ my $con = open_window;
 cmd 'move window to workspace 10';
 
 is(get_net_wm_desktop($con), 1, '_NET_WM_DESKTOP is updated when moving the window');
-
-exit_gracefully($pid);
 
 done_testing;


### PR DESCRIPTION
I suggest reviewing commit-by-commit.

I had hoped for this change to have more effect, but at least on my machine, there is no measurable change in execution time. I’m still submitting it for the code reduction.