### PR TITLE
Border artifacts when moving window

### DIFF
--- a/src/x.c
+++ b/src/x.c
@@ -796,11 +796,8 @@ void x_push_node(Con *con) {
          * background and only afterwards change the window size. This reduces
          * flickering. */
 
-        /* As the pixmap only depends on the size and not on the position, it
-         * is enough to check if width/height have changed. Also, we don’t
-         * create a pixmap at all when the window is actually not visible
-         * (height == 0) or when it is not needed. */
-        bool has_rect_changed = (state->rect.width != rect.width || state->rect.height != rect.height);
+        bool has_rect_changed = (state->rect.x != rect.x || state->rect.y != rect.y ||
+                                 state->rect.width != rect.width || state->rect.height != rect.height);
 
         /* Check if the container has an unneeded pixmap left over from
          * previously having a border or titlebar. */


### PR DESCRIPTION
Using `hide_edge_borders both` I noticed some visual artifacts on the borders.

## How to reproduce

Given the following config:

```sh
# doesn't need to be 10, but makes the issue more visible
default_border pixel 10
hide_edge_borders both
```

1. Open 2 tiled windows
2. Swap the windows (or: move the right one to the left)

### Result

Visual artifacts on the border between windows. The artifacts go away when focus changes and borders are redrawn. After being redrawn once, the artifacts don't reappear.

![before](https://user-images.githubusercontent.com/14021/41772592-7cc11df8-7619-11e8-99ab-b47637dc212b.gif)

## My fix

I updated the condition for `has_rect_changed`. Moving the window only changes its `x`, so previously this meant `has_rect_changed == false`. With the updated condition, a change in `rect.x` or `rect.y` also yields `has_rect_changed == true`.

### Result

![after](https://user-images.githubusercontent.com/14021/41772700-f53ae4d0-7619-11e8-90fb-5e6f3c082fc7.gif)

## Notes

* This is my first ever look into i3's code
* I feel the solution may result in some unnecessary rendering
* If this is the right location for the fix, should `memcmp` be used instead?
* With `hide_edge_borders none`, the issue doesn't occur
    * this leads me to believe my fix is not optimal
    * `has_rect_changed` is also false with `hide_edge_borders none`, however it doesn't suffer from this issue