### PR TITLE
dump-asy: add prerequisites check; fix empty container names warnings

### DIFF
--- a/contrib/dump-asy.pl
+++ b/contrib/dump-asy.pl
@@ -15,6 +15,12 @@ use AnyEvent::I3;
 use File::Temp;
 use File::Basename;
 use v5.10;
+use IPC::Cmd qw[can_run];
+
+# prerequisites check so we can be specific about failures caused
+# by not having these tools in the path
+can_run('asy') or die 'Please install asymptote';
+can_run('gv') or die 'Please install gv';
 
 my $i3 = i3();
 
@@ -31,7 +37,7 @@ sub dump_node {
 
     my $o = ($n->{orientation} eq 'none' ? "u" : ($n->{orientation} eq 'horizontal' ? "h" : "v"));
     my $w = (defined($n->{window}) ? $n->{window} : "N");
-    my $na = $n->{name};
+    my $na = ($n->{name} or "[Empty]");
     $na =~ s/#/\\#/g;
     $na =~ s/\$/\\\$/g;
     $na =~ s/&/\\&/g;


### PR DESCRIPTION
Since the script isn't installed via package manager with the benefit of dependency checks, the first chunk makes sure that both asymptote and gv are installed before allowing the script to fail with less useful error output.
 
The second chunk squelches the warnings created by empty container names.