### PR TITLE
Enhancement proposal for issue #3162

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -294,7 +294,7 @@ void cmd_scratchpad_show(I3_CMD);
  * Implementation of 'scratchpad show [--hide-if-visible] [on] output <name>'.
  *
  */
-void cmd_scratchpad_show_on_output(I3_CMD, const char* hide, const char* name);
+void cmd_scratchpad_show_on_output(I3_CMD, const char *hide, const char *name);
 
 /**
  * Implementation of 'swap [container] [with] id|con_id|mark <arg>'.

--- a/include/commands.h
+++ b/include/commands.h
@@ -291,6 +291,12 @@ void cmd_move_scratchpad(I3_CMD);
 void cmd_scratchpad_show(I3_CMD);
 
 /**
+ * Implementation of 'scratchpad show [--hide-if-visible] [on] output <name>'.
+ *
+ */
+void cmd_scratchpad_show_on_output(I3_CMD, const char* hide, const char* name);
+
+/**
  * Implementation of 'swap [container] [with] id|con_id|mark <arg>'.
  *
  */

--- a/include/scratchpad.h
+++ b/include/scratchpad.h
@@ -32,6 +32,17 @@ void scratchpad_move(Con *con);
 bool scratchpad_show(Con *con);
 
 /**
+ * Either shows the top-most scratchpad window (con == NULL) or the specified
+ * con (if it is scratchpad window) on the specified output.
+ *
+ * When called with con == NULL and either the scratchpad window is currently
+ * focused (or hide_if_visible is true and it is visible on the target output)
+ * it will hide the window again.
+ */
+bool scratchpad_show_on_output(Con *con, Output *current_output, Output *output,
+                               bool hide_if_visible);
+
+/**
  * When starting i3 initially (and after each change to the connected outputs),
  * this function fixes the resolution of the __i3 pseudo-output. When that
  * resolution is not set to a function which shares a common divisor with every

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -421,9 +421,25 @@ state NOP:
   end
       -> call cmd_nop(NULL)
 
+# scratchpad show
+# scratchpad show [on] [--hide-if-visible] output <name>
 state SCRATCHPAD:
   'show'
+      -> SCRATCHPAD_SHOW
+
+state SCRATCHPAD_SHOW:
+  end
       -> call cmd_scratchpad_show()
+  'on'
+      ->
+  hide = '--hide-if-visible'
+      ->
+  'output'
+      -> SCRATCHPAD_SHOW_OUTPUT
+
+state SCRATCHPAD_SHOW_OUTPUT:
+  name = string
+      -> call cmd_scratchpad_show_on_output($hide, $name)
 
 # swap [container] [with] id <window>
 # swap [container] [with] con_id <con_id>

--- a/src/commands.c
+++ b/src/commands.c
@@ -1853,7 +1853,7 @@ void cmd_scratchpad_show(I3_CMD) {
  * Implementation of 'scratchpad show [on] [--hide-if-visible] output <name>'.
  *
  */
-void cmd_scratchpad_show_on_output(I3_CMD, const char* hide, const char* name) {
+void cmd_scratchpad_show_on_output(I3_CMD, const char *hide, const char *name) {
     owindow *current;
     bool result = false;
     char *primary_name;
@@ -1864,7 +1864,7 @@ void cmd_scratchpad_show_on_output(I3_CMD, const char* hide, const char* name) {
     /* prevent user from showing to internal output or workspace */
     if (strncmp(name, "__", strlen("__")) == 0) {
         LOG("You cannot show the scratchpad on an i3-internal output (\"%s\").\n",
-                name);
+            name);
         ysuccess(false);
         return;
     }
@@ -1881,15 +1881,15 @@ void cmd_scratchpad_show_on_output(I3_CMD, const char* hide, const char* name) {
         output = get_output_from_string(current_output, name);
         if (!output) {
             ELOG("Could not get output from string \"%s\" for con %p.\n",
-                    name, focused);
+                 name, focused);
             ysuccess(false);
             return;
         }
         /* make sure the target output isn't anything internal */
         if (!strncmp((primary_name = output_primary_name(output)),
-                    "__", strlen("__"))) {
+                     "__", strlen("__"))) {
             ELOG("You can not show scratchpad on internal input (\"%s\").\n",
-                    primary_name);
+                 primary_name);
             ysuccess(false);
             return;
         }
