### PR TITLE
Add strip_workspace_name

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1594,7 +1594,7 @@ bar {
 }
 ------------------------
 
-=== Strip workspace numbers
+=== Strip workspace numbers/name
 
 Specifies whether workspace numbers should be displayed within the workspace
 buttons. This is useful if you want to have a named workspace that stays in
@@ -1605,11 +1605,15 @@ the form "[n]:[NAME]" will display only the name. You could use this, for
 instance, to display Roman numerals rather than digits by naming your
 workspaces to "1:I", "2:II", "3:III", "4:IV", ...
 
+When +strip_workspace_name+ is set to +yes+, any workspace that has a name of
+the form "[n]:[NAME]" will display only the number.
+
 The default is to display the full name within the workspace button.
 
 *Syntax*:
 ------------------------------
 strip_workspace_numbers yes|no
+strip_workspace_name yes|no
 ------------------------------
 
 *Example*:

--- a/i3bar/include/configuration.h
+++ b/i3bar/include/configuration.h
@@ -52,6 +52,7 @@ typedef struct config_t {
     bool disable_binding_mode_indicator;
     bool disable_ws;
     bool strip_ws_numbers;
+    bool strip_ws_name;
     char *bar_id;
     char *command;
     char *fontname;

--- a/i3bar/src/config.c
+++ b/i3bar/src/config.c
@@ -297,6 +297,12 @@ static int config_boolean_cb(void *params_, int val) {
         return 1;
     }
 
+    if (!strcmp(cur_key, "strip_workspace_name")) {
+        DLOG("strip_workspace_name = %d\n", val);
+        config.strip_ws_name = val;
+        return 1;
+    }
+
     if (!strcmp(cur_key, "verbose")) {
         DLOG("verbose = %d\n", val);
         config.verbose = val;

--- a/i3bar/src/workspaces.c
+++ b/i3bar/src/workspaces.c
@@ -106,8 +106,8 @@ static int workspaces_string_cb(void *params_, const unsigned char *val, size_t 
         const char *ws_name = (const char *)val;
         params->workspaces_walk->canonical_name = sstrndup(ws_name, len);
 
-        if (config.strip_ws_numbers && params->workspaces_walk->num >= 0) {
-            /* Special case: strip off the workspace number */
+        if ((config.strip_ws_numbers || config.strip_ws_name) && params->workspaces_walk->num >= 0) {
+            /* Special case: strip off the workspace number/name */
             static char ws_num[10];
 
             snprintf(ws_num, sizeof(ws_num), "%d", params->workspaces_walk->num);
@@ -119,11 +119,14 @@ static int workspaces_string_cb(void *params_, const unsigned char *val, size_t 
             if (offset && ws_name[offset] == ':')
                 offset += 1;
 
-            /* Offset may be equal to length, in which case display the number */
-            params->workspaces_walk->name = (offset < len
-                                                 ? i3string_from_markup_with_length(ws_name + offset, len - offset)
-                                                 : i3string_from_markup(ws_num));
-
+            if (config.strip_ws_numbers) {
+                /* Offset may be equal to length, in which case display the number */
+                params->workspaces_walk->name = (offset < len
+                                                     ? i3string_from_markup_with_length(ws_name + offset, len - offset)
+                                                     : i3string_from_markup(ws_num));
+            } else {
+                params->workspaces_walk->name = i3string_from_markup(ws_num);
+            }
         } else {
             /* Default case: just save the name */
             params->workspaces_walk->name = i3string_from_markup_with_length(ws_name, len);

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -96,5 +96,6 @@ CFGFUN(bar_status_command, const char *command);
 CFGFUN(bar_binding_mode_indicator, const char *value);
 CFGFUN(bar_workspace_buttons, const char *value);
 CFGFUN(bar_strip_workspace_numbers, const char *value);
+CFGFUN(bar_strip_workspace_name, const char *value);
 CFGFUN(bar_start);
 CFGFUN(bar_finish);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -331,6 +331,10 @@ struct Barconfig {
      * 'strip_workspace_numbers yes'. */
     bool strip_workspace_numbers;
 
+    /** Strip workspace name? Configuration option is
+     * 'strip_workspace_name yes'. */
+    bool strip_workspace_name;
+
     /** Hide mode button? Configuration option is 'binding_mode_indicator no'
      * but we invert the bool for the same reason as hide_workspace_buttons.*/
     bool hide_binding_mode_indicator;

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -455,6 +455,7 @@ state BAR:
   'binding_mode_indicator' -> BAR_BINDING_MODE_INDICATOR
   'workspace_buttons'      -> BAR_WORKSPACE_BUTTONS
   'strip_workspace_numbers' -> BAR_STRIP_WORKSPACE_NUMBERS
+  'strip_workspace_name' -> BAR_STRIP_WORKSPACE_NAME
   'verbose'                -> BAR_VERBOSE
   'colors'                 -> BAR_COLORS_BRACE
   '}'
@@ -554,6 +555,10 @@ state BAR_WORKSPACE_BUTTONS:
 state BAR_STRIP_WORKSPACE_NUMBERS:
   value = word
       -> call cfg_bar_strip_workspace_numbers($value); BAR
+
+state BAR_STRIP_WORKSPACE_NAME:
+  value = word
+      -> call cfg_bar_strip_workspace_name($value); BAR
 
 state BAR_VERBOSE:
   value = word

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -627,6 +627,10 @@ CFGFUN(bar_strip_workspace_numbers, const char *value) {
     current_bar->strip_workspace_numbers = eval_boolstr(value);
 }
 
+CFGFUN(bar_strip_workspace_name, const char *value) {
+    current_bar->strip_workspace_name = eval_boolstr(value);
+}
+
 CFGFUN(bar_start) {
     current_bar = scalloc(1, sizeof(struct Barconfig));
     TAILQ_INIT(&(current_bar->bar_bindings));

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -709,6 +709,9 @@ static void dump_bar_config(yajl_gen gen, Barconfig *config) {
     ystr("strip_workspace_numbers");
     y(bool, config->strip_workspace_numbers);
 
+    ystr("strip_workspace_name");
+    y(bool, config->strip_workspace_name);
+
     ystr("binding_mode_indicator");
     y(bool, !config->hide_binding_mode_indicator);
 

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -725,7 +725,7 @@ EOT
 $expected = <<'EOT';
 cfg_bar_start()
 cfg_bar_output(LVDS-1)
-ERROR: CONFIG: Expected one of these tokens: <end>, '#', 'set', 'i3bar_command', 'status_command', 'socket_path', 'mode', 'hidden_state', 'id', 'modifier', 'wheel_up_cmd', 'wheel_down_cmd', 'bindsym', 'position', 'output', 'tray_output', 'tray_padding', 'font', 'separator_symbol', 'binding_mode_indicator', 'workspace_buttons', 'strip_workspace_numbers', 'verbose', 'colors', '}'
+ERROR: CONFIG: Expected one of these tokens: <end>, '#', 'set', 'i3bar_command', 'status_command', 'socket_path', 'mode', 'hidden_state', 'id', 'modifier', 'wheel_up_cmd', 'wheel_down_cmd', 'bindsym', 'position', 'output', 'tray_output', 'tray_padding', 'font', 'separator_symbol', 'binding_mode_indicator', 'workspace_buttons', 'strip_workspace_numbers', 'strip_workspace_name', 'verbose', 'colors', '}'
 ERROR: CONFIG: (in file <stdin>)
 ERROR: CONFIG: Line   1: bar {
 ERROR: CONFIG: Line   2:     output LVDS-1


### PR DESCRIPTION
See the issue #3163 (https://github.com/i3/i3/issues/3163).

Add strip_workspace_name to strip off the workspace name.