### PR TITLE
Add "focus_wrapping" option

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1039,12 +1039,28 @@ popup_during_fullscreen smart
 
 === Focus wrapping
 
-When in a container with several windows or child containers, the opposite
-window will be focused when trying to move the focus over the edge of a
-container (and there are no other containers in that direction) -- the focus
-wraps. If however there is another window or container in that direction, focus
-will be set on that window or container. This is the default behavior so you
-can navigate to all your windows without having to use +focus parent+.
+By default, when in a container with several windows or child containers, the
+opposite window will be focused when trying to move the focus over the edge of
+a container (and there are no other containers in that direction) -- the focus
+wraps.
+
+If desired, you can disable this behavior using the +focus_wrapping+
+configuration directive:
+
+*Syntax*:
+---------------------
+focus_wrapping yes|no
+---------------------
+
+*Example*:
+-----------------
+focus_wrapping no
+-----------------
+
+By default, focus wrapping does not occur if there is another window or
+container in the specified direction, and focus will instead be set on that
+window or container. This is the default behavior so you can navigate to all
+your windows without having to use +focus parent+.
 
 If you want the focus to *always* wrap and you are aware of using +focus
 parent+ to switch to different containers, you can use the

--- a/docs/userguide
+++ b/docs/userguide
@@ -1044,38 +1044,34 @@ opposite window will be focused when trying to move the focus over the edge of
 a container (and there are no other containers in that direction) -- the focus
 wraps.
 
-If desired, you can disable this behavior using the +focus_wrapping+
-configuration directive:
+If desired, you can disable this behavior by setting the +focus_wrapping+
+configuration directive to the value +no+.
 
-*Syntax*:
----------------------
-focus_wrapping yes|no
----------------------
-
-*Example*:
------------------
-focus_wrapping no
------------------
-
-By default, focus wrapping does not occur if there is another window or
-container in the specified direction, and focus will instead be set on that
-window or container. This is the default behavior so you can navigate to all
-your windows without having to use +focus parent+.
+When enabled, focus wrapping does not occur by default if there is another
+window or container in the specified direction, and focus will instead be set
+on that window or container. This is the default behavior so you can navigate
+to all your windows without having to use +focus parent+.
 
 If you want the focus to *always* wrap and you are aware of using +focus
-parent+ to switch to different containers, you can use the
-+force_focus_wrapping+ configuration directive. After enabling it, the focus
-will always wrap.
+parent+ to switch to different containers, you can instead set +focus_wrapping+
+to the value +force+.
 
 *Syntax*:
 ---------------------------
-force_focus_wrapping yes|no
+focus_wrapping yes|no|force
+
+# Legacy syntax, equivalent to "focus_wrapping force"
+force_focus_wrapping yes
 ---------------------------
 
-*Example*:
-------------------------
-force_focus_wrapping yes
-------------------------
+*Examples*:
+-----------------
+# Disable focus wrapping
+focus_wrapping no
+
+# Force focus wrapping
+focus_wrapping force
+-----------------
 
 === Forcing Xinerama
 

--- a/docs/userguide
+++ b/docs/userguide
@@ -1039,11 +1039,12 @@ popup_during_fullscreen smart
 
 === Focus wrapping
 
-When being in a tabbed or stacked container, the first container will be
-focused when you use +focus down+ on the last container -- the focus wraps. If
-however there is another stacked/tabbed container in that direction, focus will
-be set on that container. This is the default behavior so you can navigate to
-all your windows without having to use +focus parent+.
+When in a container with several windows or child containers, the opposite
+window will be focused when trying to move the focus over the edge of a
+container (and there are no other containers in that direction) -- the focus
+wraps. If however there is another window or container in that direction, focus
+will be set on that window or container. This is the default behavior so you
+can navigate to all your windows without having to use +focus parent+.
 
 If you want the focus to *always* wrap and you are aware of using +focus
 parent+ to switch to different containers, you can use the

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -49,6 +49,7 @@ CFGFUN(workspace_layout, const char *layout);
 CFGFUN(workspace_back_and_forth, const char *value);
 CFGFUN(focus_follows_mouse, const char *value);
 CFGFUN(mouse_warping, const char *value);
