### PR TITLE
Don't refocus on a workspace cleaned up by `workspace_show` during rename (#3228)

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1991,7 +1991,7 @@ void cmd_rename_workspace(I3_CMD, const char *old_name, const char *new_name) {
 
     /* By re-attaching, the sort order will be correct afterwards. */
     Con *previously_focused = focused;
-    bool previously_focused_is_workspace = focused->type == CT_WORKSPACE;
+    Con *previously_focused_content = focused->type == CT_WORKSPACE ? focused->parent : NULL;
     Con *parent = workspace->parent;
     con_detach(workspace);
     con_attach(workspace, parent, false);
@@ -2019,11 +2019,9 @@ void cmd_rename_workspace(I3_CMD, const char *old_name, const char *new_name) {
          * focus order/number of other workspaces on the output.
          * Instead, we loop through the available workspaces and only focus
          * previously_focused if we still find it. */
-        if (previously_focused_is_workspace) {
-            Con *output, *workspace = NULL;
-            TAILQ_FOREACH(output, &(croot->nodes_head), nodes) {
-                GREP_FIRST(workspace, output_get_content(output), child == previously_focused);
-            }
+        if (previously_focused_content) {
+            Con *workspace = NULL;
+            GREP_FIRST(workspace, previously_focused_content, child == previously_focused);
             can_restore_focus &= (workspace != NULL);
         }
 

--- a/testcases/t/522-rename-assigned-workspace.t
+++ b/testcases/t/522-rename-assigned-workspace.t
@@ -94,4 +94,16 @@ cmd 'rename workspace to 5';
 is(get_output_for_workspace('5'), 'fake-0',
     'Renaming the workspace to a workspace assigned to a directional output should not move the workspace');
 
+##########################################################################
+# Renaming a workspace, so that it becomes assigned to the focused
+# output's workspace (and the focused output is empty) should
+# result in the original workspace replacing the originally
+# focused workspace.
+##########################################################################
+
+cmd 'workspace baz';
+cmd 'rename workspace 5 to 2';
+is(get_output_for_workspace('2'), 'fake-1',
+    'Renaming a workspace so that it moves to the focused output which contains only an empty workspace should replace the empty workspace');
+
 done_testing;


### PR DESCRIPTION
When moving a workspace to the current output by way of a rename, if the
current workspace is empty, it will be removed by `workspace_show`.
Attempting to restore focus to this removed workspace causes a crash.
Follow the pattern in workspace.c:996 to only restore the original focus if the
original workspace still exists.

Add a test to ensure that the renamed workspace moves to its appropriate
output and that a crash does not occur.

Fixes #3228