### PR TITLE
commands: (rename) check workspace number

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1954,11 +1954,17 @@ void cmd_rename_workspace(I3_CMD, const char *old_name, const char *new_name) {
     }
 
     Con *check_dest = get_existing_workspace_by_name(new_name);
+    if (!check_dest) {
+        long new_num = ws_name_to_number(new_name);
+        if (new_num != -1) {
+            check_dest = get_existing_workspace_by_num(new_num);
+        }
+    }
 
     /* If check_dest == workspace, the user might be changing the case of the
      * workspace, or it might just be a no-op. */
     if (check_dest != NULL && check_dest != workspace) {
-        yerror("New workspace \"%s\" already exists", new_name);
+        yerror("Workspace %ld named \"%s\" already exists", check_dest->num, check_dest->name);
         return;
     }
 


### PR DESCRIPTION
Assuming two workspaces 1 and 2, renaming the workspace 2 to "1: foo"
will reassign the number 1 already in use to the new workspace and break
the "workspace next_on_output" command.

This patch fixes this behavior by checking if a different workspace with
the same number does not already exist when renaming a given workspace.