### PR TITLE
Use con_descend_focused for workspaces in _tree_next

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -560,21 +560,10 @@ static bool _tree_next(Con *con, char way, orientation_t orientation, bool wrap)
         if (!workspace)
             return false;
 
-        workspace_show(workspace);
-
-        /* If a workspace has an active fullscreen container, one of its
-         * children should always be focused. The above workspace_show()
-         * should be adequate for that, so return. */
-        if (con_get_fullscreen_con(workspace, CF_OUTPUT))
-            return true;
-
-        Con *focus = con_descend_direction(workspace, direction);
-
-        /* special case: if there was no tiling con to focus and the workspace
-         * has a floating con in the focus stack, focus the top of the focus
-         * stack (which may be floating) */
-        if (focus == workspace)
+        Con *focus = con_descend_tiling_focused(workspace);
+        if (focus == workspace) {
             focus = con_descend_focused(workspace);
+        }
 
         if (focus) {
             con_focus(focus);

--- a/testcases/t/510-focus-across-outputs.t
+++ b/testcases/t/510-focus-across-outputs.t
@@ -92,7 +92,7 @@ reset_focus $s3_ws;
 
 cmd "workspace $s2_ws";
 cmd 'focus right';
-is($x->input_focus, $sixth->id, 'sixth window focused');
+is($x->input_focus, $seventh->id, 'seventh window focused');
 reset_focus $s3_ws;
 
 cmd "workspace $s2_ws";
@@ -110,6 +110,8 @@ is($x->input_focus, $third->id, 'third window focused');
 cmd 'focus parent';
 cmd 'focus parent';
 cmd 'split v';
+# Focus second or else $first gets to the top of the focus stack.
+cmd '[id=' . $second->id . '] focus';
 reset_focus $s0_ws;
 
 cmd "workspace $s3_ws";
@@ -136,5 +138,97 @@ is($x->input_focus, $sixth->id, 'sixth window focused');
 cmd "workspace $s2_ws";
 cmd 'focus up';
 is($x->input_focus, $second->id, 'second window focused');
+
+###################################################################
+# Test that focus (left|down|right|up), when focusing across
+# outputs, doesn't focus the next window in the given direction but
+# the most focused window of the container in the given direction.
+# In the following layout:
+# [ WS1*[ ] WS2[ H[ A B* ] ] ]
+# (where the asterisk denotes the focused container within its
+# parent) moving right from WS1 should focus B which is focused
+# inside WS2, not A which is the next window on the right of WS1.
+# See issue #1160.
+###################################################################
+
+kill_all_windows;
+
+sync_with_i3;
+$x->root->warp_pointer(1025, 0);  # Second screen.
+sync_with_i3;
+$s1_ws = fresh_workspace;
+$first = open_window;
+$second = open_window;
+
+sync_with_i3;
+$x->root->warp_pointer(0, 0);  # First screen.
+sync_with_i3;
+$s0_ws = fresh_workspace;
+open_window;
+$third = open_window;
+
+cmd 'focus right';
+is($x->input_focus, $second->id, 'second window (rightmost) focused');
+cmd 'focus left';
+is($x->input_focus, $first->id, 'first window focused');
+cmd 'focus left';
+is($x->input_focus, $third->id, 'third window focused');
+
+
+###################################################################
+# Similar but with a tabbed layout.
+###################################################################
+
+cmd 'layout tabbed';
+$fourth = open_window;
+cmd 'focus left';
+is($x->input_focus, $third->id, 'third window (tabbed) focused');
+cmd "workspace $s1_ws";
+cmd 'focus left';
+is($x->input_focus, $third->id, 'third window (tabbed) focused');
+
+
+###################################################################
+# Similar but with a stacked layout on the bottom screen.
+###################################################################
+
+sync_with_i3;
+$x->root->warp_pointer(0, 769);  # Third screen.
+sync_with_i3;
+$s2_ws = fresh_workspace;
+cmd 'layout stacked';
+$fifth = open_window;
+$sixth = open_window;
+
+cmd "workspace $s0_ws";
+cmd 'focus down';
+is($x->input_focus, $sixth->id, 'sixth window (stacked) focused');
+
+###################################################################
+# Similar but with a more complex layout.
+###################################################################
+
+sync_with_i3;
+$x->root->warp_pointer(1025, 769);  # Fourth screen.
+sync_with_i3;
+$s3_ws = fresh_workspace;
+open_window;
+open_window;
+cmd 'split v';
+open_window;
+open_window;
+cmd 'split h';
+my $nested = open_window;
+open_window;
+cmd 'focus left';
+is($x->input_focus, $nested->id, 'nested window focused');
+
+cmd "workspace $s1_ws";
+cmd 'focus down';
+is($x->input_focus, $nested->id, 'nested window focused from workspace above');
+
+cmd "workspace $s2_ws";
+cmd 'focus right';
+is($x->input_focus, $nested->id, 'nested window focused from workspace on the left');
 
 done_testing;


### PR DESCRIPTION
Fixes #1160.

This is an alternative to https://github.com/orestisf1993/i3/commit/4a920e47ec6816c053aa577e4e697695a2bf2421 that doesn't modify floating focus behavior.

I'll also write tests once the main approach is decided.