### PR TITLE
_NET_ACTIVE_WINDOW: invalidate focus to force SetInputFocus call

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -774,6 +774,8 @@ static void handle_client_message(xcb_client_message_event_t *event) {
                 scratchpad_show(con);
             } else {
                 workspace_show(ws);
+                /* Re-set focus, even if unchanged from i3’s perspective. */
+                focused_id = XCB_NONE;
                 con_focus(con);
             }
         } else {


### PR DESCRIPTION
The sender of the _NET_ACTIVE_WINDOW client message might know better when to
set focus than i3, as i3 does not know about unmanaged (override_redirect=1)
windows.

related to https://github.com/i3/i3lock/issues/35