### PR TITLE
Docs [#3164]: Clarification about X resource value

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -730,7 +730,8 @@ resource database to achieve an easily maintainable, consistent color theme
 across many X applications.
 
 Defining a resource will load this resource from the resource database and
-assign its value to the specified variable. A fallback must be specified in
+assign its value to the specified variable. This is done verbatim and the value
+must therefore be in the format that i3 uses. A fallback must be specified in
 case the resource cannot be loaded from the database.
 
 *Syntax*:


### PR DESCRIPTION
Clarification about X resource value: they are loaded verbatim and must therefore be in the format that i3 uses.
Solves #3164.