### PR TITLE
Migrate tooling to ExtUtils::MakeMaker

### DIFF
--- a/AnyEvent-I3/MANIFEST
+++ b/AnyEvent-I3/MANIFEST
@@ -1,17 +1,8 @@
 Changes
-inc/Module/Install.pm
-inc/Module/Install/Base.pm
-inc/Module/Install/Can.pm
-inc/Module/Install/Fetch.pm
-inc/Module/Install/Makefile.pm
-inc/Module/Install/Metadata.pm
-inc/Module/Install/Win32.pm
-inc/Module/Install/WriteAll.pm
 lib/AnyEvent/I3.pm
 Makefile.PL
-MANIFEST
+MANIFEST			This list of files
 MANIFEST.SKIP
-META.yml
 README
 t/00-load.t
 t/01-workspaces.t

--- a/AnyEvent-I3/MANIFEST.SKIP
+++ b/AnyEvent-I3/MANIFEST.SKIP
@@ -9,3 +9,5 @@ Build.bat
 \.tar\.gz$
 ^pod2htm(.*).tmp$
 ^AnyEvent-I3-
+^MYMETA.*
+^MANIFEST\.bak

--- a/AnyEvent-I3/Makefile.PL
+++ b/AnyEvent-I3/Makefile.PL
@@ -1,17 +1,100 @@
-use lib '.';
-use inc::Module::Install;
+use strict;
+use warnings;
 
-name     'AnyEvent-I3';
-all_from 'lib/AnyEvent/I3.pm';
-author   'Michael Stapelberg';
+use 5.006;
+use ExtUtils::MakeMaker;
 
-requires 'AnyEvent';
-requires 'AnyEvent::Handle';
-requires 'AnyEvent::Socket';
-requires 'JSON::XS';
-
-if ($^O eq 'MSWin32') {
+if ( $^O eq 'MSWin32' ) {
     die "AnyEvent::I3 cannot be used on win32 (unix sockets are missing)";
 }
 
-WriteAll;
+my %meta = (
+    name        => 'AnyEvent-I3',
+    author      => 'Michael Stapelberg, C<< <michael at i3wm.org> >>',
+    license     => ['perl'],
+    'meta-spec' => { version => 2 },
+    resources   => {
+        repository => {
+            url  => 'git://github.com/i3/i3',
+            web  => 'https://github.com/i3/i3',
+            type => 'git',
+        },
+        bugtracker => {
+            web => 'https://github.com/i3/i3/issues',
+        },
+        homepage => 'https://i3wm.org/',
+        license  => ['http://dev.perl.org/licenses'],
+    },
+);
+
+my %requirements = (
+    configure_requires => {
+        'ExtUtils::MakeMaker' => 6.36,
+    },
+    build_requires => {
+        'ExtUtils::MakeMaker' => 6.36
+    },
+    runtime_requires => {
+        'AnyEvent'         => 0,
+        'AnyEvent::Handle' => 0,
+        'AnyEvent::Socket' => 0,
+        'JSON::XS'         => 0,
+    },
+    test_requires => {
+        'Test::More' => 0.80,
+    },
+);
+
+my %merged_requirements = (
+    'ExtUtils::MakeMaker' => 0,
+    'AnyEvent'            => 0,
+    'AnyEvent::Handle'    => 0,
+    'AnyEvent::Socket'    => 0,
+    'JSON::XS'            => 0,
+    'Test::More'          => 0.80,
+);
+
+$meta{prereqs}{configure}{requires} = $requirements{configure_requires};
+$meta{prereqs}{build}{requires}     = $requirements{build_requires};
+$meta{prereqs}{runtime}{requires}   = $requirements{runtime_requires};
+$meta{prereqs}{test}{requires}      = $requirements{test_requires};
+
+my %MM_Args = (
+    AUTHOR           => 'Michael Stapelberg',
+    NAME             => 'AnyEvent::I3',
+    DISTNAME         => 'AnyEvent-I3',
+    EXE_FILES        => [],
+    MIN_PERL_VERSION => '5.006',
+    VERSION_FROM     => 'lib/AnyEvent/I3.pm',
+    ABSTRACT_FROM    => 'lib/AnyEvent/I3.pm',
+    test             => {
+        TESTS => 't/*.t',
+    },
+);
+
+sub is_eumm {
+    eval { ExtUtils::MakeMaker->VERSION( $_[0] ) };
+}
+
+is_eumm(6.30) and $MM_Args{LICENSE} = $meta{license}[0];
+is_eumm(6.47_01) or delete $MM_Args{MIN_PERL_VERSION};
+is_eumm(6.52)
+  and $MM_Args{CONFIGURE_REQUIRES} = $requirements{configure_requires};
+
+is_eumm(6.57_02) and !is_eumm(6.57_07) and $MM_Args{NO_MYMETA} = 1;
+
+if ( is_eumm(6.63_03) ) {
+    %MM_Args = (
+        %MM_Args,
+        TEST_REQUIRES  => $requirements{test_requires},
+        BUILD_REQUIRES => $requirements{build_requires},
+        PREREQ_PM      => $requirements{runtime_requires},
+    );
+}
+else {
+    $MM_Args{PREREQ_PM} = \%merged_requirements;
+}
+unless ( -f 'META.yml' ) {
+    $MM_Args{META_ADD} = \%meta;
+}
+WriteMakefile(%MM_Args);


### PR DESCRIPTION
This tends to have a lot more boiler plate, but it doesn't require any of the Module::Install dependencies to be shipped.

As usual, creating a cpan dist is:

```bash
perl Makefile.PL
make
make dist
make disttest
```
And then ship the tar.gz off to cpan.

```bash
tar -tf AnyEvent-I3-0.18.tar.gz 
AnyEvent-I3-0.18/
AnyEvent-I3-0.18/Changes
AnyEvent-I3-0.18/lib/
AnyEvent-I3-0.18/lib/AnyEvent/
AnyEvent-I3-0.18/lib/AnyEvent/I3.pm
AnyEvent-I3-0.18/Makefile.PL
AnyEvent-I3-0.18/t/
AnyEvent-I3-0.18/t/pod-coverage.t
AnyEvent-I3-0.18/t/00-load.t
AnyEvent-I3-0.18/t/manifest.t
AnyEvent-I3-0.18/t/01-workspaces.t
AnyEvent-I3-0.18/t/02-sugar.t
AnyEvent-I3-0.18/t/boilerplate.t
AnyEvent-I3-0.18/t/pod.t
AnyEvent-I3-0.18/README
AnyEvent-I3-0.18/MANIFEST.SKIP
AnyEvent-I3-0.18/META.yml
AnyEvent-I3-0.18/META.json
AnyEvent-I3-0.18/MANIFEST
```

Notes:
- I preserved your strange formatting of the `author` field as that's how you had it on the last release in the metadata.
- I fixed the publicised license field to be "perl" instead of "gpl", as the text on your `LICENSE` section says its dual-licensed as GPL2+Artistic 1, which is what "perl" basically means.
- I've leveraged a fair bit of the META2.0 spec to publish a bit of data that would previously just be impossible with `Module::Install`, like custom homepage, bug tracker values, and VCS values. ( All of which are used by `metacpan` and friends )
- And I've pointed bug tracker to github issues, despite the documentation saying `RT` mostly as an example, but I can revert it on request, this is more just getting you the ability to see what is possible.
- `Makefile.PL` is ordered in order of "things you might want to change" to "things you shouldn't ever need to change"