### PR TITLE
docs/i3bar-protocol: fix typo

### DIFF
--- a/docs/i3bar-protocol
+++ b/docs/i3bar-protocol
@@ -107,7 +107,7 @@ stop_signal::
 	processing.
 	The default value (if none is specified) is SIGSTOP.
 cont_signal::
-	Specify to i3bar the signal (as an integer)to send to continue your
+	Specify to i3bar the signal (as an integer) to send to continue your
 	processing.
 	The default value (if none is specified) is SIGCONT.
 click_events::


### PR DESCRIPTION
Unrelated to this pull request... Does `i3lock` send signals to `i3bar` and/or `i3`? Thanks in advance.