### PR TITLE
_workspace_show -> workspace_show

### DIFF
--- a/src/workspace.c
+++ b/src/workspace.c
@@ -340,7 +340,7 @@ static void workspace_reassign_sticky(Con *con) {
 
 /*
  * Callback to reset the urgent flag of the given con to false. May be started by
- * _workspace_show to avoid urgency hints being lost by switching to a workspace
+ * workspace_show to avoid urgency hints being lost by switching to a workspace
  * focusing the con.
  *
  */
@@ -360,7 +360,11 @@ static void workspace_defer_update_urgent_hint_cb(EV_P_ ev_timer *w, int revents
     }
 }
 
-static void _workspace_show(Con *workspace) {
+/*
+ * Switches to the given workspace
+ *
+ */
+void workspace_show(Con *workspace) {
     Con *current, *old = NULL;
     Con *old_focus = focused;
 
@@ -488,21 +492,13 @@ static void _workspace_show(Con *workspace) {
 }
 
 /*
- * Switches to the given workspace
- *
- */
-void workspace_show(Con *workspace) {
-    _workspace_show(workspace);
-}
-
-/*
  * Looks up the workspace by name and switches to it.
  *
  */
 void workspace_show_by_name(const char *num) {
     Con *workspace;
     workspace = workspace_get(num, NULL);
-    _workspace_show(workspace);
+    workspace_show(workspace);
 }
 
 /*


### PR DESCRIPTION
a9b57a44a9d328d5153158445bc6a5c7b78420b0 removed the extra parameter of
workspace_show.