### PR TITLE
i3bar: don't reset verbosity when parsing config values

### DIFF
--- a/i3bar/src/config.c
+++ b/i3bar/src/config.c
@@ -304,8 +304,10 @@ static int config_boolean_cb(void *params_, int val) {
     }
 
     if (!strcmp(cur_key, "verbose")) {
-        DLOG("verbose = %d\n", val);
-        config.verbose = val;
+        if (!config.verbose) {
+            DLOG("verbose = %d\n", val);
+            config.verbose = val;
+        }
         return 1;
     }
 


### PR DESCRIPTION
When i3bar is called with the -V flag but there is no `verbose yes`
directive in the bar {} config, the verbosity config value is reset.

This will introduce the opposite, negligible issue: you can't disable
i3bar's verbosity by deleting the `verbose yes` directive in the bar {}
config. To fix this we would need an enum for `config.verbose`.

Closes #3220.