### PR TITLE
Bugfix: don’t invalidate layout upon invalid 'layout toggle' params

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -1841,7 +1841,9 @@ void con_toggle_layout(Con *con, const char *toggle_mode) {
             }
         }
 
-        con_set_layout(con, new_layout);
+        if (new_layout != L_DEFAULT) {
+            con_set_layout(con, new_layout);
+        }
     } else if (strcasecmp(toggle_mode, "all") == 0 || strcasecmp(toggle_mode, "default") == 0) {
         if (parent->layout == L_STACKED)
             con_set_layout(con, L_TABBED);

--- a/testcases/t/292-regress-layout-toggle.t
+++ b/testcases/t/292-regress-layout-toggle.t
@@ -1,0 +1,29 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • http://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • http://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • http://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Regression test: verify layout toggle with invalid parameters does not set
+# layout to L_DEFAULT, which crashes i3 upon the next IPC message.
+# Ticket: #2903
+# Bug still in: 4.14-87-g607e97e6
+use i3test;
+
+cmd 'layout toggle 1337 1337';
+
+fresh_workspace;
+
+does_i3_live;
+
+done_testing;


### PR DESCRIPTION
fixes #2903