### PR TITLE
Fixes for undefined behaviour on signed shift

### DIFF
--- a/i3bar/src/ipc.c
+++ b/i3bar/src/ipc.c
@@ -278,8 +278,8 @@ void got_data(struct ev_loop *loop, ev_io *watcher, int events) {
     buffer[size] = '\0';
 
     /* And call the callback (indexed by the type) */
-    if (type & (1 << 31)) {
-        type ^= 1 << 31;
+    if (type & (1UL << 31)) {
+        type ^= 1UL << 31;
         event_handlers[type](buffer);
     } else {
         if (reply_handlers[type])

--- a/include/i3/ipc.h
+++ b/include/i3/ipc.h
@@ -87,7 +87,7 @@ typedef struct i3_ipc_header {
  * Events from i3 to clients. Events have the first bit set high.
  *
  */
-#define I3_IPC_EVENT_MASK (1 << 31)
+#define I3_IPC_EVENT_MASK (1UL << 31)
 
 /* The workspace event will be triggered upon changes in the workspace list */
 #define I3_IPC_EVENT_WORKSPACE (I3_IPC_EVENT_MASK | 0)

--- a/libi3/get_colorpixel.c
+++ b/libi3/get_colorpixel.c
@@ -43,7 +43,7 @@ uint32_t get_colorpixel(const char *hex) {
 
     /* Shortcut: if our screen is true color, no need to do a roundtrip to X11 */
     if (root_screen == NULL || root_screen->root_depth == 24 || root_screen->root_depth == 32) {
-        return (0xFF << 24) | (r << 16 | g << 8 | b);
+        return (0xFFUL << 24) | (r << 16 | g << 8 | b);
     }
 
     /* Lookup this colorpixel in the cache */


### PR DESCRIPTION
Change literal 1 to unsigned to allow safe bitshift of 31.

Caught by cppcheck.