### PR TITLE
docs/userguide: Correct mark/goto i3-input commands

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -2398,10 +2398,10 @@ TODO: make i3-input replace %s
 *Examples*:
 ---------------------------------------
 # Read 1 character and mark the current window with this character
-bindsym $mod+m exec i3-input -p 'mark ' -l 1 -P 'Mark: '
+bindsym $mod+m exec i3-input -F 'mark %s' -l 1 -P 'Mark: '
 
 # Read 1 character and go to the window with the character
-bindsym $mod+g exec i3-input -p 'goto ' -l 1 -P 'Goto: '
+bindsym $mod+g exec i3-input -F '[con_mark="%s"] focus' -l 1 -P 'Goto: '
 ---------------------------------------
 
 Alternatively, if you do not want to mess with +i3-input+, you could create


### PR DESCRIPTION
The userguide still mentions an old 'goto' command which no longer
exists and will be ignored silently (when used in the i3 config) or
causes an error to be reported (when invoked from the command line).
This change updates the userguide to correct this problem. In addition
to that it also updates the i3-input command shown to no longer use the
deprecated -p flag but -F instead.