### PR TITLE
i3bar: fix segfault when no status_command is provided

### DIFF
--- a/i3bar/src/ipc.c
+++ b/i3bar/src/ipc.c
@@ -177,7 +177,7 @@ void got_bar_config_update(char *event) {
 
     /* update the configuration with the received settings */
     DLOG("Received bar config update \"%s\"\n", event);
-    char *old_command = sstrdup(config.command);
+    char *old_command = config.command ? sstrdup(config.command) : NULL;
     bar_display_mode_t old_mode = config.hide_on_modifier;
     parse_config_json(event);
     if (old_mode != config.hide_on_modifier) {
@@ -189,7 +189,7 @@ void got_bar_config_update(char *event) {
     init_colors(&(config.colors));
 
     /* restart status command process */
-    if (strcmp(old_command, config.command) != 0) {
+    if (old_command && strcmp(old_command, config.command) != 0) {
         kill_child();
         start_child(config.command);
     }


### PR DESCRIPTION
Fixes #2933.

To reproduce add

```
bar {
}
```

in your config file and run `i3-msg bar mode toggle`.