### PR TITLE
Fix compilation warnings on all Debian architectures.

### DIFF
--- a/include/all.h
+++ b/include/all.h
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <err.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <math.h>
 #include <limits.h>
 

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -900,7 +900,9 @@ bool parse_file(const char *f, bool use_nagbar) {
 
     FREE(current_config);
     current_config = scalloc(stbuf.st_size + 1, 1);
-    fread(current_config, 1, stbuf.st_size, fstr);
+    if ((ssize_t)fread(current_config, 1, stbuf.st_size, fstr) != stbuf.st_size) {
+        die("Could not fread: %s\n", strerror(errno));
+    }
     rewind(fstr);
 
     bool invalid_sets = false;

--- a/src/util.c
+++ b/src/util.c
@@ -500,7 +500,7 @@ ssize_t slurp(const char *path, char **buf) {
     size_t n = fread(*buf, 1, stbuf.st_size, f);
     fclose(f);
     if ((ssize_t)n != stbuf.st_size) {
-        ELOG("File \"%s\" could not be read entirely: got %zd, want %zd\n", path, n, stbuf.st_size);
+        ELOG("File \"%s\" could not be read entirely: got %zd, want %" PRIi64 "\n", path, n, (int64_t)stbuf.st_size);
         free(*buf);
         *buf = NULL;
         return -1;


### PR DESCRIPTION
stbuf.st_size is of type off_t, which the standard defines as “extended signed
integral type”¹, and for which there is no correct printf format string. Hence,
we need to cast it into a hopefully-large-enough type (ugh) and use the
corresponding format string. In our case, int64_t should do it, as config files
really shouldn’t be anywhere close to those numbers.

① http://pubs.opengroup.org/onlinepubs/007908799/xsh/systypes.h.html