### PR TITLE
Add '--release' flag for bindsym in the bar block

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1377,7 +1377,7 @@ and will be removed in a future release. We strongly recommend using the more ge
 
 *Syntax*:
 ----------------------------
-bindsym button<n> <command>
+bindsym [--release] button<n> <command>
 ----------------------------
 
 *Example*:
@@ -1385,6 +1385,8 @@ bindsym button<n> <command>
 bar {
     # disable clicking on workspace buttons
     bindsym button1 nop
+    # Take a screenshot by right clicking on the bar
+    bindsym --release button3 exec --no-startup-id import /tmp/latest-screenshot.png
     # execute custom script when scrolling downwards
     bindsym button5 exec ~/.i3/scripts/custom_wheel_down
 }

--- a/i3bar/include/configuration.h
+++ b/i3bar/include/configuration.h
@@ -27,6 +27,7 @@ typedef enum { M_DOCK = 0,
 typedef struct binding_t {
     int input_code;
     char *command;
+    bool release;
 
     TAILQ_ENTRY(binding_t)
     bindings;

--- a/i3bar/src/config.c
+++ b/i3bar/src/config.c
@@ -264,6 +264,21 @@ static int config_string_cb(void *params_, const unsigned char *val, size_t _len
  *
  */
 static int config_boolean_cb(void *params_, int val) {
+    if (parsing_bindings) {
+        if (strcmp(cur_key, "release") == 0) {
+            binding_t *binding = TAILQ_LAST(&(config.bindings), bindings_head);
+            if (binding == NULL) {
+                ELOG("There is no binding to put the current command onto. This is a bug in i3.\n");
+                return 0;
+            }
+
+            binding->release = val;
+            return 1;
+        }
+
+        ELOG("Unknown key \"%s\" while parsing bar bindings.\n", cur_key);
+    }
+
     if (!strcmp(cur_key, "binding_mode_indicator")) {
         DLOG("binding_mode_indicator = %d\n", val);
         config.disable_binding_mode_indicator = !val;

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -84,7 +84,7 @@ CFGFUN(bar_verbose, const char *verbose);
 CFGFUN(bar_modifier, const char *modifier);
 CFGFUN(bar_wheel_up_cmd, const char *command);
 CFGFUN(bar_wheel_down_cmd, const char *command);
-CFGFUN(bar_bindsym, const char *button, const char *command);
+CFGFUN(bar_bindsym, const char *button, const char *release, const char *command);
 CFGFUN(bar_position, const char *position);
 CFGFUN(bar_i3bar_command, const char *i3bar_command);
 CFGFUN(bar_color, const char *colorclass, const char *border, const char *background, const char *text);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -384,6 +384,9 @@ struct Barbinding {
     /** The command which is to be executed for this button. */
     char *command;
 
+    /** If true, the command will be executed after the button is released. */
+    bool release;
+
     TAILQ_ENTRY(Barbinding)
     bindings;
 };

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -501,12 +501,16 @@ state BAR_WHEEL_DOWN_CMD:
       -> call cfg_bar_wheel_down_cmd($command); BAR
 
 state BAR_BINDSYM:
+  release = '--release'
+      ->
   button = word
       -> BAR_BINDSYM_COMMAND
 
 state BAR_BINDSYM_COMMAND:
+  release = '--release'
+      ->
   command = string
-      -> call cfg_bar_bindsym($button, $command); BAR
+      -> call cfg_bar_bindsym($button, $release, $command); BAR
 
 state BAR_POSITION:
   position = 'top', 'bottom'

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -502,7 +502,7 @@ CFGFUN(bar_modifier, const char *modifier) {
         current_bar->modifier = M_NONE;
 }
 
-static void bar_configure_binding(const char *button, const char *command) {
+static void bar_configure_binding(const char *button, const char *release, const char *command) {
     if (strncasecmp(button, "button", strlen("button")) != 0) {
         ELOG("Bindings for a bar can only be mouse bindings, not \"%s\", ignoring.\n", button);
         return;
@@ -513,16 +513,18 @@ static void bar_configure_binding(const char *button, const char *command) {
         ELOG("Button \"%s\" does not seem to be in format 'buttonX'.\n", button);
         return;
     }
+    const bool release_bool = release != NULL;
 
     struct Barbinding *current;
     TAILQ_FOREACH(current, &(current_bar->bar_bindings), bindings) {
-        if (current->input_code == input_code) {
+        if (current->input_code == input_code && current->release == release_bool) {
             ELOG("command for button %s was already specified, ignoring.\n", button);
             return;
         }
     }
 
     struct Barbinding *new_binding = scalloc(1, sizeof(struct Barbinding));
+    new_binding->release = release_bool;
     new_binding->input_code = input_code;
     new_binding->command = sstrdup(command);
     TAILQ_INSERT_TAIL(&(current_bar->bar_bindings), new_binding, bindings);
@@ -530,16 +532,16 @@ static void bar_configure_binding(const char *button, const char *command) {
 
 CFGFUN(bar_wheel_up_cmd, const char *command) {
     ELOG("'wheel_up_cmd' is deprecated. Please us 'bindsym button4 %s' instead.\n", command);
-    bar_configure_binding("button4", command);
+    bar_configure_binding("button4", NULL, command);
 }
 
 CFGFUN(bar_wheel_down_cmd, const char *command) {
     ELOG("'wheel_down_cmd' is deprecated. Please us 'bindsym button5 %s' instead.\n", command);
-    bar_configure_binding("button5", command);
+    bar_configure_binding("button5", NULL, command);
 }
 
-CFGFUN(bar_bindsym, const char *button, const char *command) {
-    bar_configure_binding(button, command);
+CFGFUN(bar_bindsym, const char *button, const char *release, const char *command) {
+    bar_configure_binding(button, release, command);
 }
 
 CFGFUN(bar_position, const char *position) {

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -572,6 +572,8 @@ static void dump_bar_bindings(yajl_gen gen, Barconfig *config) {
         y(integer, current->input_code);
         ystr("command");
         ystr(current->command);
+        ystr("release");
+        y(bool, current->release == B_UPON_KEYRELEASE);
 
         y(map_close);
     }

--- a/testcases/t/525-i3bar-mouse-bindings.t
+++ b/testcases/t/525-i3bar-mouse-bindings.t
@@ -30,6 +30,9 @@ bar {
     bindsym button3 focus left
     bindsym button4 focus right
     bindsym button5 focus left
+    bindsym --release button6 focus right
+    bindsym button7 focus left
+    bindsym button7 --release focus right
 }
 EOT
 use i3test::XTEST;
@@ -141,5 +144,44 @@ subtest 'button 5 moves focus left', \&focus_subtest,
     },
     [ $left->{id} ],
     'button 5 moves focus left';
+
+# Test --release flag with bar bindsym.
+# See issue: #3068.
+
+my $old_focus = get_focused($ws);
+subtest 'button 6 does not move focus while pressed', \&focus_subtest,
+    sub {
+        xtest_button_press(6, 3, 3);
+        xtest_sync_with($i3bar_window);
+    },
+    [],
+    'button 6 does not move focus while pressed';
+is(get_focused($ws), $old_focus, 'focus unchanged');
+
+subtest 'button 6 release moves focus right', \&focus_subtest,
+    sub {
+        xtest_button_release(6, 3, 3);
+        xtest_sync_with($i3bar_window);
+    },
+    [ $right->{id} ],
+    'button 6 release moves focus right';
+
+# Test same bindsym button with and without --release.
+
+subtest 'button 7 press moves focus left', \&focus_subtest,
+    sub {
+        xtest_button_press(7, 3, 3);
+        xtest_sync_with($i3bar_window);
+    },
+    [ $left->{id} ],
+    'button 7 press moves focus left';
+
+subtest 'button 7 release moves focus right', \&focus_subtest,
+    sub {
+        xtest_button_release(7, 3, 3);
+        xtest_sync_with($i3bar_window);
+    },
+    [ $right->{id} ],
+    'button 7 release moves focus right';
 
 done_testing;


### PR DESCRIPTION
i3bar's handle_button is modified to also handle `XCB_BUTTON_RELEASE`
events. During these button release events, only custom commands are
checked to avoid sending multiple workspace ipc messages.

The way this patch is implemented will allow to assign a custom command
for both the press and release of the same button:
```
bar {
  ...
  bindsym buttonX exec command1
  bindsym --release buttonX exec command2
}
```

Fixes #3068.

TODO:
- [x] update documentation
- [x] tests

but I am opening the PR to get some first opinions.