### PR TITLE
Fix erratic behavior with single container child jumping outputs

### DIFF
--- a/include/con.h
+++ b/include/con.h
@@ -102,7 +102,7 @@ Con *con_get_output(Con *con);
 Con *con_get_workspace(Con *con);
 
 /**
- * Searches parenst of the given 'con' until it reaches one with the specified
+ * Searches parents of the given 'con' until it reaches one with the specified
  * 'orientation'. Aborts when it comes across a floating_con.
  *
  */

--- a/src/con.c
+++ b/src/con.c
@@ -403,7 +403,7 @@ Con *con_get_workspace(Con *con) {
 }
 
 /*
- * Searches parenst of the given 'con' until it reaches one with the specified
+ * Searches parents of the given 'con' until it reaches one with the specified
  * 'orientation'. Aborts when it comes across a floating_con.
  *
  */

--- a/src/move.c
+++ b/src/move.c
@@ -248,7 +248,8 @@ void tree_move(Con *con, int direction) {
                         ? AFTER
                         : BEFORE);
         insert_con_into(con, target, position);
-    } else if (con->parent->parent->type == CT_WORKSPACE &&
+    } else if (!next &&
+               con->parent->parent->type == CT_WORKSPACE &&
                con->parent->layout != L_DEFAULT &&
                con_num_children(con->parent) == 1) {
         /* Con is the lone child of a non-default layout container at the edge

--- a/testcases/t/537-move-single-to-output.t
+++ b/testcases/t/537-move-single-to-output.t
@@ -1,0 +1,63 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests that windows inside containers with a single child do not jump
+# over other containers and erratically move across outputs.
+# Ticket: #2466
+# Bug still in: 4.14-63-g75d11820
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+fake-outputs 640x480+0+0,640x480+640+0
+
+workspace left output fake-0
+workspace right output fake-1
+EOT
+
+cmd 'workspace right';
+
+# ┌───────────────────────────┐ ┌───────────────────────────┐
+# │         Output 1          │ │     Output 2 - splith     │
+# │                           │ │┌───────────┐┌────────────┐│
+# │                           │ ││           ││   splitv   ││
+# │                           │ ││           ││╔══════════╗││
+# │                           │ ││           ││║          ║││
+# │     (empty workspace)     │ ││   first   ││║  second  ║││
+# │                           │ ││           ││║          ║││
+# │                           │ ││           ││║          ║││
+# │                           │ ││           ││╚══════════╝││
+# │                           │ │└───────────┘└────────────┘│
+# └───────────────────────────┘ └───────────────────────────┘
+#
+# Moving "second" left shouldn't cause it to jump over to output 1.
+
+my $first = open_window;
+my $second = open_window;
+
+# Put the second window into its own splitv container
+cmd 'split v';
+
+is_num_children('left', 0, 'No children on left');
+is_num_children('right', 2, 'Two children on right');
+
+# Move the second window to the left
+cmd 'move left';
+
+is_num_children('left', 0, 'Still no children on left');
+is_num_children('right', 2, 'Still two children on right');
+
+done_testing;


### PR DESCRIPTION
This fixes a regression introduced in commit 4e88c10564ca5366c2578908f62ec56625a26718: when attempting to move the single child of a container in the direction of another output, i3 would move the window to the output, despite the window not being at the edge of its output, instead of moving it to its parent container.

The bug occurred because the check for moving containers across outputs with non-default workspace layouts (issue #1603) did not actually verify that the moved window lies at the edge of the workspace, despite what its comment said.

Fixes #2466.