### PR TITLE
man: Fix title markers

### DIFF
--- a/man/i3-input.man
+++ b/man/i3-input.man
@@ -1,5 +1,5 @@
 i3-input(1)
-=========
+===========
 Michael Stapelberg <michael+i3@stapelberg.de>
 v4.1.2, April 2012
 

--- a/man/i3-sensible-editor.man
+++ b/man/i3-sensible-editor.man
@@ -1,5 +1,5 @@
 i3-sensible-editor(1)
-===================
+=====================
 Michael Stapelberg <michael+i3@stapelberg.de>
 v4.1, November 2011
 

--- a/man/i3-sensible-pager.man
+++ b/man/i3-sensible-pager.man
@@ -1,5 +1,5 @@
 i3-sensible-pager(1)
-===================
+====================
 Michael Stapelberg <michael+i3@stapelberg.de>
 v4.1, November 2011
 


### PR DESCRIPTION
The title marker lines have to be aligned with the previous lines.
The error was caught by asciidoctor, which tends to be picker than
asciidoc.

I'm submitting on behalf of Takashi (@tiwai).