### PR TITLE
i3bar: Fix i3bar re-hidden by any modifier (#3474)

### DIFF
--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -1106,13 +1106,16 @@ void xcb_prep_cb(struct ev_loop *loop, ev_prepare *watcher, int revents) {
 
             xcb_xkb_state_notify_event_t *state = (xcb_xkb_state_notify_event_t *)event;
             const uint32_t mod = (config.modifier & 0xFFFF);
-            mod_pressed = (mod != 0 && (state->mods & mod) == mod);
-            if (state->xkbType == XCB_XKB_STATE_NOTIFY && config.modifier != XCB_NONE) {
-                if (mod_pressed) {
-                    activated_mode = false;
-                    unhide_bars();
-                } else if (!activated_mode) {
-                    hide_bars();
+            const bool new_mod_pressed = (mod != 0 && (state->mods & mod) == mod);
+            if (new_mod_pressed != mod_pressed) {
+                mod_pressed = new_mod_pressed;
+                if (state->xkbType == XCB_XKB_STATE_NOTIFY && config.modifier != XCB_NONE) {
+                    if (mod_pressed) {
+                        activated_mode = false;
+                        unhide_bars();
+                    } else if (!activated_mode) {
+                        hide_bars();
+                    }
                 }
             }
 


### PR DESCRIPTION
Here is one way to fix this #3474.
