### PR TITLE
Free ran_assignments

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -160,10 +160,16 @@ void load_configuration(xcb_connection_t *conn, const char *override_configpath,
             FREE(barconfig);
         }
 
-        /* Invalidate pixmap caches in case font or colors changed */
         Con *con;
-        TAILQ_FOREACH(con, &all_cons, all_cons)
-        FREE(con->deco_render_params);
+        TAILQ_FOREACH(con, &all_cons, all_cons) {
+            /* Assignments changed, previously ran assignments are invalid. */
+            if (con->window) {
+                con->window->nr_assignments = 0;
+                FREE(con->window->ran_assignments);
+            }
+            /* Invalidate pixmap caches in case font or colors changed. */
+            FREE(con->deco_render_params);
+        }
 
         /* Get rid of the current font */
         free_font();


### PR DESCRIPTION
When we run `reload` all the assignments are freed:
https://github.com/i3/i3/blob/e3e09119bf994ea3f5222441832952a8dd352941/src/config.c#L99-L109

Assignments are saved to each window after they are executed:
https://github.com/i3/i3/blob/e3e09119bf994ea3f5222441832952a8dd352941/src/assignments.c#L41-L46

This means that the pointers stored in `window->ran_assignments` are
invalid (shouldn't be dangerous currently but could lead to a segfault
if the code is modified) after a `reload`.