### PR TITLE
Set WM_STATE to normal when focusing a window

### DIFF
--- a/src/x.c
+++ b/src/x.c
@@ -1168,6 +1168,13 @@ void x_push_changes(Con *con) {
 
                 change_ewmh_focus((con_has_managed_window(focused) ? focused->window->id : XCB_WINDOW_NONE), last_focused);
 
+                /* Some applications request iconic state when they lose focus, revert them to normal when they regain focus. */
+                if (focused->window != NULL) {
+                    long data[] = {XCB_ICCCM_WM_STATE_NORMAL, XCB_NONE};
+                    xcb_change_property(conn, XCB_PROP_MODE_REPLACE, focused->window->id,
+                                        A_WM_STATE, A_WM_STATE, 32, 2, data);
+                }
+
                 if (to_focus != XCB_NONE && to_focus != last_focused && focused->window != NULL && is_con_attached(focused))
                     ipc_send_window_event("focus", focused);
             }


### PR DESCRIPTION
Some applications request iconic state when they lose focus. One notable example is games running in Wine that use the Windows exclusive full-screen API.
While this is perfectly sound behavior on a floating window manager, we do not support the concept of iconized windows, so not only do we not handle this case, but there is also no sane way to escape that state. This leaves the aforementioned games in a paused state, with the contents reduced to a tiny corner of the window, and with no audio playing. The workaround, up until now, was to enable Wine's virtual desktop, but that is pretty inconvenient to use.
To remedy this, reset WM_STATE to a normal state when the window is focused. This allows the application to do whatever it wants to do while it's not focused (pause the game, let the GPU idle, etc), and avoids breaking it with a simple workspace switch.