### PR TITLE
Correctly handle bindings for the same key with and without --release 

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -649,6 +649,14 @@ void switch_mode(const char *new_mode) {
         translate_keysyms();
         grab_all_keys(conn);
 
+        /* Reset all B_UPON_KEYRELEASE_IGNORE_MODS bindings to avoid possibly
+         * activating one of them. */
+        Binding *bind;
+        TAILQ_FOREACH(bind, bindings, bindings) {
+            if (bind->release == B_UPON_KEYRELEASE_IGNORE_MODS)
+                bind->release = B_UPON_KEYRELEASE;
+        }
+
         char *event_msg;
         sasprintf(&event_msg, "{\"change\":\"%s\", \"pango_markup\":%s}",
                   mode->name, (mode->pango_markup ? "true" : "false"));

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -227,9 +227,9 @@ static Binding *get_binding(i3_event_state_mask_t state_filtered, bool is_releas
         /* For keyboard bindings where a symbol was specified by the user, we
          * need to look in the array of translated keycodes for the event’s
          * keycode */
+        bool found_keycode = false;
         if (input_type == B_KEYBOARD && bind->symbol != NULL) {
             xcb_keycode_t input_keycode = (xcb_keycode_t)input_code;
-            bool found_keycode = false;
             struct Binding_Keycode *binding_keycode;
             TAILQ_FOREACH(binding_keycode, &(bind->keycodes_head), keycodes) {
                 const uint32_t modifiers_mask = (binding_keycode->modifiers & 0x0000FFFF);
@@ -241,16 +241,12 @@ static Binding *get_binding(i3_event_state_mask_t state_filtered, bool is_releas
                     break;
                 }
             }
-            if (!found_keycode) {
-                continue;
-            }
         } else {
             /* This case is easier: The user specified a keycode */
             if (bind->keycode != input_code) {
                 continue;
             }
 
-            bool found_keycode = false;
             struct Binding_Keycode *binding_keycode;
             TAILQ_FOREACH(binding_keycode, &(bind->keycodes_head), keycodes) {
                 const uint32_t modifiers_mask = (binding_keycode->modifiers & 0x0000FFFF);
@@ -262,9 +258,9 @@ static Binding *get_binding(i3_event_state_mask_t state_filtered, bool is_releas
                     break;
                 }
             }
-            if (!found_keycode) {
-                continue;
-            }
+        }
+        if (!found_keycode) {
+            continue;
         }
 
         /* If this binding is a release binding, it matches the key which the

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -236,7 +236,8 @@ static Binding *get_binding(i3_event_state_mask_t state_filtered, bool is_releas
                 const bool mods_match = (modifiers_mask == modifiers_state);
                 DLOG("binding_keycode->modifiers = %d, modifiers_mask = %d, modifiers_state = %d, mods_match = %s\n",
                      binding_keycode->modifiers, modifiers_mask, modifiers_state, (mods_match ? "yes" : "no"));
-                if (binding_keycode->keycode == input_keycode && mods_match) {
+                if (binding_keycode->keycode == input_keycode &&
+                    (mods_match || (bind->release == B_UPON_KEYRELEASE_IGNORE_MODS && is_release))) {
                     found_keycode = true;
                     break;
                 }

--- a/testcases/t/258-keypress-release.t
+++ b/testcases/t/258-keypress-release.t
@@ -36,6 +36,13 @@ bindsym --release Shift+x nop Shift+x
 # 133 == Mod4
 bindcode 133 nop 133
 bindcode --release 133 nop 133 release
+
+mode "a_mode" {
+    # 27 == r
+    bindcode 27 --release mode "default"
+}
+bindsym Mod1+r mode "a_mode"
+bindcode 27 nop do not receive
 EOT
 use i3test::XTEST;
 use ExtUtils::PkgConfig;
@@ -133,6 +140,30 @@ is(listen_for_binding(
     ),
     '133 release',
     'triggered the 133 keycode release binding');
+
+for my $i (1 .. 2) {
+    is(listen_for_binding(
+        sub {
+            xtest_key_press(64); # Alt_l
+            xtest_key_press(27); # r
+            xtest_key_release(27); # r
+            xtest_key_release(64); # Alt_l
+            xtest_sync_with_i3;
+        },
+        ),
+        'mode "a_mode"',
+        "switched to mode \"a_mode\" $i/2");
+
+    is(listen_for_binding(
+        sub {
+            xtest_key_press(27); # r
+            xtest_key_release(27); # r
+            xtest_sync_with_i3;
+        },
+        ),
+        'mode "default"',
+        "switched back to default $i/2");
+}
 
 }
 

--- a/testcases/t/258-keypress-release.t
+++ b/testcases/t/258-keypress-release.t
@@ -31,6 +31,11 @@ bindsym Mod1+b nop Mod1+b
 bindsym --release Mod1+Shift+b nop Mod1+Shift+b release
 
 bindsym --release Shift+x nop Shift+x
+
+# see issue #2733
+# 133 == Mod4
+bindcode 133 nop 133
+bindcode --release 133 nop 133 release
 EOT
 use i3test::XTEST;
 use ExtUtils::PkgConfig;
@@ -110,6 +115,25 @@ is(listen_for_binding(
         ),
        'Shift+x',
        'triggered the "Shift+x" keybinding by releasing Shift first');
+
+is(listen_for_binding(
+    sub {
+        xtest_key_press(133);
+        xtest_sync_with_i3;
+    },
+    ),
+    '133',
+    'triggered the 133 keycode press binding');
+
+is(listen_for_binding(
+    sub {
+        xtest_key_release(133);
+        xtest_sync_with_i3;
+    },
+    ),
+    '133 release',
+    'triggered the 133 keycode release binding');
+
 }
 
 done_testing;

--- a/testcases/t/258-keypress-release.t
+++ b/testcases/t/258-keypress-release.t
@@ -29,6 +29,8 @@ bindsym --release Control+Print nop Control+Print
 # see issue #2442
 bindsym Mod1+b nop Mod1+b
 bindsym --release Mod1+Shift+b nop Mod1+Shift+b release
+
+bindsym --release Shift+x nop Shift+x
 EOT
 use i3test::XTEST;
 use ExtUtils::PkgConfig;
@@ -85,6 +87,29 @@ is(listen_for_binding(
     'Mod1+Shift+b release',
     'triggered the "Mod1+Shift+b" release keybinding');
 
+is(listen_for_binding(
+        sub {
+            xtest_key_press(50); # Shift
+            xtest_key_press(53); # x
+            xtest_key_release(53); # x
+            xtest_key_release(50); # Shift
+            xtest_sync_with_i3;
+        },
+        ),
+       'Shift+x',
+       'triggered the "Shift+x" keybinding by releasing x first');
+
+is(listen_for_binding(
+        sub {
+            xtest_key_press(50); # Shift
+            xtest_key_press(53); # x
+            xtest_key_release(50); # Shift
+            xtest_key_release(53);  # x
+            xtest_sync_with_i3;
+        },
+        ),
+       'Shift+x',
+       'triggered the "Shift+x" keybinding by releasing Shift first');
 }
 
 done_testing;


### PR DESCRIPTION
Actually #2733's title is different from what I am fixing. I'll reread the thread tomorrow but `bindcode --release` works fine currently.

I am fixing the issue described in https://github.com/i3/i3/issues/2733#issuecomment-360805836.
I also wrote a small explanation in the second commit message.

- [x] I have
    ```
    mode "resize" {
    ...
        bindsym r --release exec --no-startup-id ~/bin/draw-resize.sh $(xdotool getactivewindow), mode "default"
    }
    bindsym $mod+r mode "resize"
    ```
    in my config. The first time I $mod+r it works as intended. The second time I $mod+r the r `--release` bindsym gets triggered immediately. This does not happen w/ `next`. Need to investigate.
- [ ] Tests from https://github.com/i3/i3/pull/3179#issuecomment-374261240

Fixes #2733 