### PR TITLE
[WIP] Add default_{,floating_}border

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -586,23 +586,26 @@ workspace_layout default|stacking|tabbed
 workspace_layout tabbed
 ---------------------
 
-=== Border style for new windows
+=== Default border style for new windows
 
 This option determines which border style new windows will have. The default is
-+normal+. Note that new_float applies only to windows which are starting out as
++normal+. Note that default_floating_border applies only to windows which are starting out as
 floating windows, e.g., dialog windows, but not windows that are floated later on.
 
 *Syntax*:
 ---------------------------------------------
-new_window normal|none|pixel
-new_window normal|pixel <px>
-new_float normal|none|pixel
-new_float normal|pixel <px>
+default_border normal|none|pixel
+default_border normal|pixel <px>
+default_floating_border normal|none|pixel
+default_floating_border normal|pixel <px>
 ---------------------------------------------
+
+Please note that +new_window+ and +new_float+ have been deprecated in favor of the above options
+and will be removed in a future release. We strongly recommend using the new options instead.
 
 *Example*:
 ---------------------
-new_window pixel
+default_border pixel
 ---------------------
 
 The "normal" and "pixel" border styles support an optional border width in
@@ -610,11 +613,11 @@ pixels:
 
 *Example*:
 ---------------------
-# The same as new_window none
-new_window pixel 0
+# The same as default_border none
+default_border pixel 0
 
 # A 3 px border
-new_window pixel 3
+default_border pixel 3
 ---------------------
 
 

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -67,7 +67,7 @@ CFGFUN(popup_during_fullscreen, const char *value);
 CFGFUN(color, const char *colorclass, const char *border, const char *background, const char *text, const char *indicator, const char *child_border);
 CFGFUN(color_single, const char *colorclass, const char *color);
 CFGFUN(floating_modifier, const char *modifiers);
-CFGFUN(new_window, const char *windowtype, const char *border, const long width);
+CFGFUN(default_border, const char *windowtype, const char *border, const long width);
 CFGFUN(workspace, const char *workspace, const char *output);
 CFGFUN(binding, const char *bindtype, const char *modifiers, const char *key, const char *release, const char *border, const char *whole_window, const char *exclude_titlebar, const char *command);
 

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -29,7 +29,8 @@ state INITIAL:
   'floating_modifier'                      -> FLOATING_MODIFIER
   'default_orientation'                    -> DEFAULT_ORIENTATION
   'workspace_layout'                       -> WORKSPACE_LAYOUT
-  windowtype = 'new_window', 'new_float'   -> NEW_WINDOW
+  windowtype = 'default_border', 'new_window', 'default_floating_border', 'new_float'
+      -> DEFAULT_BORDER
   'hide_edge_borders'                      -> HIDE_EDGE_BORDERS
   'for_window'                             -> FOR_WINDOW
   'assign'                                 -> ASSIGN
@@ -105,25 +106,25 @@ state WORKSPACE_LAYOUT:
   layout = 'default', 'stacking', 'stacked', 'tabbed'
       -> call cfg_workspace_layout($layout)
 
-# new_window <normal|1pixel|none>
-# new_float <normal|1pixel|none>
-state NEW_WINDOW:
+# <default_border|new_window> <normal|1pixel|none>
+# <default_floating_border|new_float> <normal|1pixel|none>
+state DEFAULT_BORDER:
   border = 'normal', 'pixel'
-      -> NEW_WINDOW_PIXELS
+      -> DEFAULT_BORDER_PIXELS
   border = '1pixel', 'none'
-      -> call cfg_new_window($windowtype, $border, -1)
+      -> call cfg_default_border($windowtype, $border, -1)
 
-state NEW_WINDOW_PIXELS:
+state DEFAULT_BORDER_PIXELS:
   end
-      -> call cfg_new_window($windowtype, $border, 2)
+      -> call cfg_default_border($windowtype, $border, 2)
   width = number
-      -> NEW_WINDOW_PIXELS_PX
+      -> DEFAULT_BORDER_PIXELS_PX
 
