### PR TITLE
Always center text vertically

### DIFF
--- a/libi3/font.c
+++ b/libi3/font.c
@@ -109,9 +109,8 @@ static void draw_text_pango(const char *text, size_t text_len,
     cairo_set_source_rgb(cr, pango_font_red, pango_font_green, pango_font_blue);
     pango_cairo_update_layout(cr, layout);
     pango_layout_get_pixel_size(layout, NULL, &height);
-    /* Center the piece of text vertically if its height is smaller than the
-     * cached font height, and just let "high" symbols fall out otherwise. */
-    int yoffset = abs(height - savedFont->height) / 2;
+    /* Center the piece of text vertically. */
+    int yoffset = (height - savedFont->height) / 2;
     cairo_move_to(cr, x, y - yoffset);
     pango_cairo_show_layout(cr, layout);
 


### PR DESCRIPTION
Tries to fix #3472 without messing up #3114.

I've been unable to reproduce the original issue, though, so I cannot verify that it remains reasonably fixed.