### PR TITLE
Add alacritty to `i3-sensible-terminal`

### DIFF
--- a/i3-sensible-terminal
+++ b/i3-sensible-terminal
@@ -8,7 +8,7 @@
 # We welcome patches that add distribution-specific mechanisms to find the
 # preferred terminal emulator. On Debian, there is the x-terminal-emulator
 # symlink for example.
-for terminal in "$TERMINAL" x-terminal-emulator urxvt rxvt termit terminator Eterm aterm uxterm xterm gnome-terminal roxterm xfce4-terminal termite lxterminal mate-terminal terminology st qterminal lilyterm tilix terminix konsole kitty guake tilda; do
+for terminal in "$TERMINAL" x-terminal-emulator urxvt rxvt termit terminator Eterm aterm uxterm xterm gnome-terminal roxterm xfce4-terminal termite lxterminal mate-terminal terminology st qterminal lilyterm tilix terminix konsole kitty guake tilda alacritty; do
     if command -v "$terminal" > /dev/null 2>&1; then
         exec "$terminal" "$@"
     fi

--- a/man/i3-sensible-terminal.man
+++ b/man/i3-sensible-terminal.man
@@ -47,6 +47,7 @@ It tries to start one of the following (in that order):
 * kitty
 * guake
 * tilda
+* alacritty
 
 Please don’t complain about the order: If the user has any preference, they will
 have $TERMINAL set or modified their i3 configuration file.


### PR DESCRIPTION
This adds the `alacritty` terminal emulator to the
`i3-sensible-terminal` script.

Alacritty is still in its very early stages but it looks like it's not
going away for now, so this is a proposal to add it to
`i3-sensible-terminal` for that little bit of convenience.

If there are any limitations/requirements that need to be met before a
new terminal emulator is added to `i3-sensible-terminal`, please let me
know.