### PR TITLE
travis: fix mk-build-deps call by providing changelog file

### DIFF
--- a/travis/travis-base.Dockerfile
+++ b/travis/travis-base.Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && \
 
 # Install i3 build dependencies.
 COPY debian/control /usr/src/i3-debian-packaging/control
+COPY debian/changelog /usr/src/i3-debian-packaging/changelog
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive mk-build-deps --install --remove --tool 'apt-get --no-install-recommends -y' /usr/src/i3-debian-packaging/control && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
mk-build-deps started using the changelog file to get the version number, but a
bug prevents it from falling back correctly to 1.0 if no changelog is
present. This has been fixed upstream in
https://salsa.debian.org/debian/devscripts/commit/4b15abd4f0cfe4accbf28f24546891867344a73c,
but we can just ship the changelog file until that fix lands.