-state NEW_WINDOW_PIXELS_PX:
+state DEFAULT_BORDER_PIXELS_PX:
   'px'
       ->
   end
-      -> call cfg_new_window($windowtype, $border, &width)
+      -> call cfg_default_border($windowtype, $border, &width)
 
 # hide_edge_borders <none|vertical|horizontal|both|smart>
 # also hide_edge_borders <bool> for compatibility

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -197,7 +197,7 @@ CFGFUN(workspace_layout, const char *layout) {
         config.default_layout = L_TABBED;
 }
 
-CFGFUN(new_window, const char *windowtype, const char *border, const long width) {
+CFGFUN(default_border, const char *windowtype, const char *border, const long width) {
     int border_style;
     int border_width;
 
@@ -215,7 +215,8 @@ CFGFUN(new_window, const char *windowtype, const char *border, const long width)
         border_width = width;
     }
 
-    if (strcmp(windowtype, "new_window") == 0) {
+    if ((strcmp(windowtype, "default_border") == 0) ||
+        (strcmp(windowtype, "new_window") == 0)) {
         DLOG("default tiled border style = %d and border width = %d (%d physical px)\n",
              border_style, border_width, logical_px(border_width));
         config.default_border = border_style;

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -145,7 +145,7 @@ is(parser_calls($config),
 
 $config = <<'EOT';
 floating_minimum_size 80x55
-floating_minimum_size 80    x  55  
+floating_minimum_size 80    x  55
 floating_maximum_size 73 x 10
 EOT
 
@@ -245,8 +245,8 @@ is(parser_calls($config),
 ################################################################################
 
 $config = <<'EOT';
-workspace "3" output DP-1 
-workspace "3" output     	VGA-1	
+workspace "3" output DP-1
+workspace "3" output     	VGA-1
 EOT
 
 $expected = <<'EOT';
@@ -266,19 +266,33 @@ $config = <<'EOT';
 new_window 1pixel
 new_window normal
 new_window none
+default_border 1pixel
+default_border normal
+default_border none
 new_float 1pixel
 new_float normal
 new_float none
+default_floating_border 1pixel
+default_floating_border normal
+default_floating_border none
 EOT
 
 $expected = <<'EOT';
-cfg_new_window(new_window, 1pixel, -1)
-cfg_new_window(new_window, normal, 2)
-cfg_new_window(new_window, none, -1)
-cfg_new_window(new_float, 1pixel, -1)
-cfg_new_window(new_float, normal, 2)
-cfg_new_window(new_float, none, -1)
+cfg_default_border(new_window, 1pixel, -1)
+cfg_default_border(new_window, normal, 2)
+cfg_default_border(new_window, none, -1)
+cfg_default_border(default_border, 1pixel, -1)
+cfg_default_border(default_border, normal, 2)
+cfg_default_border(default_border, none, -1)
+cfg_default_border(new_float, 1pixel, -1)
+cfg_default_border(new_float, normal, 2)
+cfg_default_border(new_float, none, -1)
+cfg_default_border(default_floating_border, 1pixel, -1)
+cfg_default_border(default_floating_border, normal, 2)
+cfg_default_border(default_floating_border, none, -1)
 EOT
+
+# TODO: are there no tests for "border pixel 1" etc?
 
 is(parser_calls($config),
    $expected,
@@ -462,7 +476,9 @@ my $expected_all_tokens = "ERROR: CONFIG: Expected one of these tokens: <end>, '
         floating_modifier
         default_orientation
         workspace_layout
+        default_border
         new_window
+        default_floating_border
         new_float
         hide_edge_borders
         for_window


### PR DESCRIPTION
Implementation of i3/i3#2702

- [x] copy/rename `new_{window,float}` and associated states in `parser-config/config.spec`
- [x] rename `cfg_new_{window,float}` in `config_directives.c` and update calls in tests
- [x] extend the test case in `201-config-parser.t`
- [x] update the user guide

