### PR TITLE
add specific GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,8 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
 <!--
 PLEASE HELP US PROCESS GITHUB ISSUES FASTER BY PROVIDING THE FOLLOWING INFORMATION.
 -->
@@ -5,7 +10,7 @@ PLEASE HELP US PROCESS GITHUB ISSUES FASTER BY PROVIDING THE FOLLOWING INFORMATI
 ## I'm submitting a…
 <!-- Please check one of the following options with "x" -->
 <pre>
-[ ] Bug
+[x] Bug
 [ ] Feature Request
 [ ] Documentation Request
 [ ] Other (Please describe in detail)
@@ -25,9 +30,7 @@ e.g., »The window left next to the current window should be focused.«
 
 ## Reproduction Instructions
 <!--
-For bug reports, please provide detailed instructions on how the bug can be reproduced.
-For feature requests you can remove this section.
-
+Please provide detailed instructions on how the bug can be reproduced.
 E.g., »Open three windows in a V[A H[B C]] layout on a new workspace«
 -->
 
@@ -42,7 +45,7 @@ i3 version:
 </pre>
 
 <!--
-For bug reports, please include your (complete) i3 config with which the issue occurs. You can either paste the file directly or provide a link to a service such as pastebin.
+Please include your (complete) i3 config with which the issue occurs. You can either paste the file directly or provide a link to a service such as pastebin.
 
 If you would like to help debugging the issue, please try to reduce the config such that it is as close to the default config as possible while still reproducing the issue. This can help us bisect the root cause.
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,3 +1,8 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
 <!--
 PLEASE HELP US PROCESS GITHUB ISSUES FASTER BY PROVIDING THE FOLLOWING INFORMATION.
 -->
@@ -6,7 +11,7 @@ PLEASE HELP US PROCESS GITHUB ISSUES FASTER BY PROVIDING THE FOLLOWING INFORMATI
 <!-- Please check one of the following options with "x" -->
 <pre>
 [ ] Bug
-[ ] Feature Request
+[x] Feature Request
 [ ] Documentation Request
 [ ] Other (Please describe in detail)
 </pre>
@@ -17,18 +22,10 @@ Describe the current behavior,
 e.g., »When pressing Alt+j (focus left), the window above the current window is focused.«
 -->
 
-## Expected Behavior
+## Desired Behavior
 <!--
 Describe the desired behavior you expect after mitigation of the issue,
 e.g., »The window left next to the current window should be focused.«
--->
-
-## Reproduction Instructions
-<!--
-For bug reports, please provide detailed instructions on how the bug can be reproduced.
-For feature requests you can remove this section.
-
-E.g., »Open three windows in a V[A H[B C]] layout on a new workspace«
 -->
 
 ## Environment
@@ -39,24 +36,6 @@ Note that we only support the latest major release and the current development v
 Output of `i3 --moreversion 2>&-`:
 <pre>
 i3 version: 
-</pre>
-
-<!--
-For bug reports, please include your (complete) i3 config with which the issue occurs. You can either paste the file directly or provide a link to a service such as pastebin.
-
-If you would like to help debugging the issue, please try to reduce the config such that it is as close to the default config as possible while still reproducing the issue. This can help us bisect the root cause.
--->
-<pre>
-</pre>
-
-<!--
-Providing a logfile can help us trace the root cause of an issue much quicker. You can learn how to generate the logfile here:
-https://i3wm.org/docs/debugging.html
-
-Providing the logfile is optional.
--->
-<pre>
-Logfile URL:
 </pre>
 
 <!--


### PR DESCRIPTION
I learnt about this from the GitHub blog:
https://blog.github.com/2018-05-02-issue-template-improvements/

Unfortunately, it seems like one cannot set a title in the template, otherwise we could do away with the first section of the template entirely.