### PR TITLE
Do not assume STDIN_FILENO is available for input from child

### DIFF
--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -35,6 +35,7 @@ i3bar_child child;
 
 /* stdin- and SIGCHLD-watchers */
 ev_io *stdin_io;
+int stdin_fd;
 ev_child *child_sig;
 
 /* JSON parser for stdin */
@@ -450,7 +451,7 @@ static void stdin_io_first_line_cb(struct ev_loop *loop, ev_io *watcher, int rev
     }
     free(buffer);
     ev_io_stop(main_loop, stdin_io);
-    ev_io_init(stdin_io, &stdin_io_cb, STDIN_FILENO, EV_READ);
+    ev_io_init(stdin_io, &stdin_io_cb, stdin_fd, EV_READ);
     ev_io_start(main_loop, stdin_io);
 }
 
@@ -562,17 +563,17 @@ void start_child(char *command) {
             close(pipe_in[1]);
             close(pipe_out[0]);
 
-            dup2(pipe_in[0], STDIN_FILENO);
+            stdin_fd = pipe_in[0];
             child_stdin = pipe_out[1];
 
             break;
     }
 
     /* We set O_NONBLOCK because blocking is evil in event-driven software */
-    fcntl(STDIN_FILENO, F_SETFL, O_NONBLOCK);
+    fcntl(stdin_fd, F_SETFL, O_NONBLOCK);
 
     stdin_io = smalloc(sizeof(ev_io));
-    ev_io_init(stdin_io, &stdin_io_first_line_cb, STDIN_FILENO, EV_READ);
+    ev_io_init(stdin_io, &stdin_io_first_line_cb, stdin_fd, EV_READ);
     ev_io_start(main_loop, stdin_io);
 
     /* We must cleanup, if the child unexpectedly terminates */


### PR DESCRIPTION
Fixes #3477 

Testcases all pass, although I did have to modify t/189-floating-constraints.t to change the "my sub" declarations to "sub" in order to get this test-case to pass (even without my changes).  Presumably my perl is too old (This is perl 5, version 16, subversion 3 (v5.16.3)).

Perhaps the variable name (stdin_fd) is ill-advised.  "input_from_child_fd" might be a clearer name.
