### PR TITLE
Fixed issue of crashing when opening some new workspace referred to by number.

### DIFF
--- a/src/workspace.c
+++ b/src/workspace.c
@@ -479,7 +479,7 @@ static void _workspace_show(Con *workspace) {
     ewmh_update_current_desktop();
 
     /* Push any sticky windows to the now visible workspace. */
-    output_push_sticky_windows(old_focus);
+    output_push_sticky_windows(focused);
 }
 
 /*


### PR DESCRIPTION
i3 has a bug, where if I refer to the workspaces by number (names change dynamically in my use-case), then sometimes on switching to a yet unopened workspace leads to crash and logout.
I traced this issue to the src/workspace.c source, where the function `_workspace_show(Con *workspace)` accesses the previous workspace, after it was destroyed in this function, leading to access violation. Changing `output_push_sticky_windows(old_focus)` to `output_push_sticky_windows(focused)` fixes the issue. Other use-cases than mine may theoretically be affected.
I have originally made this pull request on the fork i3-gaps, and was told to bring it upstream.