### PR TITLE
Add support for relative coordinates in i3bar click events

### DIFF
--- a/docs/i3bar-protocol
+++ b/docs/i3bar-protocol
@@ -236,6 +236,11 @@ x, y::
 	X11 root window coordinates where the click occurred
 button::
 	X11 button ID (for example 1 to 3 for left/middle/right mouse button)
+relative_x, relative_y::
+    Coordinates where the click occurred, with respect to the top left corner
+    of the block
+width, height::
+    Width and height (in px) of the block
 
 *Example*:
 ------------------------------------------
@@ -244,6 +249,10 @@ button::
  "instance": "eth0",
  "button": 1,
  "x": 1320,
- "y": 1400
+ "y": 1400,
+ "relative_x": 12,
+ "relative_y": 8,
+ "width": 50,
+ "height": 22
 }
 ------------------------------------------

--- a/i3bar/include/child.h
+++ b/i3bar/include/child.h
@@ -85,4 +85,4 @@ bool child_want_click_events(void);
  * Generates a click event, if enabled.
  *
  */
-void send_block_clicked(int button, const char *name, const char *instance, int x, int y);
+void send_block_clicked(int button, const char *name, const char *instance, int x, int y, int x_rel, int y_rel, int width, int height);

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -596,7 +596,7 @@ void child_click_events_key(const char *key) {
  * Generates a click event, if enabled.
  *
  */
-void send_block_clicked(int button, const char *name, const char *instance, int x, int y) {
+void send_block_clicked(int button, const char *name, const char *instance, int x, int y, int x_rel, int y_rel, int width, int height) {
     if (!child.click_events) {
         return;
     }
@@ -623,6 +623,18 @@ void send_block_clicked(int button, const char *name, const char *instance, int 
 
     child_click_events_key("y");
     yajl_gen_integer(gen, y);
+
+    child_click_events_key("relative_x");
+    yajl_gen_integer(gen, x_rel);
+
+    child_click_events_key("relative_y");
+    yajl_gen_integer(gen, y_rel);
+
+    child_click_events_key("width");
+    yajl_gen_integer(gen, width);
+
+    child_click_events_key("height");
+    yajl_gen_integer(gen, height);
 
     yajl_gen_map_close(gen);
     child_write_output();

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -523,7 +523,8 @@ void handle_button(xcb_button_press_event_t *event) {
                 block_x += render->width + render->x_offset + render->x_append + get_sep_offset(block) + sep_offset_remainder;
 
                 if (statusline_x <= block_x && statusline_x >= last_block_x) {
-                    send_block_clicked(event->detail, block->name, block->instance, event->root_x, event->root_y);
+                    send_block_clicked(event->detail, block->name, block->instance,
+                                       event->root_x, event->root_y, statusline_x - last_block_x, event->event_y, block_x - last_block_x, bar_height);
                     return;
                 }
 


### PR DESCRIPTION
The JSON in the stdin of the status_command would get 4 new parameters:
```
x_rel  - relative position of click w.r.t. block (x coord)
y_rel  - relative position of click w.r.t. block (y coord)
width  - width of block
height - height of block
```
This was discussed in #2767 