### PR TITLE
Resize tile px

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -2326,10 +2326,10 @@ resize set <width> [px | ppt] <height> [px | ppt]
 Direction can either be one of +up+, +down+, +left+ or +right+. Or you can be
 less specific and use +width+ or +height+, in which case i3 will take/give
 space from all the other containers. The optional pixel argument specifies by
-how many pixels a *floating container* should be grown or shrunk (the default
-is 10 pixels). The ppt argument means percentage points and specifies by how
-many percentage points a *tiling container* should be grown or shrunk (the
-default is 10 percentage points).
+how many pixels a container should be grown or shrunk (the default is 10
+pixels).  The optional ppt argument means "percentage points", and if
+specified it indicates that a *tiling container* should be grown or shrunk by
+that many points, instead of by the +px+ value.
 
 Notes about +resize set+: a value of 0 for <width> or <height> means "do
 not resize in this direction", and resizing a tiling container by +px+ is not

--- a/include/util.h
+++ b/include/util.h
@@ -177,3 +177,9 @@ bool parse_long(const char *str, long *out, int base);
  *
  */
 ssize_t slurp(const char *path, char **buf);
+
+/**
+ * Convert a string direction ("left", "right", etc.) to a direction_t,
+ * or return false if the direction does not match one of those strings.
+ */
+bool parse_direction(const char *str, direction_t *direction);

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -243,7 +243,7 @@ state RESIZE_TILING:
   'or'
       -> RESIZE_TILING_OR
   end
-      -> call cmd_resize($way, $direction, &resize_px, 10)
+      -> call cmd_resize($way, $direction, &resize_px, 0)
 
 state RESIZE_TILING_OR:
   resize_ppt = number

