### PR TITLE
Perform proper cleanup for signals with 'Term' action

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -38,9 +38,6 @@ int listen_fds;
 /* We keep the xcb_prepare watcher around to be able to enable and disable it
  * temporarily for drag_pointer(). */
 static struct ev_prepare *xcb_prepare;
-static struct ev_signal signal_watchers[6];
-
-#define NUM_WATCHERS (sizeof(signal_watchers) / sizeof(signal_watchers[0]))
 
 extern Con *focused;
 
@@ -211,6 +208,9 @@ static void handle_term_signal(struct ev_loop *loop, ev_signal *signal, int reve
  *
  */
 static void setup_term_handlers(void) {
+    static struct ev_signal signal_watchers[6];
+    size_t num_watchers = sizeof(signal_watchers) / sizeof(signal_watchers[0]);
+
     /* We have to rely on libev functionality here and should not use
      * sigaction handlers because we need to invoke the exit handlers
      * and cannot do so from an asynchronous signal handling context as
@@ -223,10 +223,11 @@ static void setup_term_handlers(void) {
     ev_signal_init(&signal_watchers[3], handle_term_signal, SIGTERM);
     ev_signal_init(&signal_watchers[4], handle_term_signal, SIGUSR1);
     ev_signal_init(&signal_watchers[5], handle_term_signal, SIGUSR1);
-    for (size_t i = 0; i < NUM_WATCHERS; i++) {
+    for (size_t i = 0; i < num_watchers; i++) {
         ev_signal_start(main_loop, &signal_watchers[i]);
-        /* None of the signal handlers should hold a reference to the
-         * main loop. */
+        /* The signal handlers should not block ev_run from returning
+         * and so none of the signal handlers should hold a reference to
+         * the main loop. */
         ev_unref(main_loop);
     }
 }

--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -12,6 +12,7 @@ use AnyEvent::I3;
 use List::Util qw(first);
 use Time::HiRes qw(sleep);
 use Cwd qw(abs_path);
+use POSIX ':sys_wait_h';
 use Scalar::Util qw(blessed);
 use SocketActivation;
 use i3test::Util qw(slurp);
