### PR TITLE
Remove obsolete macro FOR_TABLE

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -25,9 +25,6 @@
 #define STARTS_WITH(string, needle) (strncasecmp((string), (needle), strlen((needle))) == 0)
 #define CIRCLEQ_NEXT_OR_NULL(head, elm, field) (CIRCLEQ_NEXT(elm, field) != CIRCLEQ_END(head) ? CIRCLEQ_NEXT(elm, field) : NULL)
 #define CIRCLEQ_PREV_OR_NULL(head, elm, field) (CIRCLEQ_PREV(elm, field) != CIRCLEQ_END(head) ? CIRCLEQ_PREV(elm, field) : NULL)
-#define FOR_TABLE(workspace)                             \
-    for (int cols = 0; cols < (workspace)->cols; cols++) \
-        for (int rows = 0; rows < (workspace)->rows; rows++)
 
 #define NODES_FOREACH(head)                                                    \
     for (Con *child = (Con *)-1; (child == (Con *)-1) && ((child = 0), true);) \


### PR DESCRIPTION
Was added in 38c8541807d50e18bf5ea61995ec6b3ab3e8a068, should have been removed in c145f7e5297ef06aaf84689762a736d5bc8cbb83.