### PR TITLE
Respect max size from WM_NORMAL_HINTS

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -477,6 +477,10 @@ struct Window {
     int min_width;
     int min_height;
 
+    /* Maximum size specified for the window. */
+    int max_width;
+    int max_height;
+
     /* aspect ratio from WM_NORMAL_HINTS (MPlayer uses this for example) */
     double aspect_ratio;
 };

--- a/src/floating.c
+++ b/src/floating.c
@@ -96,6 +96,18 @@ void floating_check_size(Con *floating_con) {
             floating_con->rect.height += border_rect.height;
         }
 
+        if (focused_con->window->max_width) {
+            floating_con->rect.width -= border_rect.width;
+            floating_con->rect.width = min(floating_con->rect.width, focused_con->window->max_width);
+            floating_con->rect.width += border_rect.width;
+        }
+
+        if (focused_con->window->max_height) {
+            floating_con->rect.height -= border_rect.height;
+            floating_con->rect.height = min(floating_con->rect.height, focused_con->window->max_height);
+            floating_con->rect.height += border_rect.height;
+        }
+
         if (focused_con->window->height_increment &&
             floating_con->rect.height >= focused_con->window->base_height + border_rect.height) {
             floating_con->rect.height -= focused_con->window->base_height + border_rect.height;

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -981,9 +981,18 @@ static bool handle_normal_hints(void *data, xcb_connection_t *conn, uint8_t stat
         con->window->min_height = size_hints.min_height;
     }
 
+    if ((size_hints.flags & XCB_ICCCM_SIZE_HINT_P_MAX_SIZE)) {
+        DLOG("Maximum size: %d (width) x %d (height)\n", size_hints.max_width, size_hints.max_height);
+
+        con->window->max_width = size_hints.max_width;
+        con->window->max_height = size_hints.max_height;
+    }
+
     if (con_is_floating(con)) {
         win_width = MAX(win_width, con->window->min_width);
         win_height = MAX(win_height, con->window->min_height);
+        win_width = MIN(win_width, con->window->max_width);
+        win_height = MIN(win_height, con->window->max_height);
     }
 
     bool changed = false;

--- a/src/manage.c
+++ b/src/manage.c
@@ -520,6 +520,12 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
         nc->window->min_height = wm_size_hints.min_height;
     }
 
+    if (wm_size_hints.flags & XCB_ICCCM_SIZE_HINT_P_MAX_SIZE) {
+        DLOG("Window specifies maximum size %d x %d\n", wm_size_hints.max_width, wm_size_hints.max_height);
+        nc->window->max_width = wm_size_hints.max_width;
+        nc->window->max_height = wm_size_hints.max_height;
+    }
+
     /* Store the requested geometry. The width/height gets raised to at least
      * 75x50 when entering floating mode, which is the minimum size for a
      * window to be useful (smaller windows are usually overlays/toolbars/…

--- a/testcases/t/189-floating-constraints.t
+++ b/testcases/t/189-floating-constraints.t
@@ -21,6 +21,7 @@
 #
 
 use i3test i3_autostart => 0;
+use X11::XCB qw/PROP_MODE_REPLACE/;
 
 ################################################################################
 # 1: check floating_minimum_size (with non-default limits)
@@ -215,6 +216,84 @@ sync_with_i3;
 $rect = $window->rect;
 is($rect->{width}, 80, 'width did not exceed minimum width');
 is($rect->{height}, 70, 'height did not exceed minimum height');
+
+exit_gracefully($pid);
+
+################################################################################
+# 8: check minimum_size and maximum_size set by WM_NORMAL_HINTS
+################################################################################
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+EOT
+
+my $min_width = 150;
+my $min_height = 100;
+my $max_width = 250;
+my $max_height = 200;
+
+my sub open_with_max_size {
+    # The type of the WM_NORMAL_HINTS property is WM_SIZE_HINTS
+    # https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.2.3
+    my $XCB_ICCCM_SIZE_HINT_P_MIN_SIZE = 0x32;
+    my $XCB_ICCCM_SIZE_HINT_P_MAX_SIZE = 0x16;
+
+    my $flags = $XCB_ICCCM_SIZE_HINT_P_MIN_SIZE | $XCB_ICCCM_SIZE_HINT_P_MAX_SIZE;
+
+    my $pad = 0x00;
+
+    my $window = open_window(
+        before_map => sub {
+            my ($window) = @_;
+
+            my $atomname = $x->atom(name => 'WM_NORMAL_HINTS');
+            my $atomtype = $x->atom(name => 'WM_SIZE_HINTS');
+            $x->change_property(
+                PROP_MODE_REPLACE,
+                $window->id,
+                $atomname->id,
+                $atomtype->id,
+                32,
+                13,
+                pack('C5N8', $flags, $pad, $pad, $pad, $pad, 0, 0, 0, $min_width, $min_height, $max_width, $max_height),
+            );
+        },
+    );
+
+    return $window;
+}
+
+my sub check_minsize {
+    is($window->rect->{width}, $min_width, 'width = min_width');
+    is($window->rect->{height}, $min_height, 'height = min_height');
+}
+
+my sub check_maxsize {
+    is($window->rect->{width}, $max_width, 'width = max_width');
+    is($window->rect->{height}, $max_height, 'height = max_height');
+}
+
+$pid = launch_with_config($config);
+
+$window = open_with_max_size;
+cmd 'floating enable';
+cmd 'border none';
+sync_with_i3;
+
+cmd "resize set $min_width px $min_height px";
+check_minsize;
+
+# Try to resize below minimum width
+cmd 'resize set ' . ($min_width - 10) . ' px ' . ($min_height - 50) . ' px';
+check_minsize;
+
+cmd "resize set $max_width px $max_height px";
+check_maxsize;
+
+# Try to resize above maximum width
+cmd 'resize set ' . ($max_width + 150) . ' px ' . ($max_height + 500) . ' px';
+check_maxsize;
 
 exit_gracefully($pid);
 


### PR DESCRIPTION
This change will only affect windows that would already qualify as "dialog"
windows.

Some programs make optimizations based on the assumption that the window size
won't change, or don't properly handle resizes -- for example, quake freezes if
the window gets resized too often. Many OpenGL/Vulkan applications make similar
assumptions, since resizing means synchronizing, then recreating the swap chain
and the framebuffer.

This is my first contribution to i3 -- although I've used it since installing
Arch -- so if there is a better way or this is just a bad idea, please let me
know and I'll make the changes/drop it.