### PR TITLE
Added libiconv to search libs for OpenBSD patch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,8 @@ AC_SEARCH_LIBS([ev_run], [ev], , [AC_MSG_FAILURE([cannot find the required ev_ru
 
 AC_SEARCH_LIBS([shm_open], [rt])
 
-AC_SEARCH_LIBS([iconv_open], [iconv], , [AC_MSG_FAILURE([cannot find the required iconv_open() function despite trying to link with -liconv])])
+AC_SEARCH_LIBS([iconv_open], [iconv], ,
+AC_SEARCH_LIBS([libiconv_open], [iconv], , [AC_MSG_FAILURE([cannot find the required iconv_open() function despite trying to link with -liconv])]))
 
 AX_PTHREAD
 


### PR DESCRIPTION
I created a PR for i3-gaps (https://github.com/Airblader/i3/pull/224) and was asked if I'd move this fix upstream.

Most of the details are in the comment(s) of the original PR. ^ In the OpenBSD port for i3, there is a configure patch (http://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/x11/i3/patches/patch-configure?rev=1.2&content-type=text/plain) to get i3 to build. I have only been able to test this on OpenBSD thus far, so am not certain if this change causes any other effects.