### PR TITLE
Fix bugs in enabling & disabling randr outputs

### DIFF
--- a/include/randr.h
+++ b/include/randr.h
@@ -48,7 +48,7 @@ void output_init_con(Output *output);
  * • Create the first unused workspace.
  *
  */
-void init_ws_for_output(Output *output, Con *content);
+void init_ws_for_output(Output *output);
 
 /**
  * Initializes the specified output, assigning the specified workspace to it.

--- a/src/fake_outputs.c
+++ b/src/fake_outputs.c
@@ -74,7 +74,7 @@ void fake_outputs_init(const char *output_spec) {
             else
                 TAILQ_INSERT_TAIL(&outputs, new_output, outputs);
             output_init_con(new_output);
-            init_ws_for_output(new_output, output_get_content(new_output->con));
+            init_ws_for_output(new_output);
             num_screens++;
         }
         new_output->primary = primary;

--- a/src/randr.c
+++ b/src/randr.c
@@ -942,13 +942,8 @@ void randr_disable_output(Output *output) {
 
     if (output->con != NULL) {
         /* We need to move the workspaces from the disappearing output to the first output */
-        /* 1: Get the con to focus next, if the disappearing ws is focused */
-        Con *next = NULL;
-        if (TAILQ_FIRST(&(croot->focus_head)) == output->con) {
-            DLOG("This output (%p) was focused! Getting next\n", output->con);
-            next = focused;
-            DLOG("next = %p\n", next);
-        }
+        /* 1: Get the con to focus next */
+        Con *next = focused;
 
         /* 2: iterate through workspaces and re-assign them, fixing the coordinates
          * of floating containers as we go */
@@ -971,15 +966,12 @@ void randr_disable_output(Output *output) {
             TAILQ_FOREACH(floating_con, &(current->floating_head), floating_windows) {
                 floating_fix_coordinates(floating_con, &(output->con->rect), &(first->con->rect));
             }
-            DLOG("Done, next\n");
         }
-        DLOG("re-attached all workspaces\n");
 
-        if (next) {
-            DLOG("now focusing next = %p\n", next);
-            con_activate(next);
-            workspace_show(con_get_workspace(next));
-        }
+        /* Restore focus after con_detach / con_attach */
+        DLOG("now focusing next = %p\n", next);
+        con_focus(next);
+        workspace_show(con_get_workspace(next));
 
         /* 3: move the dock clients to the first output */
         Con *child;

--- a/src/randr.c
+++ b/src/randr.c
@@ -420,7 +420,8 @@ void output_init_con(Output *output) {
  * • Create the first unused workspace.
  *
  */
-void init_ws_for_output(Output *output, Con *content) {
+void init_ws_for_output(Output *output) {
+    Con *content = output_get_content(output->con);
     Con *previous_focus = con_get_workspace(focused);
 
     /* go through all assignments and move the existing workspaces to this output */
@@ -908,7 +909,7 @@ void randr_query_outputs(void) {
         if (!TAILQ_EMPTY(&(content->nodes_head)))
             continue;
         DLOG("Should add ws for output %s\n", output_primary_name(output));
-        init_ws_for_output(output, content);
+        init_ws_for_output(output);
     }
 
     /* Focus the primary screen, if possible */
@@ -1013,7 +1014,7 @@ void randr_disable_output(Output *output) {
 static void fallback_to_root_output(void) {
     root_output->active = true;
     output_init_con(root_output);
-    init_ws_for_output(root_output, output_get_content(root_output->con));
+    init_ws_for_output(root_output);
 }
 
 /*

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -966,7 +966,11 @@ bool workspace_move_to_output(Con *ws, Output *output) {
     LOG("got output %p with content %p\n", output, content);
 
     Con *previously_visible_ws = TAILQ_FIRST(&(content->focus_head));
-    LOG("Previously visible workspace = %p / %s\n", previously_visible_ws, previously_visible_ws->name);
+    if (previously_visible_ws) {
+        DLOG("Previously visible workspace = %p / %s\n", previously_visible_ws, previously_visible_ws->name);
+    } else {
+        DLOG("No previously visible workspace on output.\n");
+    }
 
     bool workspace_was_visible = workspace_is_visible(ws);
     if (con_num_children(ws->parent) == 1) {
@@ -1022,6 +1026,10 @@ bool workspace_move_to_output(Con *ws, Output *output) {
     if (workspace_was_visible) {
         /* Focus the moved workspace on the destination output. */
         workspace_show(ws);
+    }
+
+    if (!previously_visible_ws) {
+        return true;
     }
 
     /* NB: We cannot simply work with previously_visible_ws since it might

--- a/src/xinerama.c
+++ b/src/xinerama.c
@@ -71,7 +71,7 @@ static void query_screens(xcb_connection_t *conn) {
             else
                 TAILQ_INSERT_TAIL(&outputs, s, outputs);
             output_init_con(s);
-            init_ws_for_output(s, output_get_content(s->con));
+            init_ws_for_output(s);
             num_screens++;
         }
 
@@ -98,7 +98,7 @@ static void use_root_output(xcb_connection_t *conn) {
     s->active = true;
     TAILQ_INSERT_TAIL(&outputs, s, outputs);
     output_init_con(s);
-    init_ws_for_output(s, output_get_content(s->con));
+    init_ws_for_output(s);
 }
 
 /*


### PR DESCRIPTION
Since this is not testable (but bug-prone) I'd like to run it on my machine for a while.

Another bug: no workspace assignments, empty ws1 on Screen1, non-empty, focused ws2 on Screen2. Disable Screen2 => ws1 does not get deleted but ws2 is focused on Screen1.