### PR TITLE
Add "modifiers" to events sent by i3bar

### DIFF
--- a/docs/i3bar-protocol
+++ b/docs/i3bar-protocol
@@ -243,6 +243,9 @@ relative_x, relative_y::
     of the block
 width, height::
     Width and height (in px) of the block
+modifiers::
+    An array of the modifiers active when the click occurred. The order in which
+    modifiers are listed is not guaranteed.
 
 *Example*:
 ------------------------------------------
@@ -250,6 +253,7 @@ width, height::
  "name": "ethernet",
  "instance": "eth0",
  "button": 1,
+ "modifiers": ["Shift", "Mod1"],
  "x": 1320,
  "y": 1400,
  "relative_x": 12,

--- a/i3bar/include/child.h
+++ b/i3bar/include/child.h
@@ -85,4 +85,4 @@ bool child_want_click_events(void);
  * Generates a click event, if enabled.
  *
  */
-void send_block_clicked(int button, const char *name, const char *instance, int x, int y, int x_rel, int y_rel, int width, int height);
+void send_block_clicked(int button, const char *name, const char *instance, int x, int y, int x_rel, int y_rel, int width, int height, int mods);

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -8,6 +8,7 @@
  *
  */
 #include "common.h"
+#include "yajl_utils.h"
 
 #include <stdlib.h>
 #include <unistd.h>
@@ -26,6 +27,8 @@
 #include <yajl/yajl_version.h>
 #include <yajl/yajl_gen.h>
 #include <paths.h>
+
+#include <xcb/xcb_keysyms.h>
 
 /* Global variables for child_*() */
 i3bar_child child;
@@ -588,15 +591,11 @@ static void child_click_events_initialize(void) {
     }
 }
 
-static void child_click_events_key(const char *key) {
-    yajl_gen_string(gen, (const unsigned char *)key, strlen(key));
-}
-
 /*
  * Generates a click event, if enabled.
  *
  */
-void send_block_clicked(int button, const char *name, const char *instance, int x, int y, int x_rel, int y_rel, int width, int height) {
+void send_block_clicked(int button, const char *name, const char *instance, int x, int y, int x_rel, int y_rel, int width, int height, int mods) {
     if (!child.click_events) {
         return;
     }
@@ -606,34 +605,52 @@ void send_block_clicked(int button, const char *name, const char *instance, int 
     yajl_gen_map_open(gen);
 
     if (name) {
-        child_click_events_key("name");
-        yajl_gen_string(gen, (const unsigned char *)name, strlen(name));
+        ystr("name");
+        ystr(name);
     }
 
     if (instance) {
-        child_click_events_key("instance");
-        yajl_gen_string(gen, (const unsigned char *)instance, strlen(instance));
+        ystr("instance");
+        ystr(instance);
     }
 
-    child_click_events_key("button");
+    ystr("button");
     yajl_gen_integer(gen, button);
 
-    child_click_events_key("x");
+    ystr("modifiers");
+    yajl_gen_array_open(gen);
+    if (mods & XCB_MOD_MASK_SHIFT)
+        ystr("Shift");
+    if (mods & XCB_MOD_MASK_CONTROL)
+        ystr("Control");
+    if (mods & XCB_MOD_MASK_1)
+        ystr("Mod1");
+    if (mods & XCB_MOD_MASK_2)
+        ystr("Mod2");
+    if (mods & XCB_MOD_MASK_3)
+        ystr("Mod3");
+    if (mods & XCB_MOD_MASK_4)
+        ystr("Mod4");
+    if (mods & XCB_MOD_MASK_5)
+        ystr("Mod5");
+    yajl_gen_array_close(gen);
+
+    ystr("x");
     yajl_gen_integer(gen, x);
 
-    child_click_events_key("y");
+    ystr("y");
     yajl_gen_integer(gen, y);
 
-    child_click_events_key("relative_x");
+    ystr("relative_x");
     yajl_gen_integer(gen, x_rel);
 
-    child_click_events_key("relative_y");
+    ystr("relative_y");
     yajl_gen_integer(gen, y_rel);
 
-    child_click_events_key("width");
+    ystr("width");
     yajl_gen_integer(gen, width);
 
-    child_click_events_key("height");
+    ystr("height");
     yajl_gen_integer(gen, height);
 
     yajl_gen_map_close(gen);

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -524,7 +524,8 @@ static void handle_button(xcb_button_press_event_t *event) {
                 const int relative_x = statusline_x - last_block_x;
                 if (relative_x >= 0 && (uint32_t)relative_x <= render->width) {
                     send_block_clicked(event->detail, block->name, block->instance,
-                                       event->root_x, event->root_y, relative_x, event->event_y, render->width, bar_height);
+                                       event->root_x, event->root_y, relative_x, event->event_y, render->width, bar_height,
+                                       event->state);
                     return;
                 }
 


### PR DESCRIPTION
The modifiers field is an array of modifier names, e.g. ["ctrl", "Mod3"].

Fixes #3461