### PR TITLE
Update userguide "Focus Parent": add the default

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -247,7 +247,7 @@ So, how can you open a new terminal window to the *right* of the current one?
 The solution is to use +focus parent+, which will focus the +Parent Container+ of
 the current +Container+. In default configuration, use +$mod+a+ to navigate one 
 +Container+ up the tree (you can repeat this multiple times until you get to the
-+Workspace Container+. In this case, you would focus the +Vertical Split Container+
++Workspace Container+). In this case, you would focus the +Vertical Split Container+
 which is *inside* the horizontally oriented workspace. Thus, now new windows will be
 opened to the right of the +Vertical Split Container+:
 

--- a/docs/userguide
+++ b/docs/userguide
@@ -245,9 +245,11 @@ you open a new terminal, it will open below the current one.
 
 So, how can you open a new terminal window to the *right* of the current one?
 The solution is to use +focus parent+, which will focus the +Parent Container+ of
-the current +Container+. In this case, you would focus the +Vertical Split
-Container+ which is *inside* the horizontally oriented workspace. Thus, now new
-windows will be opened to the right of the +Vertical Split Container+:
+the current +Container+. In default configuration, use +$mod+a+ to navigate one 
++Container+ up the tree (you can repeat this multiple times until you get to the
++Workspace Container+. In this case, you would focus the +Vertical Split Container+
+which is *inside* the horizontally oriented workspace. Thus, now new windows will be
+opened to the right of the +Vertical Split Container+:
 
 image::tree-shot3.png["shot3",title="Focus parent, then open new terminal"]
 


### PR DESCRIPTION
While reading the UserGuide, I had to refer to the TL;DR image on top to find the default keybind for "Focus Parent" since it's not mentioned in the text.
This pr fixes it.