### PR TITLE
Issue 3208

### DIFF
--- a/include/workspace.h
+++ b/include/workspace.h
@@ -207,4 +207,4 @@ Con *workspace_encapsulate(Con *ws);
  * This returns true if and only if moving the workspace was successful.
  *
  */
-bool workspace_move_to_output(Con *ws, const char *output);
+bool workspace_move_to_output(Con *ws, Output *output);

--- a/src/commands.c
+++ b/src/commands.c
@@ -1128,7 +1128,21 @@ void cmd_move_workspace_to_output(I3_CMD, const char *name) {
             continue;
         }
 
-        bool success = workspace_move_to_output(ws, name);
+        Output *current_output = get_output_for_con(ws);
+        if (current_output == NULL) {
+            ELOG("Cannot get current output. This is a bug in i3.\n");
+            ysuccess(false);
+            return;
+        }
+
+        Output *target_output = get_output_from_string(current_output, name);
+        if (!target_output) {
+            ELOG("Could not get output from string \"%s\"\n", name);
+            ysuccess(false);
+            return;
+        }
+
+        bool success = workspace_move_to_output(ws, target_output);
         if (!success) {
             ELOG("Failed to move workspace to output.\n");
             ysuccess(false);
@@ -1990,7 +2004,12 @@ void cmd_rename_workspace(I3_CMD, const char *old_name, const char *new_name) {
             continue;
         }
 
-        workspace_move_to_output(workspace, assignment->output);
+        Output *target_output = get_output_by_name(assignment->output, true);
+        if (!target_output) {
+            LOG("Could not get output named \"%s\"\n", assignment->output);
+            continue;
+        }
+        workspace_move_to_output(workspace, target_output);
 
         if (previously_focused)
             workspace_show(con_get_workspace(previously_focused));

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -923,18 +923,12 @@ Con *workspace_encapsulate(Con *ws) {
  * Move the given workspace to the specified output.
  * This returns true if and only if moving the workspace was successful.
  */
-bool workspace_move_to_output(Con *ws, const char *name) {
-    LOG("Trying to move workspace %p / %s to output \"%s\".\n", ws, ws->name, name);
+bool workspace_move_to_output(Con *ws, Output *output) {
+    LOG("Trying to move workspace %p / %s to output %p / \"%s\".\n", ws, ws->name, output, output_primary_name(output));
 
     Output *current_output = get_output_for_con(ws);
     if (current_output == NULL) {
         ELOG("Cannot get current output. This is a bug in i3.\n");
-        return false;
-    }
-
-    Output *output = get_output_from_string(current_output, name);
-    if (!output) {
-        ELOG("Could not get output from string \"%s\"\n", name);
         return false;
     }
 

--- a/testcases/t/522-rename-assigned-workspace.t
+++ b/testcases/t/522-rename-assigned-workspace.t
@@ -28,6 +28,7 @@ workspace 1 output fake-0
 workspace 2 output fake-1
 workspace 3:foo output fake-1
 workspace baz output fake-1
+workspace 5 output left
 EOT
 
 my $i3 = i3(get_socket_path());
@@ -81,5 +82,16 @@ cmd 'focus output fake-0';
 cmd 'rename workspace to baz';
 is(get_output_for_workspace('baz'), 'fake-1',
     'Renaming the workspace to a number and name should move it to the assigned output');
+
+##########################################################################
+# Renaming a workspace so that it is assigned a directional output does
+# not move the workspace or crash
+##########################################################################
+
+cmd 'focus output fake-0';
+cmd 'workspace bar';
+cmd 'rename workspace to 5';
+is(get_output_for_workspace('5'), 'fake-0',
+    'Renaming the workspace to a workspace assigned to a directional output should not move the workspace');
 
 done_testing;


### PR DESCRIPTION
These two commits fix and test the issue of interpreting output assignments as directions when renaming a workspace.