--- a/src/commands.c
+++ b/src/commands.c
@@ -495,8 +495,11 @@ static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, c
     switch (search_direction) {
         case D_RIGHT:  // fall through
         case D_LEFT:
-            first_size = first->rect.width + first->deco_rect.width;
-            total_size = first_size + second->rect.width + second->deco_rect.width;
+            /* Note that we don't add on the deco_rect.width here; the
+             * width is handled differently than the height.  See render.c in
+             * render_con_split. */
+            first_size = first->rect.width;
+            total_size = first_size + second->rect.width;
             break;
         case D_DOWN:  // fall through
         case D_UP:

--- a/src/commands.c
+++ b/src/commands.c
@@ -507,7 +507,7 @@ static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, c
 
     double relative_percent;
     if (ppt != 0) {
-        // resize based on the ppet
+        // resize based on the ppt
         relative_percent = first_size / total_size + (double)ppt/100.0;
     } else  {
         // resize based on the px

--- a/src/commands.c
+++ b/src/commands.c
@@ -493,12 +493,12 @@ static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, c
     double first_size;
     double total_size;
     switch (search_direction) {
-        case D_RIGHT: // fall through
+        case D_RIGHT:  // fall through
         case D_LEFT:
             first_size = first->rect.width + first->deco_rect.width;
             total_size = first_size + second->rect.width + second->deco_rect.width;
             break;
-        case D_DOWN: // fall through
+        case D_DOWN:  // fall through
         case D_UP:
             first_size = first->rect.height + first->deco_rect.height;
             total_size = first_size + second->rect.height + second->deco_rect.height;
@@ -508,8 +508,8 @@ static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, c
     double relative_percent;
     if (ppt != 0) {
         // resize based on the ppt
-        relative_percent = first_size / total_size + (double)ppt/100.0;
-    } else  {
+        relative_percent = first_size / total_size + (double)ppt / 100.0;
+    } else {
         // resize based on the px
         relative_percent = (first_size + px) / total_size;
     }
@@ -521,7 +521,7 @@ static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, c
     }
 
     first->percent = total_percent * relative_percent;
-    second->percent = total_percent  * (1 - relative_percent);
+    second->percent = total_percent * (1 - relative_percent);
 
     return true;
 }

--- a/src/commands.c
+++ b/src/commands.c
@@ -508,7 +508,7 @@ static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, c
     double relative_percent;
     if (ppt != 0) {
         // resize based on the ppet
-        relative_percent = first_size / total_size + ppt;
+        relative_percent = first_size / total_size + (double)ppt/100.0;
     } else  {
         // resize based on the px
         relative_percent = (first_size + px) / total_size;

--- a/src/commands.c
+++ b/src/commands.c
@@ -495,13 +495,13 @@ static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, c
     switch (search_direction) {
         case D_RIGHT: // fall through
         case D_LEFT:
-            first_size = first->rect.width;
-            total_size = first_size + second->rect.width;
+            first_size = first->rect.width + first->deco_rect.width;
+            total_size = first_size + second->rect.width + second->deco_rect.width;
             break;
         case D_DOWN: // fall through
         case D_UP:
-            first_size = first->rect.height;
-            total_size = first_size + second->rect.height;
+            first_size = first->rect.height + first->deco_rect.height;
+            total_size = first_size + second->rect.height + second->deco_rect.height;
             break;
     }
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -471,19 +471,16 @@ static void cmd_resize_floating(I3_CMD, const char *way, const char *direction, 
         floating_con->scratchpad_state = SCRATCHPAD_CHANGED;
 }
 
-static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, const char *direction, int ppt) {
+static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, const char *direction, int px) {
     LOG("tiling resize\n");
     Con *second = NULL;
     Con *first = current;
     direction_t search_direction;
-    if (!strcmp(direction, "left"))
-        search_direction = D_LEFT;
-    else if (!strcmp(direction, "right"))
-        search_direction = D_RIGHT;
-    else if (!strcmp(direction, "up"))
-        search_direction = D_UP;
-    else
-        search_direction = D_DOWN;
+    if (!parse_direction(direction, &search_direction)) {
+        LOG("Unknown direction '%s'.\n", direction);
+        ysuccess(false);
+        return false;
+    }
 
     bool res = resize_find_tiling_participants(&first, &second, search_direction, false);
     if (!res) {
@@ -492,32 +489,30 @@ static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, c
         return false;
     }
 
-    /* get the default percentage */
-    int children = con_num_children(first->parent);
-    LOG("ins. %d children\n", children);
-    double percentage = 1.0 / children;
-    LOG("default percentage = %f\n", percentage);
-
-    /* resize */
-    LOG("first->percent before = %f\n", first->percent);
-    LOG("second->percent before = %f\n", second->percent);
-    if (first->percent == 0.0)
-        first->percent = percentage;
-    if (second->percent == 0.0)
-        second->percent = percentage;
-    double new_first_percent = first->percent + ((double)ppt / 100.0);
-    double new_second_percent = second->percent - ((double)ppt / 100.0);
-    LOG("new_first_percent = %f\n", new_first_percent);
-    LOG("new_second_percent = %f\n", new_second_percent);
-    /* Ensure that the new percentages are positive. */
-    if (new_first_percent > 0.0 && new_second_percent > 0.0) {
-        first->percent = new_first_percent;
-        second->percent = new_second_percent;
-        LOG("first->percent after = %f\n", first->percent);
-        LOG("second->percent after = %f\n", second->percent);
-    } else {
-        LOG("Not resizing, already at minimum size\n");
+    double total_percent = first->percent + second->percent;
+    double first_size;
+    double total_size;
+    switch (search_direction) {
+        case D_RIGHT: // fall through
+        case D_LEFT:
+            first_size = first->rect.width;
+            total_size = first_size + second->rect.width;
+            break;
+        case D_DOWN: // fall through
+        case D_UP:
+            first_size = first->rect.height;
+            total_size = first_size + second->rect.height;
+            break;
     }
+
+    double relative_percent = (first_size + px) / total_size;
+    if (relative_percent < 0.0 || relative_percent > 1.0) {
+        LOG("Not resizing, already at minimum size\n");
+        return true;
+    }
+
+    first->percent = total_percent * relative_percent;
+    second->percent = total_percent  * (1 - relative_percent);
 
     return true;
 }
@@ -613,7 +608,8 @@ void cmd_resize(I3_CMD, const char *way, const char *direction, long resize_px, 
                     return;
             } else {
                 if (!cmd_resize_tiling_direction(current_match, cmd_output,
-                                                 current->con, way, direction, resize_ppt))
+                                                 current->con, way, direction,
+                                                 resize_px))
                     return;
             }
         }

