### PR TITLE
Support startup-notification in i3-nagbar & i3-config-wizard

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -357,10 +357,12 @@ i3_msg_i3_msg_SOURCES = \
 
 i3_nagbar_i3_nagbar_CFLAGS = \
 	$(AM_CFLAGS) \
+	$(LIBSN_CFLAGS) \
 	$(libi3_CFLAGS)
 
 i3_nagbar_i3_nagbar_LDADD = \
 	$(libi3_LIBS) \
+	$(LIBSN_LIBS) \
 	$(XCB_UTIL_CURSOR_LIBS)
 
 i3_nagbar_i3_nagbar_SOURCES = \
@@ -414,10 +416,12 @@ i3bar_i3bar_SOURCES = \
 i3_config_wizard_i3_config_wizard_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(libi3_CFLAGS) \
+	$(LIBSN_CFLAGS) \
 	$(XKBCOMMON_CFLAGS)
 
 i3_config_wizard_i3_config_wizard_LDADD = \
 	$(libi3_LIBS) \
+	$(LIBSN_LIBS) \
 	$(XCB_UTIL_KEYSYMS_LIBS) \
 	$(XKBCOMMON_LIBS)
 

--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -293,6 +293,7 @@ static char *next_state(const cmdp_token *token) {
         }
         sasprintf(&res, "bindsym %s%s%s %s%s\n", (modifiers == NULL ? "" : modrep), (modifiers == NULL ? "" : "+"), str, (release == NULL ? "" : release), get_string("command"));
         clear_stack();
+        free(modrep);
         return res;
     }
 

--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -48,6 +48,9 @@
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-x11.h>
 
+#define SN_API_NOT_YET_FROZEN 1
+#include <libsn/sn-launchee.h>
+
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
 #include <X11/XKBlib.h>
@@ -847,6 +850,10 @@ int main(int argc, char *argv[]) {
 #include "atoms.xmacro"
 #undef xmacro
 
+    /* Init startup notification. */
+    SnDisplay *sndisplay = sn_xcb_display_new(conn, NULL, NULL);
+    SnLauncheeContext *sncontext = sn_launchee_context_new_from_environment(sndisplay, screen);
+
     root_screen = xcb_aux_get_screen(conn, screen);
     root = root_screen->root;
 
@@ -879,6 +886,7 @@ int main(int argc, char *argv[]) {
             0, /* back pixel: black */
             XCB_EVENT_MASK_EXPOSURE |
                 XCB_EVENT_MASK_BUTTON_PRESS});
+    sn_launchee_context_setup_window(sncontext, win);
 
     /* Map the window (make it visible) */
     xcb_map_window(conn, win);
@@ -939,6 +947,11 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Could not grab keyboard, status = %d\n", reply->status);
         exit(-1);
     }
+
+    /* Startup complete. */
+    sn_launchee_context_complete(sncontext);
+    sn_launchee_context_unref(sncontext);
+    sn_display_unref(sndisplay);
 
     xcb_flush(conn);
 


### PR DESCRIPTION
The default i3 config uses the `exec` command without `--no-startup-id` to launch:
1. i3-nagbar https://github.com/i3/i3/blob/4cba9fcbdab1487459014dbf8882f5f34e61435e/etc/config#L150
2. i3-config-wizard https://github.com/i3/i3/blob/4cba9fcbdab1487459014dbf8882f5f34e61435e/etc/config#L194

A user that opens i3 for the first time will be greeted with a "loading" cursor because of i3-config-wizard.