### PR TITLE
Refocus focused window for FOCUS_IN events on the root window.

### DIFF
--- a/include/xcb.h
+++ b/include/xcb.h
@@ -53,6 +53,7 @@
                                                                   ConfigureNotify */                  \
                          XCB_EVENT_MASK_POINTER_MOTION |                                              \
                          XCB_EVENT_MASK_PROPERTY_CHANGE |                                             \
+                         XCB_EVENT_MASK_FOCUS_CHANGE |                                                \
                          XCB_EVENT_MASK_ENTER_WINDOW)
 
 #define xmacro(atom) xcb_atom_t A_##atom;

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -1207,6 +1207,14 @@ static bool handle_clientleader_change(void *data, xcb_connection_t *conn, uint8
  */
 static void handle_focus_in(xcb_focus_in_event_t *event) {
     DLOG("focus change in, for window 0x%08x\n", event->event);
+
+    if (event->event == root) {
+        DLOG("Received focus in for root window, refocusing the focused window.\n");
+        con_focus(focused);
+        focused_id = XCB_NONE;
+        x_push_changes(croot);
+    }
+
     Con *con;
     if ((con = con_by_window_id(event->event)) == NULL || con->window == NULL)
         return;


### PR DESCRIPTION
This deals with (admittedly somewhat misbehaving) clients which
use XSetInputFocus to take focus, but then don't properly restore
focus. This has been observed with TK apps, but also, e.g., Steam.

fixes #2722
fixes #3096