### PR TITLE
fix height offset calculation in pango text drawing

### DIFF
--- a/libi3/font.c
+++ b/libi3/font.c
@@ -111,7 +111,7 @@ static void draw_text_pango(const char *text, size_t text_len,
     pango_layout_get_pixel_size(layout, NULL, &height);
     /* Center the piece of text vertically if its height is smaller than the
      * cached font height, and just let "high" symbols fall out otherwise. */
-    int yoffset = (height < savedFont->height ? 0.5 : 1) * (height - savedFont->height);
+    int yoffset = abs(height - savedFont->height) / 2;
     cairo_move_to(cr, x, y - yoffset);
     pango_cairo_show_layout(cr, layout);
 


### PR DESCRIPTION
* difference is zero: dividing by two does nothing (that's fine)
* difference is positive: halve the difference, subtract it from the height to center it
* difference is negative: `abs` it, then do the same as above.

Works fine on my fresh laptop; dunno about older pango versions. I'm not exactly sure about what changed with things that are larger than given height.

Unless I'm mistaken, this shouldn't affect anything where `height <= savedFont->height`. This just changes the previous case of subtracting the (positive) height difference when something was too tall (and thus shifting everything a decent amount above the bar canvas).

This handles it *well enough* for the case "text too tall". I'm not really sure if there's a "good" solution for this, since it's usually just one glyph that's messing up the height.

Fixes #3114