### PR TITLE
Fix: ConfigureNotify can crash i3 with fake-outputs

### DIFF
--- a/src/randr.c
+++ b/src/randr.c
@@ -856,8 +856,9 @@ void randr_query_outputs(void) {
     /* If there's no randr output, enable the output covering the root window. */
     if (any_randr_output_active()) {
         DLOG("Active RandR output found. Disabling root output.\n");
-        if (root_output->active)
+        if (root_output && root_output->active) {
             root_output->to_be_disabled = true;
+        }
     } else {
         DLOG("No active RandR output found. Enabling root output.\n");
         root_output->active = true;


### PR DESCRIPTION
I am not sure if this is worth investigating more. Whenever I launch thunar, gvim, geany (probably more) with `fake-outputs`, i3 crashes. I just noticed this today randomly while it has never happened before and it still doesn't happen on my laptop. It happens with older versions of i3 too.