### PR TITLE
Activate the focused child when scrolling over tab/stack decorations

### DIFF
--- a/src/click.c
+++ b/src/click.c
@@ -235,6 +235,7 @@ static int route_click(Con *con, xcb_button_press_event_t *event, const bool mod
          * container the user scrolled on. */
         Con *focused = con->parent;
         focused = TAILQ_FIRST(&(focused->focus_head));
+        con_activate(con_descend_focused(focused));
         /* To prevent scrolling from going outside the container (see ticket
          * #557), we first check if scrolling is possible at all. */
         bool scroll_prev_possible = (TAILQ_PREV(focused, nodes_head, nodes) != NULL);

--- a/testcases/t/297-scroll-tabbed.t
+++ b/testcases/t/297-scroll-tabbed.t
@@ -53,7 +53,7 @@ open_window;
 cmd 'splitv';
 my $last = open_window;
 # Second child of the outer horizontal split, next to the tabbed one.
-open_window;
+my $outside = open_window;
 cmd 'move right, move right';
 
 cmd '[id=' . $first->id . '] focus';
@@ -75,5 +75,10 @@ scroll_up;
 is($x->input_focus, $first->id, 'First window focused through scrolling');
 scroll_up;
 is($x->input_focus, $first->id, 'Scrolling again doesn\'t focus the whole sibling');
+
+# Try scrolling with another window focused
+cmd '[id=' . $outside->id . '] focus';
+scroll_up;
+is($x->input_focus, $first->id, 'Scrolling from outside the tabbed container works');
 
 done_testing;


### PR DESCRIPTION
fbce834b introduced a bug where scrolling over the decoration while
another container is focused would not focus the tabbed/stacked
container itself, but would instead move focus through the currently
focused container.