+CFGFUN(focus_wrapping, const char *value);
 CFGFUN(force_focus_wrapping, const char *value);
 CFGFUN(force_xinerama, const char *value);
 CFGFUN(disable_randr15, const char *value);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -137,6 +137,14 @@ struct Config {
      * comes with i3. Thus, you can turn it off entirely. */
     bool disable_workspace_bar;
 
+    /** When focus wrapping is enabled (the default), attempting to
+     * move focus past the edge of the screen (in other words, in a
+     * direction in which there are no more containers to focus) will
+     * cause the focus to wrap to the opposite edge of the current
+     * container. When it is disabled, nothing happens; the current
+     * focus is preserved.  */
+    bool focus_wrapping;
+
     /** Think of the following layout: Horizontal workspace with a tabbed
      * con on the left of the screen and a terminal on the right of the
      * screen. You are in the second container in the tabbed container and

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -142,18 +142,19 @@ struct Config {
      * direction in which there are no more containers to focus) will
      * cause the focus to wrap to the opposite edge of the current
      * container. When it is disabled, nothing happens; the current
-     * focus is preserved.  */
-    bool focus_wrapping;
-
-    /** Think of the following layout: Horizontal workspace with a tabbed
-     * con on the left of the screen and a terminal on the right of the
-     * screen. You are in the second container in the tabbed container and
-     * focus to the right. By default, i3 will set focus to the terminal on
-     * the right. If you are in the first container in the tabbed container
-     * however, focusing to the left will wrap. This option forces i3 to
-     * always wrap, which will result in you having to use "focus parent"
-     * more often. */
-    bool force_focus_wrapping;
+     * focus is preserved.
+     *
+     * Additionally, focus wrapping may be forced. Think of the
+     * following layout: Horizontal workspace with a tabbed con on the
+     * left of the screen and a terminal on the right of the
+     * screen. You are in the second container in the tabbed container
+     * and focus to the right. By default, i3 will set focus to the
+     * terminal on the right. If you are in the first container in the
+     * tabbed container however, focusing to the left will
+     * wrap. Setting focus_wrapping to FOCUS_WRAPPING_FORCE forces i3
+     * to always wrap, which will result in you having to use "focus
+     * parent" more often. */
+    focus_wrapping_t focus_wrapping;
 
     /** By default, use the RandR API for multi-monitor setups.
      * Unfortunately, the nVidia binary graphics driver doesn't support

--- a/include/data.h
+++ b/include/data.h
@@ -134,6 +134,15 @@ typedef enum {
 } warping_t;
 
 /**
+ * Focus wrapping modes.
+ */
+typedef enum {
+    FOCUS_WRAPPING_OFF = 0,
+    FOCUS_WRAPPING_ON = 1,
+    FOCUS_WRAPPING_FORCE = 2
+} focus_wrapping_t;
+
+/**
  * Stores a rectangle, for example the size of a window, the child window etc.
  * It needs to be packed so that the compiler will not add any padding bytes.
  * (it is used in src/ewmh.c for example)

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -36,6 +36,7 @@ state INITIAL:
   'no_focus'                               -> NO_FOCUS
   'focus_follows_mouse'                    -> FOCUS_FOLLOWS_MOUSE
   'mouse_warping'                          -> MOUSE_WARPING
+  'focus_wrapping'                         -> FOCUS_WRAPPING
   'force_focus_wrapping'                   -> FORCE_FOCUS_WRAPPING
   'force_xinerama', 'force-xinerama'       -> FORCE_XINERAMA
   'disable_randr15', 'disable-randr15'     -> DISABLE_RANDR15
@@ -202,6 +203,11 @@ state FOCUS_FOLLOWS_MOUSE:
 state MOUSE_WARPING:
   value = 'none', 'output'
       -> call cfg_mouse_warping($value)
+
+# focus_wrapping
+state FOCUS_WRAPPING:
+  value = word
+      -> call cfg_focus_wrapping($value)
 
 # force_focus_wrapping
 state FORCE_FOCUS_WRAPPING:

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -206,7 +206,7 @@ state MOUSE_WARPING:
 
 # focus_wrapping
 state FOCUS_WRAPPING:
-  value = word
+  value = '1', 'yes', 'true', 'on', 'enable', 'active', '0', 'no', 'false', 'off', 'disable', 'inactive', 'force'
       -> call cfg_focus_wrapping($value)
 
 # force_focus_wrapping

--- a/src/config.c
+++ b/src/config.c
@@ -227,7 +227,7 @@ void load_configuration(xcb_connection_t *conn, const char *override_configpath,
     if (config.workspace_urgency_timer == 0)
         config.workspace_urgency_timer = 0.5;
 
-    config.focus_wrapping = true;
+    config.focus_wrapping = FOCUS_WRAPPING_ON;
 
     parse_configuration(override_configpath, true);
 

--- a/src/config.c
+++ b/src/config.c
@@ -227,6 +227,8 @@ void load_configuration(xcb_connection_t *conn, const char *override_configpath,
     if (config.workspace_urgency_timer == 0)
         config.workspace_urgency_timer = 0.5;
 
+    config.focus_wrapping = true;
+
     parse_configuration(override_configpath, true);
 
     if (reload) {

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -264,6 +264,10 @@ CFGFUN(disable_randr15, const char *value) {
     config.disable_randr15 = eval_boolstr(value);
 }
 
+CFGFUN(focus_wrapping, const char *value) {
+    config.focus_wrapping = eval_boolstr(value);
+}
+
 CFGFUN(force_focus_wrapping, const char *value) {
     config.force_focus_wrapping = eval_boolstr(value);
 }

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -265,11 +265,26 @@ CFGFUN(disable_randr15, const char *value) {
 }
 
 CFGFUN(focus_wrapping, const char *value) {
-    config.focus_wrapping = eval_boolstr(value);
+    if (strcmp(value, "force") == 0) {
+        config.focus_wrapping = FOCUS_WRAPPING_FORCE;
+    } else if (eval_boolstr(value)) {
+        config.focus_wrapping = FOCUS_WRAPPING_ON;
+    } else {
+        config.focus_wrapping = FOCUS_WRAPPING_OFF;
+    }
 }
 
 CFGFUN(force_focus_wrapping, const char *value) {
-    config.force_focus_wrapping = eval_boolstr(value);
+    /* Legacy syntax. */
+    if (eval_boolstr(value)) {
+        config.focus_wrapping = FOCUS_WRAPPING_FORCE;
+    } else {
+        /* For "force_focus_wrapping off", don't enable or disable
+         * focus wrapping, just ensure it's not forced. */
+        if (config.focus_wrapping == FOCUS_WRAPPING_FORCE) {
+            config.focus_wrapping = FOCUS_WRAPPING_ON;
+        }
+    }
 }
 
 CFGFUN(workspace_back_and_forth, const char *value) {

--- a/src/tree.c
+++ b/src/tree.c
@@ -675,7 +675,7 @@ static bool _tree_next(Con *con, char way, orientation_t orientation, bool wrap)
  *
  */
 void tree_next(char way, orientation_t orientation) {
-    _tree_next(focused, way, orientation, true);
+    _tree_next(focused, way, orientation, config.focus_wrapping);
 }
 
 /*

--- a/src/tree.c
+++ b/src/tree.c
@@ -641,7 +641,7 @@ static bool _tree_next(Con *con, char way, orientation_t orientation, bool wrap)
         next = TAILQ_PREV(current, nodes_head, nodes);
 
     if (!next) {
-        if (!config.force_focus_wrapping) {
+        if (config.focus_wrapping != FOCUS_WRAPPING_FORCE) {
             /* If there is no next/previous container, we check if we can focus one
              * when going higher (without wrapping, though). If so, we are done, if
              * not, we wrap */
@@ -675,7 +675,8 @@ static bool _tree_next(Con *con, char way, orientation_t orientation, bool wrap)
  *
  */
 void tree_next(char way, orientation_t orientation) {
-    _tree_next(focused, way, orientation, config.focus_wrapping);
+    _tree_next(focused, way, orientation,
+               config.focus_wrapping != FOCUS_WRAPPING_OFF);
 }
 
 /*

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -470,6 +470,7 @@ my $expected_all_tokens = "ERROR: CONFIG: Expected one of these tokens: <end>, '
         no_focus
         focus_follows_mouse
         mouse_warping
+        focus_wrapping
         force_focus_wrapping
         force_xinerama
         force-xinerama

--- a/testcases/t/539-disable_focus_wrapping.t
+++ b/testcases/t/539-disable_focus_wrapping.t
@@ -1,0 +1,51 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests that focus does not wrap when focus_wrapping is disabled in
+# the configuration.
+# Ticket: #2352
+# Bug still in: 4.14-72-g6411130c
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+focus_wrapping no
+EOT
+
+sub test_orientation {
+    my ($orientation, $prev, $next) = @_;
+    my $tmp = fresh_workspace;
+
+    cmd "split $orientation";
+
+    my $win1 = open_window;
+    my $win2 = open_window;
+
+    is($x->input_focus, $win2->id, "Second window focused initially");
+    cmd "focus $prev";
+    is($x->input_focus, $win1->id, "First window focused");
+    cmd "focus $prev";
+    is($x->input_focus, $win1->id, "First window still focused");
+    cmd "focus $next";
+    is($x->input_focus, $win2->id, "Second window focused");
+    cmd "focus $next";
+    is($x->input_focus, $win2->id, "Second window still focused");
+}
+
+test_orientation('v', 'up', 'down');
+test_orientation('h', 'left', 'right');
+
+done_testing;


### PR DESCRIPTION
This implements enhancement request #2352.

The actual change is trivial:

```diff
 void tree_next(char way, orientation_t orientation) {
-    _tree_next(focused, way, orientation, true);
+    _tree_next(focused, way, orientation, config.focus_wrapping);
 }
```

The rest is bureaucracy. :)