### PR TITLE
dump-asy.pl: use correct tmp dirname instead of hardcoded /tmp

### DIFF
--- a/contrib/dump-asy.pl
+++ b/contrib/dump-asy.pl
@@ -13,6 +13,7 @@ use warnings;
 use Data::Dumper;
 use AnyEvent::I3;
 use File::Temp;
+use File::Basename;
 use v5.10;
 
 my $i3 = i3();
@@ -75,4 +76,5 @@ say $tmp "draw(n" . $root->{id} . ", (0, 0));";
 close($tmp);
 my $rep = "$tmp";
 $rep =~ s/asy$/eps/;
-system("cd /tmp && asy $tmp && gv --scale=-1000 --noresize --widgetless $rep && rm $rep");
+my $tmp_dir = dirname($rep);
+system("cd $tmp_dir && asy $tmp && gv --scale=-1000 --noresize --widgetless $rep && rm $rep");


### PR DESCRIPTION
For example, on some systems, $rep might be saved in /tmp/$USER/ instead
of /tmp/.