@@ -37,6 +38,7 @@ our @EXPORT = qw(
     cmd
     sync_with_i3
     exit_gracefully
+    exit_forcefully
     workspace_exists
     focused_ws
     get_socket_path
@@ -123,7 +125,7 @@ END {
 
     } else {
         kill(-9, $i3_pid)
-            or $tester->BAIL_OUT("could not kill i3");
+            or $tester->BAIL_OUT("could not kill i3: $!");
 
         waitpid $i3_pid, 0;
     }
@@ -152,8 +154,7 @@ sub import {
     $i3_autostart = delete($args{i3_autostart}) // 1;
     my $i3_config = delete($args{i3_config}) // '-default';
 
-    my $cv;
-    ($i3_pid, $cv) = launch_with_config($i3_config, dont_block => 1)
+    my $cv = launch_with_config($i3_config, dont_block => 1)
         if $i3_autostart;
 
     my $test_more_args = '';
@@ -760,7 +761,7 @@ sub exit_gracefully {
 
     if (!$exited) {
         kill(9, $pid)
-            or $tester->BAIL_OUT("could not kill i3");
+            or $tester->BAIL_OUT("could not kill i3: $!");
     }
 
     if ($socketpath =~ m,^/tmp/i3-test-socket-,) {
@@ -768,6 +769,48 @@ sub exit_gracefully {
     }
 
     waitpid $pid, 0;
+    undef $i3_pid;
+}
+
+=head2 exit_forcefully($pid, [ $signal ])
+
+Tries to exit i3 forcefully by sending a signal (defaults to SIGTERM).
+
+You only need to use this function if you want to test signal handling
+(in which case you must have launched i3 on your own with
+C<launch_with_config>).
+
+  use i3test i3_autostart => 0;
+  my $pid = launch_with_config($config);
+  # …
+  exit_forcefully($pid);
+
+=cut
+sub exit_forcefully {
+    my ($pid, $signal) = @_;
+    $signal ||= 'TERM';
+
+    # Send the given signal to the i3 instance and wait for up to 10s
+    # for it to terminate.
+    kill($signal, $pid)
+        or $tester->BAIL_OUT("could not kill i3: $!");
+    my $status;
+    my $timeout = 10;
+    do {
+        $status = waitpid $pid, WNOHANG;
+
+        if ($status <= 0) {
+            sleep(1);
+            $timeout--;
+        }
+    } while ($status <= 0 && $timeout > 0);
+
+    if ($status <= 0) {
+        kill('KILL', $pid)
+            or $tester->BAIL_OUT("could not kill i3: $!");
+        waitpid $pid, 0;
+    }
+    undef $i3_pid;
 }
 
 =head2 get_socket_path([ $cache ])
@@ -841,7 +884,7 @@ sub launch_with_config {
     close($fh);
 
     my $cv = AnyEvent->condvar;
-    my $pid = activate_i3(
+    $i3_pid = activate_i3(
         unix_socket_path => "$tmp_socket_path-activation",
         display => $ENV{DISPLAY},
         configfile => $tmpfile,
@@ -862,7 +905,10 @@ sub launch_with_config {
     # there's nothing else we need to do.
     if ($args{validate_config}) {
         $cv->recv;
-        waitpid $pid, 0;
+        waitpid $i3_pid, 0;
+
+        # We need this since exit_gracefully will not be called in this case.
+        undef $i3_pid;
 
         return ${^CHILD_ERROR_NATIVE};
     }
@@ -871,12 +917,12 @@ sub launch_with_config {
     # as soon as i3 has started
     $cv->cb(sub { get_socket_path(0) });
 
-    return $pid, $cv if $args{dont_block};
+    return $cv if $args{dont_block};
 
     # blockingly wait until i3 is ready
     $cv->recv;
 
-    return $pid;
+    return $i3_pid;
 }
 
 =head2 get_i3_log

--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -152,7 +152,8 @@ sub import {
     $i3_autostart = delete($args{i3_autostart}) // 1;
     my $i3_config = delete($args{i3_config}) // '-default';
 
-    my $cv = launch_with_config($i3_config, dont_block => 1)
+    my $cv;
+    ($i3_pid, $cv) = launch_with_config($i3_config, dont_block => 1)
         if $i3_autostart;
 
     my $test_more_args = '';
@@ -767,7 +768,6 @@ sub exit_gracefully {
     }
 
     waitpid $pid, 0;
-    undef $i3_pid;
 }
 
 =head2 get_socket_path([ $cache ])
@@ -841,7 +841,7 @@ sub launch_with_config {
     close($fh);
 
     my $cv = AnyEvent->condvar;
-    $i3_pid = activate_i3(
+    my $pid = activate_i3(
         unix_socket_path => "$tmp_socket_path-activation",
         display => $ENV{DISPLAY},
         configfile => $tmpfile,
@@ -862,10 +862,7 @@ sub launch_with_config {
     # there's nothing else we need to do.
     if ($args{validate_config}) {
         $cv->recv;
-        waitpid $i3_pid, 0;
-
-        # We need this since exit_gracefully will not be called in this case.
-        undef $i3_pid;
+        waitpid $pid, 0;
 
         return ${^CHILD_ERROR_NATIVE};
     }
@@ -874,12 +871,12 @@ sub launch_with_config {
     # as soon as i3 has started
     $cv->cb(sub { get_socket_path(0) });
 
-    return $cv if $args{dont_block};
+    return $pid, $cv if $args{dont_block};
 
     # blockingly wait until i3 is ready
     $cv->recv;
 
-    return $i3_pid;
+    return $pid;
 }
 
 =head2 get_i3_log

--- a/testcases/t/540-sigterm-cleanup.t
+++ b/testcases/t/540-sigterm-cleanup.t
@@ -1,0 +1,37 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests that the socket file is cleaned up properly after gracefully
+# shutting down i3 via SIGTERM.
+# Ticket: #3049
+use i3test i3_autostart => 0;
+use File::Temp qw(tempfile tempdir);
+
+my $config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+EOT
+
+my $pid = launch_with_config($config, dont_add_socket_path => 1);
+my $socket = get_socket_path();
+ok(-S $socket, "socket $socket exists");
+
+kill('TERM', $pid);
+waitpid $pid, 0;
+
+ok(!-e $socket, "socket $socket no longer exists");
+
+done_testing;

--- a/testcases/t/540-sigterm-cleanup.t
+++ b/testcases/t/540-sigterm-cleanup.t
@@ -18,7 +18,6 @@
 # shutting down i3 via SIGTERM.
 # Ticket: #3049
 use i3test i3_autostart => 0;
-use File::Temp qw(tempfile tempdir);
 
 my $config = <<EOT;
 # i3 config file (v4)
@@ -29,8 +28,7 @@ my $pid = launch_with_config($config, dont_add_socket_path => 1);
 my $socket = get_socket_path();
 ok(-S $socket, "socket $socket exists");
 
-kill('TERM', $pid);
-waitpid $pid, 0;
+exit_forcefully($pid, 'TERM');
 
 ok(!-e $socket, "socket $socket no longer exists");
 


### PR DESCRIPTION
Issue #3049 describes a case where terminating i3 by means of SIGTERM
causes it to leak the runtime directory and all its contents. There are
multiple issues at play: first, any cleanup handlers registered via
atexit are never invoked when a signal terminates the program (see
atexit(3)). Hence, the log SHM log cleanup performed in i3_exit is not
invoked in that case. Second, compared to the shutdown path for the
'exit' command, we do not unlink the UNIX domain socket we create,
causing it to be leaked as well. Third, a handler for SIGTERM is not
registered at all despite handle_signal claiming to be the handler for
all 'Term' signals.
This change addresses all three problems and results in a graceful exit
including cleanup to happen when we receive a signal with the default
action 'Term'. It addresses issue #3049.