### PR TITLE
Remove hardcoded 2013 date from user guide

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1,7 +1,6 @@
 i3 User’s Guide
 ===============
 Michael Stapelberg <michael@i3wm.org>
-March 2013
 
 This document contains all the information you need to configure and use the i3
 window manager. If it does not, please check https://www.reddit.com/r/i3wm/


### PR DESCRIPTION
The front page and docs landing page emphasize documentation, but the user guide looks like it hasn't been updated since 2013. It seems from the history of the file that this 2013 date is misleading. Hopefully I'm not missing something.