### PR TITLE
Allow assign to output

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -2238,7 +2238,6 @@ bindsym $mod+x move container to output VGA1
 bindsym $mod+x move container to output primary
 --------------------------------------------------------
 
--------------------------------
 Note that you might not have a primary output configured yet. To do so, run:
 -------------------------
 xrandr --output <output> --primary

--- a/docs/userguide
+++ b/docs/userguide
@@ -760,6 +760,10 @@ title change. As i3 will get the title as soon as the application maps the
 window (mapping means actually displaying it on the screen), you’d need to have
 to match on 'Firefox' in this case.
 
+You can also assign a window to show up on a specific output. You can use RandR
+names such as +VGA1+ or names relative to the output with the currently focused
+workspace such as +left+ and +down+.
+
 Assignments are processed by i3 in the order in which they appear in the config
 file. The first one which matches the window wins and later assignments are not
 considered.
@@ -767,6 +771,7 @@ considered.
 *Syntax*:
 ------------------------------------------------------------
 assign <criteria> [→] [workspace] [number] <workspace>
+assign <criteria> [→] output left|right|up|down|primary|<output>
 ------------------------------------------------------------
 
 *Examples*:
@@ -791,9 +796,20 @@ assign [class="^URxvt$"] → number "2: work"
 
 # Start urxvt -name irssi
 assign [class="^URxvt$" instance="^irssi$"] → 3
+
+# Assign urxvt to the output right of the current one
+assign [class="^URxvt$"] → output right
+
+# Assign urxvt to the primary output
+assign [class="^URxvt$"] → output primary
 ----------------------
 
-Note that the arrow is not required, it just looks good :-). If you decide to
+Note that you might not have a primary output configured yet. To do so, run:
+-------------------------
+xrandr --output <output> --primary
+-------------------------
+
+Also, the arrow is not required, it just looks good :-). If you decide to
 use it, it has to be a UTF-8 encoded arrow, not `->` or something like that.
 
 To get the class and instance, you can use +xprop+. After clicking on the

