### PR TITLE
Skip internal workspaces with 'move workspace to output'

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1121,6 +1121,10 @@ void cmd_move_workspace_to_output(I3_CMD, const char *name) {
     owindow *current;
     TAILQ_FOREACH(current, &owindows, owindows) {
         Con *ws = con_get_workspace(current->con);
+        if (con_is_internal(ws)) {
+            continue;
+        }
+
         bool success = workspace_move_to_output(ws, name);
         if (!success) {
             ELOG("Failed to move workspace to output.\n");

--- a/testcases/t/504-move-workspace-to-output.t
+++ b/testcases/t/504-move-workspace-to-output.t
@@ -180,5 +180,35 @@ cmd '[con_mark=marked] move workspace to output current';
 ok($ws1 ~~ @$x0, 'ws1 on fake-0');
 
 ################################################################################
+# Verify that '[class=".*"] move workspace to output' doesn't fail when
+# containers in the scratchpad are matched.
+# See issue: #3064.
+################################################################################
+my $__i3_scratch = get_ws('__i3_scratch');
+is(scalar @{$__i3_scratch->{floating_nodes}}, 0, 'scratchpad is empty');
+
+my $ws0 = fresh_workspace(output => 0);
+open_window(wm_class => 'a');
+
+my $ws1 = fresh_workspace(output => 1);
+open_window(wm_class => 'b');
+my $scratchpad_window = open_window(wm_class => 'c');
+cmd 'move to scratchpad';
+
+($x0, $x1) = workspaces_per_screen();
+ok($ws0 ~~ @$x0, 'ws0 on fake-0');
+ok($ws1 ~~ @$x1, 'ws1 on fake-1');
+
+my $reply = cmd '[class=".*"] move workspace to output fake-1';
+ok($reply->[0]->{success}, 'move successful');
+
+($x0, $x1) = workspaces_per_screen();
+ok($ws0 ~~ @$x1, 'ws0 on fake-1');
+ok($ws1 ~~ @$x1, 'ws1 on fake-1');
+
+$__i3_scratch = get_ws('__i3_scratch');
+is(scalar @{$__i3_scratch->{floating_nodes}}, 1, 'window still in scratchpad');
+
+################################################################################
 
 done_testing;


### PR DESCRIPTION
Fixes #3064.