### PR TITLE
Avoid some code duplication

### DIFF
--- a/include/resize.h
+++ b/include/resize.h
@@ -11,6 +11,6 @@
 
 #include <config.h>
 
-bool resize_find_tiling_participants(Con **current, Con **other, direction_t direction);
+bool resize_find_tiling_participants(Con **current, Con **other, direction_t direction, bool both_sides);
 
 int resize_graphical_handler(Con *first, Con *second, orientation_t orientation, const xcb_button_press_event_t *event);

--- a/src/click.c
+++ b/src/click.c
@@ -49,7 +49,7 @@ static bool tiling_resize_for_border(Con *con, border_t border, xcb_button_press
             break;
     }
 
-    bool res = resize_find_tiling_participants(&first, &second, search_direction);
+    bool res = resize_find_tiling_participants(&first, &second, search_direction, false);
     if (!res) {
         LOG("No second container in this direction found.\n");
         return false;

--- a/src/resize.c
+++ b/src/resize.c
@@ -47,7 +47,7 @@ DRAGGING_CB(resize_callback) {
     xcb_flush(conn);
 }
 
-bool resize_find_tiling_participants(Con **current, Con **other, direction_t direction) {
+bool resize_find_tiling_participants(Con **current, Con **other, direction_t direction, bool both_sides) {
     DLOG("Find two participants for resizing container=%p in direction=%i\n", other, direction);
     Con *first = *current;
     Con *second = NULL;
@@ -74,8 +74,14 @@ bool resize_find_tiling_participants(Con **current, Con **other, direction_t dir
         /* get the counterpart for this resizement */
         if (dir_backwards) {
             second = TAILQ_PREV(first, nodes_head, nodes);
+            if (second == NULL && both_sides == true) {
+                second = TAILQ_NEXT(first, nodes);
+            }
         } else {
             second = TAILQ_NEXT(first, nodes);
+            if (second == NULL && both_sides == true) {
+                second = TAILQ_PREV(first, nodes_head, nodes);
+            }
         }
 
         if (second == NULL) {


### PR DESCRIPTION
Some code and checks in cmd_resize_tiling_width_height() can be replaced with a call to resize_find_tiling_participants(). To get the same behavior, resize_find_tiling_participants() is extended so it can also look for a resize target in two direction simultaneously: left+right or top+bottom.
The need for this change emerged in the discussion of #3036, it and can be reused in that PR as well.