@@ -1908,20 +1908,20 @@ void cmd_scratchpad_show_on_output(I3_CMD, const char* hide, const char* name) {
             output = get_output_from_string(current_output, name);
             if (!output) {
                 ELOG("Could not get output from string \"%s\" for con %p.\n",
-                        name, current->con);
+                     name, current->con);
                 result |= false;
                 continue;
             }
             /* make sure the target output isn't anything internal */
             if (!strncmp((primary_name = output_primary_name(output)),
-                        "__", strlen("__"))) {
+                         "__", strlen("__"))) {
                 ELOG("You can not show scratchpad on internal input (\"%s\").\n",
-                        primary_name);
+                     primary_name);
                 result |= false;
                 continue;
             }
             result |= scratchpad_show_on_output(current->con, current_output,
-                    output, hide_if_visible);
+                                                output, hide_if_visible);
         }
     }
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -1854,11 +1854,12 @@ void cmd_scratchpad_show(I3_CMD) {
  *
  */
 void cmd_scratchpad_show_on_output(I3_CMD, const char* hide, const char* name) {
-    DLOG("should show scartchpad on output %s (hide? %s)\n", name, hide);
     owindow *current;
     bool result = false;
     char *primary_name;
     bool hide_if_visible = (hide != NULL);
+
+    DLOG("should show scratchpad on output %s (hide? %s)\n", name, hide);
 
     /* prevent user from showing to internal output or workspace */
     if (strncmp(name, "__", strlen("__")) == 0) {
@@ -1873,14 +1874,14 @@ void cmd_scratchpad_show_on_output(I3_CMD, const char* hide, const char* name) {
     if (match_is_empty(current_match)) {
         current_output = get_output_for_con(focused);
         if (!current_output) {
-            ELOG("Could not find an output for matching con %p.\n", current->con);
+            ELOG("Could not find an output for matching con %p.\n", focused);
             ysuccess(false);
             return;
         }
         output = get_output_from_string(current_output, name);
         if (!output) {
             ELOG("Could not get output from string \"%s\" for con %p.\n",
-                    name, current->con);
+                    name, focused);
             ysuccess(false);
             return;
         }

--- a/src/scratchpad.c
+++ b/src/scratchpad.c
@@ -219,7 +219,7 @@ bool scratchpad_show(Con *con) {
  * it will hide the window again.
  */
 bool scratchpad_show_on_output(Con *con, Output *current_output, Output *output,
-        bool hide_if_visible) {
+                               bool hide_if_visible) {
     DLOG("should show scratchpad window %p on output %p\n", con, output);
     Con *__i3_scratch = workspace_get("__i3_scratch", NULL);
     Con *floating, *output_con, *walk_con, *ws;

--- a/testcases/t/501-scratchpad.t
+++ b/testcases/t/501-scratchpad.t
@@ -108,4 +108,101 @@ $second = fresh_workspace(output => 0);
 
 verify_scratchpad_switch($first, $second);
 
+################################################################################
+# Test 'scratchpad show [on] output <name>'
+################################################################################
+
+sub is_num_floating_children {
+    my ($ws, $num, $msg) = @_;
+    is(scalar @{get_ws($ws)->{floating_nodes}}, $num, $msg);
+}
+
+sub verify_show_on_output {
+    my ($outa, $outb) = @_;
+
+    my $out_a = "fake-$outa";
+    my $out_b = "fake-$outb";
+
+    # open window in first workspace
+    my $first_ws = fresh_workspace(output => $outa);
+    cmd "workspace $first_ws";
+
+    my $sp_window = open_window(name=>'Scratchpad');
+    my $sp_con = get_focused($first_ws);
+
+    is_num_children($first_ws, 1, 'scratchpad window created');
+
+    # test moving to scratchpad works
+    cmd "move scratchpad";
+
+    is_num_children($first_ws, 0, 'window moved to scratchpad');
+
+    # test that 'show'ing it from the same workspace works fine
+    cmd "scratchpad show on output $out_a";
+
+    is(focused_ws, $first_ws, 'workspace at output a is focused');
+    is(get_focused($first_ws), $sp_con, 'scratchpad is focused');
+
+    # check that executing the command with the scratchpad window focused
+    # hides the window
+    cmd "scratchpad show on output $out_a";
+
+    is_num_children($first_ws, 0, 'no node on first workspace');
+    is_num_floating_children($first_ws, 0, 'no floating node on workspace');
+
+    # focus workspace on output b
+    my $second_ws = fresh_workspace(output => $outb);
+    cmd "workspace $second_ws";
+
+    is(focused_ws, $second_ws, 'second workspace is focused');
+
+    # check that showing scratchpad windows adds windows to workspace and
+    # focuses them
+    cmd "scratchpad show on output $out_a";
+
+    is(focused_ws, $first_ws, 'workspace at output a is focused');
+    is(get_focused($first_ws), $sp_con, 'scratchpad window focused');
+
+    # go back to second workspace and check that 'show'ing brings focus
+    # back to the window
+    cmd "workspace $second_ws";
+
+    is(focused_ws, $second_ws, 'second workspace is focused');
+
+    cmd "scratchpad show on output $out_a";
+
+    is(focused_ws, $first_ws, 'workspace at output a is focused');
+    is(get_focused($first_ws), $sp_con, 'scratchpad window focused');
+
+    # go to a new workspace on the same output and make sure 'show'ing
+    # the window moves it up to this workspace
+    my $third_ws = fresh_workspace(output => $outa);
+    cmd "workspace $third_ws";
+
+    is(focused_ws, $third_ws, 'third workspace is focused');
+
+    cmd "scratchpad show on output $out_a";
+
+    is(focused_ws, $third_ws, 'workspace three is focused');
+    is(get_focused($third_ws), $sp_con, 'scratchpad window focused');
+
+    # go back to second workspace and check that '--hide-if-visible'
+    # sends the window back to scratchpad
+    cmd "workspace $second_ws";
+
+    is(focused_ws, $second_ws, 'second workspace is focused');
+
+
+    cmd "scratchpad show --hide-if-visible on output $out_a";
+
+    is_num_floating_children($third_ws, 0, 'no floating child for third workspace');
+    is_num_children($third_ws, 0, 'no child for third workspace');
+}
+
+kill_all_windows;
+verify_show_on_output(0, 1);
+
+kill_all_windows;
+verify_show_on_output(1, 0);
+
 done_testing;


### PR DESCRIPTION
Added a variant of the `scratchpad show` command, `scratchpad show [--hide-if-visible] [on] output <name>` as a possible solution for #3162 .

From my comment on the issue:

> I agree that it doesn't make much sense to assign the scratchpad (workspace) to an input, so I propose a variant of `scratchpad show` is added: `scratchpad show [--hide-if-visible] [on] output <name>`. This would behave similarly to how `scratchpad show` behaves: (i) running it while focusing a scratchpad window on the target output ("<name>") hides the window; running it without focusing a scratchpad window brings up (on the target output) either (ii) an unfocused scratchpad window on the target output's active workspace or (in case there aren't any) (iii) an unfocused scratchpad window on any of the workspaces in the target output or (iv) an unfocused scratchpad window on any (non-internal) workspace or (v) brings up the highest window on the scratchpad workspace focus stack. This would make it so running `scratchpad show on output current` results (I believe) in the same behavior as running `scratchpad show`, but a user could bind a key to show their scratchpad on a specific monitor. 

and

> The idea behind `--hide-if-visible` is that it will hide not only hide the scratchpad window if it is focused (behavior i) but also hide the scratchpad window in the active workspace of the target output.

For more of the context, please check the issue.

I tried my best to mirror the styles I saw in source files, but please let me know if anything should be done differently.