### PR TITLE
add --modifier flag to i3-config-wizard (#3136)

### DIFF
--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -745,10 +745,12 @@ int main(int argc, char *argv[]) {
     char *pattern = "pango:monospace 8";
     char *patternbold = "pango:monospace bold 8";
     int o, option_index = 0;
+    bool headless_run = false;
 
     static struct option long_options[] = {
         {"socket", required_argument, 0, 's'},
         {"version", no_argument, 0, 'v'},
+        {"modifier", required_argument, 0, 'm'},
         {"limit", required_argument, 0, 'l'},
         {"prompt", required_argument, 0, 'P'},
         {"prefix", required_argument, 0, 'p'},
@@ -767,9 +769,18 @@ int main(int argc, char *argv[]) {
             case 'v':
                 printf("i3-config-wizard " I3_VERSION "\n");
                 return 0;
+            case 'm':
+                headless_run = true;
+                if (strcmp(optarg, "alt") == 0)
+                    modifier = MOD_Mod1;
+                else if (strcmp(optarg, "win") == 0)
+                    modifier = MOD_Mod4;
+                else
+                    err(EXIT_FAILURE, "Invalid modifier key %s", optarg);
+                break;
             case 'h':
                 printf("i3-config-wizard " I3_VERSION "\n");
-                printf("i3-config-wizard [-s <socket>] [-v]\n");
+                printf("i3-config-wizard [-s <socket>] [-v] [--modifier <modifier key>]\n");
                 return 0;
         }
     }
@@ -825,6 +836,11 @@ int main(int argc, char *argv[]) {
     xcb_get_modifier_mapping_cookie_t modmap_cookie;
     modmap_cookie = xcb_get_modifier_mapping(conn);
     symbols = xcb_key_symbols_alloc(conn);
+
+    if (headless_run) {
+        finish();
+        return 0;
+    }
 
 /* Place requests for the atoms we need as soon as possible */
 #define xmacro(atom) \

--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -758,7 +758,7 @@ int main(int argc, char *argv[]) {
         {"help", no_argument, 0, 'h'},
         {0, 0, 0, 0}};
 
-    char *options_string = "s:vh";
+    char *options_string = "sm:vh";
 
     while ((o = getopt_long(argc, argv, options_string, long_options, &option_index)) != -1) {
         switch (o) {
@@ -780,7 +780,7 @@ int main(int argc, char *argv[]) {
                 break;
             case 'h':
                 printf("i3-config-wizard " I3_VERSION "\n");
-                printf("i3-config-wizard [-s <socket>] [-v] [--modifier <modifier key>]\n");
+                printf("i3-config-wizard [-s <socket>] [-v] [-m <modifier key>]\n");
                 return 0;
         }
     }

--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -780,7 +780,7 @@ int main(int argc, char *argv[]) {
                 break;
             case 'h':
                 printf("i3-config-wizard " I3_VERSION "\n");
-                printf("i3-config-wizard [-s <socket>] [-v] [-m <modifier key>]\n");
+                printf("i3-config-wizard [-s <socket>] [-m win|alt] [-v] [-h]\n");
                 return 0;
         }
     }

--- a/man/i3-config-wizard.man
+++ b/man/i3-config-wizard.man
@@ -9,7 +9,21 @@ i3-config-wizard - creates a keysym based config based on your layout
 
 == SYNOPSIS
 
-i3-config-wizard
+i3-config-wizard [*-s* 'socket'] [*-m* 'modifier'] [*-v*] [*-h*]
+
+== OPTIONS
+
+*-s, --socket* 'socket'::
+Overwrites the path to the i3 IPC socket.
+
+*-m, --modifier* 'modifier'::
+Generates the configuration file headlessly. Accepts win or alt.
+
+*-v, --version*::
+Display version number and exit.
+
+*-h, --help*::
+Display a short help message and exit.
 
 == FILES
 


### PR DESCRIPTION
The --modifier flag accepts either alt or win, and will generate the
configuration file without opening a window

Fixes #3136.