### PR TITLE
do not check for NULL in FREE macro

### DIFF
--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -58,12 +58,10 @@
 #error "SYSCONFDIR not defined"
 #endif
 
-#define FREE(pointer)          \
-    do {                       \
-        if (pointer != NULL) { \
-            free(pointer);     \
-            pointer = NULL;    \
-        }                      \
+#define FREE(pointer)   \
+    do {                \
+        free(pointer);  \
+        pointer = NULL; \
     } while (0)
 
 #include "xcb.h"

--- a/i3-input/i3-input.h
+++ b/i3-input/i3-input.h
@@ -5,12 +5,10 @@
 #include <err.h>
 
 #define die(...) errx(EXIT_FAILURE, __VA_ARGS__);
-#define FREE(pointer)          \
-    do {                       \
-        if (pointer != NULL) { \
-            free(pointer);     \
-            pointer = NULL;    \
-        }                      \
+#define FREE(pointer)   \
+    do {                \
+        free(pointer);  \
+        pointer = NULL; \
     } while (0)
 
 extern xcb_window_t root;

--- a/i3-nagbar/i3-nagbar.h
+++ b/i3-nagbar/i3-nagbar.h
@@ -5,12 +5,10 @@
 #include <err.h>
 
 #define die(...) errx(EXIT_FAILURE, __VA_ARGS__);
-#define FREE(pointer)          \
-    do {                       \
-        if (pointer != NULL) { \
-            free(pointer);     \
-            pointer = NULL;    \
-        }                      \
+#define FREE(pointer)   \
+    do {                \
+        free(pointer);  \
+        pointer = NULL; \
     } while (0)
 
 #define xmacro(atom) xcb_atom_t A_##atom;

--- a/i3bar/include/util.h
+++ b/i3bar/include/util.h
@@ -20,12 +20,10 @@
 #define STARTS_WITH(string, len, needle) (((len) >= strlen((needle))) && strncasecmp((string), (needle), strlen((needle))) == 0)
 
 /* Securely free p */
-#define FREE(p)          \
-    do {                 \
-        if (p != NULL) { \
-            free(p);     \
-            p = NULL;    \
-        }                \
+#define FREE(p)   \
+    do {          \
+        free(p);  \
+        p = NULL; \
     } while (0)
 
 /* Securely free single-linked list */

--- a/include/util.h
+++ b/include/util.h
@@ -47,12 +47,10 @@
         break;                            \
     }
 
-#define FREE(pointer)          \
-    do {                       \
-        if (pointer != NULL) { \
-            free(pointer);     \
-            pointer = NULL;    \
-        }                      \
+#define FREE(pointer)   \
+    do {                \
+        free(pointer);  \
+        pointer = NULL; \
     } while (0)
 
 #define CALL(obj, member, ...) obj->member(obj, ##__VA_ARGS__)


### PR DESCRIPTION
free(3) is safe to invoke on a NULL pointer, in which case no action is
taken. This change adjusts the FREE macros to omit this unnecessary
check.