### PR TITLE
If no trayoutput matches, take first

### DIFF
--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -794,7 +794,7 @@ static void handle_client_message(xcb_client_message_event_t *event) {
 
             /* If no tray_output has been specified, we fall back to the first
              * available output. */
-            if (output == NULL && TAILQ_EMPTY(&(config.tray_outputs))) {
+            if (output == NULL) {
                 SLIST_FOREACH(walk, outputs, slist) {
                     if (!walk->active)
                         continue;


### PR DESCRIPTION
When changing the screen, the tray was searching for a matching output.
But if no screen matched, it neglected the setting and didn't show
anything.

As the default, the i3bar shows a tray on the first matching output.
Its intention is to display a tray. So it should also show a tray, if
the monitors don't match.

Fixes #3317