--- a/include/con.h
+++ b/include/con.h
@@ -307,7 +307,16 @@ void con_move_to_workspace(Con *con, Con *workspace, bool fix_coordinates,
  * visible workspace on the given output.
  *
  */
-void con_move_to_output(Con *con, Output *output);
+void con_move_to_output(Con *con, Output *output, bool fix_coordinates);
+
+/**
+ * Moves the given container to the currently focused container on the
+ * visible workspace on the output specified by the given name.
+ * The current output for the container is used to resolve relative names
+ * such as left, right, up, down.
+ *
+ */
+bool con_move_to_output_name(Con *con, const char *name, bool fix_coordinates);
 
 /**
  * Moves the given container to the given mark.

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -57,6 +57,7 @@ CFGFUN(force_display_urgency_hint, const long duration_ms);
 CFGFUN(focus_on_window_activation, const char *mode);
 CFGFUN(show_marks, const char *value);
 CFGFUN(hide_edge_borders, const char *borders);
+CFGFUN(assign_output, const char *output);
 CFGFUN(assign, const char *workspace, bool is_number);
 CFGFUN(no_focus);
 CFGFUN(ipc_socket, const char *path);

--- a/include/data.h
+++ b/include/data.h
@@ -557,7 +557,8 @@ struct Assignment {
         A_COMMAND = (1 << 0),
         A_TO_WORKSPACE = (1 << 1),
         A_NO_FOCUS = (1 << 2),
-        A_TO_WORKSPACE_NUMBER = (1 << 3)
+        A_TO_WORKSPACE_NUMBER = (1 << 3),
+        A_TO_OUTPUT = (1 << 4)
     } type;
 
     /** the criteria to check if a window matches */
@@ -567,6 +568,7 @@ struct Assignment {
     union {
         char *command;
         char *workspace;
+        char *output;
     } dest;
 
     TAILQ_ENTRY(Assignment)

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -141,7 +141,7 @@ state FOR_WINDOW_COMMAND:
   command = string
       -> call cfg_for_window($command)
 
-# assign <criteria> [→] workspace
+# assign <criteria> [→] [workspace | output] <name>
 state ASSIGN:
   '['
       -> call cfg_criteria_init(ASSIGN_WORKSPACE); CRITERIA
@@ -149,12 +149,18 @@ state ASSIGN:
 state ASSIGN_WORKSPACE:
   '→'
       ->
+  'output'
+      -> ASSIGN_OUTPUT
   'workspace'
       ->
   'number'
       -> ASSIGN_WORKSPACE_NUMBER
   workspace = string
       -> call cfg_assign($workspace, 0)
+
+state ASSIGN_OUTPUT:
+  output = string
+      -> call cfg_assign_output($output)
 
 state ASSIGN_WORKSPACE_NUMBER:
   number = string

--- a/src/commands.c
+++ b/src/commands.c
@@ -1044,25 +1044,7 @@ void cmd_move_con_to_output(I3_CMD, const char *name) {
     TAILQ_FOREACH(current, &owindows, owindows) {
         DLOG("matching: %p / %s\n", current->con, current->con->name);
 
-        Output *current_output = get_output_for_con(current->con);
-        assert(current_output != NULL);
-
-        Output *output = get_output_from_string(current_output, name);
-        if (output == NULL) {
-            ELOG("Could not find output \"%s\", skipping.\n", name);
-            had_error = true;
-            continue;
-        }
-
-        Con *ws = NULL;
-        GREP_FIRST(ws, output_get_content(output->con), workspace_is_visible(child));
-        if (ws == NULL) {
-            ELOG("Could not find a visible workspace on output %p.\n", output);
-            had_error = true;
-            continue;
-        }
-
-        con_move_to_workspace(current->con, ws, true, false, false);
+        had_error |= !con_move_to_output_name(current->con, name, true);
     }
 
     cmd_output->needs_tree_render = true;

--- a/src/con.c
+++ b/src/con.c
@@ -1284,12 +1284,33 @@ void con_move_to_workspace(Con *con, Con *workspace, bool fix_coordinates, bool 
  * visible workspace on the given output.
  *
  */
-void con_move_to_output(Con *con, Output *output) {
+void con_move_to_output(Con *con, Output *output, bool fix_coordinates) {
     Con *ws = NULL;
     GREP_FIRST(ws, output_get_content(output->con), workspace_is_visible(child));
     assert(ws != NULL);
     DLOG("Moving con %p to output %s\n", con, output_primary_name(output));
-    con_move_to_workspace(con, ws, false, false, false);
+    con_move_to_workspace(con, ws, fix_coordinates, false, false);
+}
+
+/*
+ * Moves the given container to the currently focused container on the
+ * visible workspace on the output specified by the given name.
+ * The current output for the container is used to resolve relative names
+ * such as left, right, up, down.
+ *
+ */
+bool con_move_to_output_name(Con *con, const char *name, bool fix_coordinates) {
+    Output *current_output = get_output_for_con(con);
+    assert(current_output != NULL);
+
+    Output *output = get_output_from_string(current_output, name);
+    if (output == NULL) {
+        ELOG("Could not find output \"%s\"\n", name);
+        return false;
+    }
+
+    con_move_to_output(con, output, fix_coordinates);
+    return true;
 }
 
 /*

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -377,6 +377,20 @@ CFGFUN(color, const char *colorclass, const char *border, const char *background
 #undef APPLY_COLORS
 }
 
+CFGFUN(assign_output, const char *output) {
+    if (match_is_empty(current_match)) {
+        ELOG("Match is empty, ignoring this assignment\n");
+        return;
+    }
+
+    DLOG("New assignment, using above criteria, to output \"%s\".\n", output);
+    Assignment *assignment = scalloc(1, sizeof(Assignment));
+    match_copy(&(assignment->match), current_match);
+    assignment->type = A_TO_OUTPUT;
+    assignment->dest.output = sstrdup(output);
+    TAILQ_INSERT_TAIL(&assignments, assignment, assignments);
+}
+
 CFGFUN(assign, const char *workspace, bool is_number) {
     if (match_is_empty(current_match)) {
         ELOG("Match is empty, ignoring this assignment\n");

--- a/src/manage.c
+++ b/src/manage.c
@@ -384,7 +384,7 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
              * needed e.g. for LibreOffice Impress multi-monitor
              * presentations to work out of the box. */
             if (output != NULL)
-                con_move_to_output(nc, output);
+                con_move_to_output(nc, output, false);
             con_toggle_fullscreen(nc, CF_OUTPUT);
         }
         fs = NULL;

--- a/src/manage.c
+++ b/src/manage.c
@@ -322,6 +322,10 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
             } else
                 nc = tree_open_con(NULL, cwindow);
         }
+
+        if ((assignment = assignment_for(cwindow, A_TO_OUTPUT))) {
+            con_move_to_output_name(nc, assignment->dest.output, true);
+        }
     } else {
         /* M_BELOW inserts the new window as a child of the one which was
          * matched (e.g. dock areas) */

--- a/testcases/t/166-assign.t
+++ b/testcases/t/166-assign.t
@@ -21,12 +21,12 @@ use i3test i3_autostart => 0;
 sub open_special {
     my %args = @_;
     $args{name} //= 'special window';
+    $args{wm_class} //= 'special';
 
     # We use dont_map because i3 will not map the window on the current
     # workspace. Thus, open_window would time out in wait_for_map (2 seconds).
     my $window = open_window(
         %args,
-        wm_class => 'special',
         dont_map => 1,
     );
     $window->map;
@@ -50,8 +50,7 @@ sub test_workspace_assignment {
     # We use sync_with_i3 instead of wait_for_map here because i3 will not actually
     # map the window -- it will be assigned to a different workspace and will only
     # be mapped once you switch to that workspace
-    my $window = open_special(dont_map => 1);
-    $window->map;
+    my $window = open_special;
     sync_with_i3;
 
     ok(@{get_ws_content($tmp)} == 0, 'still no containers');

--- a/testcases/t/166-assign.t
+++ b/testcases/t/166-assign.t
@@ -242,7 +242,7 @@ $tmp = fresh_workspace;
 
 ok(@{get_ws_content($tmp)} == 0, 'no containers yet');
 my @docked = get_dock_clients;
-is(@docked, 0, 'one dock client yet');
+is(@docked, 0, 'no dock client yet');
 
 $window = open_special(
     window_type => $x->atom(name => '_NET_WM_WINDOW_TYPE_DOCK'),

--- a/testcases/t/166-assign.t
+++ b/testcases/t/166-assign.t
@@ -203,8 +203,127 @@ my $content = get_ws($tmp);
 ok(@{$content->{nodes}} == 0, 'no tiling cons');
 ok(@{$content->{floating_nodes}} == 1, 'one floating con');
 
-$window->destroy;
+kill_all_windows;
+exit_gracefully($pid);
 
+#####################################################################
+# test assignments to named outputs
+#####################################################################
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+fake-outputs 1024x768+0+0,1024x768+1024+0,1024x768+1024+768,1024x768+0+768
+
+workspace ws-0 output fake-0
+workspace ws-1 output fake-1
+workspace ws-2 output fake-2
+workspace ws-3 output fake-3
+
+assign [class="special-0"] → output fake-0
+assign [class="special-1"] → output fake-1
+assign [class="special-2"] → output fake-2
+assign [class="special-3"] → output fake-3
+assign [class="special-4"] → output invalid
+
+EOT
+
+$pid = launch_with_config($config);
+
+sub open_in_output {
+    my ($num, $expected_count) = @_;
+    my $ws = "ws-$num";
+    my $class = "special-$num";
+    my $output = "fake-$num";
+
+    is_num_children($ws, $expected_count - 1,
+                    "before: " . ($expected_count - 1) . " containers on output $output");
+    $window = open_special(wm_class => $class);
+    sync_with_i3;
+    is_num_children($ws, $expected_count,
+                    "after: $expected_count containers on output $output");
+}
+
+cmd "workspace ws-0";
+open_in_output(0, 1);
+my $focused = $x->input_focus;
+
+open_in_output(1, 1);
+is($x->input_focus, $focused, 'focus remains on output fake-0');
+
+open_in_output(2, 1);
+is($x->input_focus, $focused, 'focus remains on output fake-0');
+
+for my $i (1 .. 5){
+    open_in_output(3, $i);
+    is($x->input_focus, $focused, 'focus remains on output fake-0');
+}
+
+# Check invalid output
+$tmp = fresh_workspace;
+open_special(wm_class => "special-4");
+sync_with_i3;
+is_num_children($tmp, 1, 'window assigned to invalid output opened in current workspace');
+open_special(wm_class => "special-3");
+sync_with_i3;
+is_num_children($tmp, 1, 'but window assigned to valid output did not');
+
+kill_all_windows;
+exit_gracefully($pid);
+
+#####################################################################
+# Test assignments to outputs with relative names
+#####################################################################
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+fake-outputs 1024x768+0+0,1024x768+1024+0,1024x768+1024+768,1024x768+0+768
+
+workspace left-top output fake-0
+workspace right-top output fake-1
+workspace right-bottom output fake-2
+workspace left-bottom output fake-3
+
+assign [class="current"] → output current
+assign [class="left"] → output left
+assign [class="right"] → output right
+assign [class="up"] → output up
+assign [class="down"] → output down
+EOT
+
+$pid = launch_with_config($config);
+
+cmd 'workspace left-top';
+
+is_num_children('left-top', 0, 'no childreon on left-top');
+for my $i (1 .. 5){
+    open_special(wm_class => 'current');
+}
+sync_with_i3;
+is_num_children('left-top', 5, 'windows opened in current workspace');
+
+is_num_children('right-top', 0, 'no children on right-top');
+open_special(wm_class => 'right');
+sync_with_i3;
+is_num_children('right-top', 1, 'one child on right-top');
+
+is_num_children('left-bottom', 0, 'no children on left-bottom');
+open_special(wm_class => 'down');
+sync_with_i3;
+is_num_children('left-bottom', 1, 'one child on left-bottom');
+
+cmd 'workspace right-bottom';
+
+open_special(wm_class => 'up');
+sync_with_i3;
+is_num_children('right-top', 2, 'two children on right-top');
+
+open_special(wm_class => 'left');
+sync_with_i3;
+is_num_children('left-bottom', 2, 'two children on left-bottom');
+
+kill_all_windows;
 exit_gracefully($pid);
 
 #####################################################################


### PR DESCRIPTION
Implements the "assign" part of issue #2764.

TODO:

- [x] Tests
- [x] Documentation. Multiple examples, eg `assign [...] output right`.