### PR TITLE
i3-msg: only print input + errorposition if they exist

### DIFF
--- a/i3-msg/main.c
+++ b/i3-msg/main.c
@@ -95,8 +95,10 @@ static int reply_start_map_cb(void *params) {
 
 static int reply_end_map_cb(void *params) {
     if (!last_reply.success) {
-        fprintf(stderr, "ERROR: Your command: %s\n", last_reply.input);
-        fprintf(stderr, "ERROR:               %s\n", last_reply.errorposition);
+        if (last_reply.input) {
+            fprintf(stderr, "ERROR: Your command: %s\n", last_reply.input);
+            fprintf(stderr, "ERROR:               %s\n", last_reply.errorposition);
+        }
         fprintf(stderr, "ERROR: %s\n", last_reply.error);
     }
     return 1;


### PR DESCRIPTION
Before:
```
$ i3-msg floating disable, move window to position 100 px 100 px
ERROR: Your command: (null)
ERROR:               (null)
ERROR: Cannot change position of a window/container because it is not floating.
[{"success":true},{"success":false,"error":"Cannot change position of a window/container because it is not floating."}]
```

After:
```
$ i3-msg floating disable, move window to position 100 px 100 px
ERROR: Cannot change position of a window/container because it is not floating.
[{"success":true},{"success":false,"error":"Cannot change position of a window/container because it is not floating."}]
```