--- a/src/commands.c
+++ b/src/commands.c
@@ -495,14 +495,14 @@ static bool cmd_resize_tiling_direction(I3_CMD, Con *current, const char *way, c
     switch (search_direction) {
         case D_RIGHT:  // fall through
         case D_LEFT:
-            /* Note that we don't add on the deco_rect.width here; the
-             * width is handled differently than the height.  See render.c in
-             * render_con_split. */
             first_size = first->rect.width;
             total_size = first_size + second->rect.width;
             break;
         case D_DOWN:  // fall through
         case D_UP:
+            /* For height changes, we need to account for the title bar (if
+             * present) because it is used in the rendering function when
+             * calculating the height */
             first_size = first->rect.height + first->deco_rect.height;
             total_size = first_size + second->rect.height + second->deco_rect.height;
             break;

--- a/src/util.c
+++ b/src/util.c
@@ -507,3 +507,22 @@ ssize_t slurp(const char *path, char **buf) {
     }
     return (ssize_t)n;
 }
+
+/**
+ * Convert a string direction ("left", "right", etc.) to a direction_t,
+ * or return false if the direction does not match one of those strings.
+ */
+bool parse_direction(const char *str, direction_t *direction) {
+    if (strcasecmp(str, "left") == 0)
+        *direction = D_LEFT;
+    else if (strcasecmp(str, "right") == 0)
+        *direction = D_RIGHT;
+    else if (strcasecmp(str, "up") == 0)
+        *direction = D_UP;
+    else if (strcasecmp(str, "down") == 0)
+        *direction = D_DOWN;
+    else
+        return false;
+
+    return true;
+}

--- a/testcases/t/141-resize.t
+++ b/testcases/t/141-resize.t
@@ -142,6 +142,81 @@ cmp_float($nodes->[2]->{percent}, 0.166666666666667, 'third window got 16%');
 cmp_float($nodes->[3]->{percent}, 0.50, 'fourth window got 50%');
 
 ################################################################################
+# Check that we can grow tiled windows by pixels
+################################################################################
+
+$tmp = fresh_workspace;
+
+$left = open_window;
+$right = open_window;
+
+($nodes, $focus) = get_ws_content($tmp);
+cmp_float($nodes->[0]->{rect}->{width}, 640, 'left window is 640px');
+cmp_float($nodes->[1]->{rect}->{width}, 640, 'right window is 640px');
+
+cmd 'resize grow left 10px';
+($nodes, $focus) = get_ws_content($tmp);
+cmp_float($nodes->[0]->{rect}->{width}, 630, 'left window is 630px');
+cmp_float($nodes->[1]->{rect}->{width}, 650, 'right window is 650px');
+
+################################################################################
+# Check that we can shrink tiled windows by pixels
+################################################################################
+
+$tmp = fresh_workspace;
+
+$left = open_window;
+$right = open_window;
+
+($nodes, $focus) = get_ws_content($tmp);
+cmp_float($nodes->[0]->{rect}->{width}, 640, 'left window is 640px');
+cmp_float($nodes->[1]->{rect}->{width}, 640, 'right window is 640px');
+
+cmd 'resize shrink left 10px';
+($nodes, $focus) = get_ws_content($tmp);
+cmp_float($nodes->[0]->{rect}->{width}, 650, 'left window is 650px');
+cmp_float($nodes->[1]->{rect}->{width}, 630, 'right window is 630px');
+
+
+################################################################################
+# Check that we can shrink vertical tiled windows by pixels
+################################################################################
+
+$tmp = fresh_workspace;
+
+cmd 'split v';
+
+$top = open_window;
+$bottom = open_window;
+
+($nodes, $focus) = get_ws_content($tmp);
+my @heights = ($nodes->[0]->{rect}->{height}, $nodes->[1]->{rect}->{height});
+
+cmd 'resize grow up 10px';
+($nodes, $focus) = get_ws_content($tmp);
+cmp_float($nodes->[0]->{rect}->{height}, $heights[0] - 10, 'top window is 10px larger');
+cmp_float($nodes->[1]->{rect}->{height}, $heights[0] + 10, 'bottom window is 10px smaller');
+
+################################################################################
+# Check that we can shrink vertical tiled windows by pixels
+################################################################################
+
+$tmp = fresh_workspace;
+
+cmd 'split v';
+
+$top = open_window;
+$bottom = open_window;
+
+($nodes, $focus) = get_ws_content($tmp);
+my @heights = ($nodes->[0]->{rect}->{height}, $nodes->[1]->{rect}->{height});
+
+cmd 'resize shrink up 10px';
+($nodes, $focus) = get_ws_content($tmp);
+cmp_float($nodes->[0]->{rect}->{height}, $heights[0] + 10, 'top window is 10px smaller');
+cmp_float($nodes->[1]->{rect}->{height}, $heights[0] - 10, 'bottom window is 10px larger');
+
+################################################################################
 # Check that the resize grow/shrink width/height syntax works if a nested split
 # was set on the container, but no sibling has been opened yet. See #2015.
 ################################################################################

--- a/testcases/t/187-commands-parser.t
+++ b/testcases/t/187-commands-parser.t
@@ -86,9 +86,9 @@ is(parser_calls(
    'resize shrink left 25 px or 33 ppt; ' .
    'resize shrink left 25'),
    "cmd_resize(shrink, left, 10, 10)\n" .
-   "cmd_resize(shrink, left, 25, 10)\n" .
+   "cmd_resize(shrink, left, 25, 0)\n" .
    "cmd_resize(shrink, left, 25, 33)\n" .
-   "cmd_resize(shrink, left, 25, 10)",
+   "cmd_resize(shrink, left, 25, 0)",
    'simple resize ok');
 
 is(parser_calls('resize shrink left 25 px or 33 ppt,'),


### PR DESCRIPTION
Allows resizing of tiled containers by px instead of just by ppt.  Syntax is just appended to current resize command, and will be backwards compatible if px is not specified.

Fixes #3239 