### PR TITLE
Fix userguide link

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -2258,8 +2258,7 @@ See <<move_to_outputs>> for how to move a container/workspace to a different
 RandR output.
 
 [[move_to_outputs]]
-[[_moving_containers_workspaces_to_randr_outputs]]
-=== Moving containers/workspaces to RandR outputs
+=== [[_moving_containers_workspaces_to_randr_outputs]]Moving containers/workspaces to RandR outputs
 
 To move a container to another RandR output (addressed by names like +LVDS1+ or
 +VGA1+) or to a RandR output identified by a specific direction (like +left+,


### PR DESCRIPTION
`[[move_to_outputs]]` doesn't work currently:
https://i3wm.org/docs/userguide.html#move_to_outputs
This does:
https://i3wm.org/docs/userguide.html#_moving_containers_workspaces_to_randr_outputs

This combines a 'BlockId Element' with an 'anchor'. Both should work
now.