### PR TITLE
_con_move_to_con: focus_next isn't always con_next_focused(con)

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -1140,7 +1140,13 @@ static bool _con_move_to_con(Con *con, Con *target, bool behind_focused, bool fi
 
     /* 1: save the container which is going to be focused after the current
      * container is moved away */
-    Con *focus_next = con_next_focused(con);
+    Con *focus_next = NULL;
+    if (!ignore_focus && source_ws == current_ws) {
+        focus_next = con_descend_focused(source_ws);
+        if (focus_next == con || con_has_parent(focus_next, con)) {
+            focus_next = con_next_focused(con);
+        }
+    }
 
     /* 2: we go up one level, but only when target is a normal container */
     if (target->type != CT_WORKSPACE) {
@@ -1223,7 +1229,7 @@ static bool _con_move_to_con(Con *con, Con *target, bool behind_focused, bool fi
 
     /* Set focus only if con was on current workspace before moving.
      * Otherwise we would give focus to some window on different workspace. */
-    if (!ignore_focus && source_ws == current_ws)
+    if (focus_next)
         con_activate(con_descend_focused(focus_next));
 
     /* 8. If anything within the container is associated with a startup sequence,

--- a/testcases/t/294-focus-order.t
+++ b/testcases/t/294-focus-order.t
@@ -27,6 +27,7 @@ sub kill_and_confirm_focus {
 }
 
 my @windows;
+my $ws;
 
 sub focus_windows {
     for (my $i = $#windows; $i >= 0; $i--) {
@@ -121,5 +122,23 @@ $windows[0] = open_window;
 
 cmd '[id=' . $windows[3]->id . '] move right';
 confirm_focus('split-v + unfocused move');
+
+######################################################################
+# Test that moving an unfocused container from inside a split
+# container to another workspace doesn't focus sibling.
+######################################################################
+
+$ws = fresh_workspace;
+$windows[0] = open_window;
+$windows[1] = open_window;
+cmd 'split v';
+open_window;
+cmd 'mark a';
+
+cmd '[id=' . $windows[0]->id . '] focus';
+cmd '[con_mark=a] move to workspace ' . get_unused_workspace;
+
+is(@{get_ws_content($ws)}, 2, 'Sanity check: marked window moved');
+confirm_focus('Move unfocused window from split container');
 
 done_testing;


### PR DESCRIPTION
`con_next_focused` uses con's parent. But since `con` can be inside an unfocused container this means that one of it's siblings could become focused in the current workspace.

There is another small issue with `focus_next`: since we descend when focusing later, moving an unrelated container while a parent container is selected will discard the user's selection.