### PR TITLE
debian/control: remove dependency on x11-utils

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,7 +40,7 @@ Description: metapackage (i3 window manager, screen locker, menu, statusbar)
 
 Package: i3-wm
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}, x11-utils
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${perl:Depends}
 Provides: x-window-manager
 Recommends: xfonts-base, fonts-dejavu-core, libanyevent-i3-perl (>= 0.12), libjson-xs-perl, rxvt-unicode | x-terminal-emulator
 Description: improved dynamic tiling window manager


### PR DESCRIPTION
This was a introduce in commit a61e34d2771fffdf2d94ee69d887585087c76b98 in 2009,
and we haven’t used xmessage in any way in a long time.

fixes https://bugs.debian.org/910997