### PR TITLE
(WIP) Rework `tree_flatten`

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -16,6 +16,8 @@
 /** The beginning of the prototype for every cmd_ function. */
 #define I3_CMD Match *current_match, struct CommandResultIR *cmd_output
 
+void cmd_flatten_tree(I3_CMD);
+
 /**
  * Initializes the specified 'Match' data structure and the initial state of
  * commands.c for matching target windows of a command.

--- a/include/commands.h
+++ b/include/commands.h
@@ -242,6 +242,8 @@ void cmd_exit(I3_CMD);
  */
 void cmd_reload(I3_CMD);
 
+void cmd_remove_parent(I3_CMD);
+
 /**
  * Implementation of 'restart'.
  *

--- a/include/tree.h
+++ b/include/tree.h
@@ -90,7 +90,7 @@ bool tree_restore(const char *path, xcb_get_geometry_reply_t *geometry);
  * Removes the target node while shifting its children up to its parent.
  * Assumes: target->window == NULL
  */
-void tree_remove_node(Con* target);
+void tree_remove_node(Con *target);
 
 /**
  * tree_flatten() removes pairs of redundant split containers, e.g.:

--- a/include/tree.h
+++ b/include/tree.h
@@ -87,6 +87,12 @@ bool tree_close_internal(Con *con, kill_window_t kill_window, bool dont_kill_par
 bool tree_restore(const char *path, xcb_get_geometry_reply_t *geometry);
 
 /**
+ * Removes the target node while shifting its children up to its parent.
+ * Assumes: target->window == NULL
+ */
+void tree_remove_node(Con* target);
+
+/**
  * tree_flatten() removes pairs of redundant split containers, e.g.:
  *       [workspace, horizontal]
  *   [v-split]           [child3]

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -13,6 +13,7 @@ state INITIAL:
   # We have an end token here for all the commands which just call some
   # function without using an explicit 'end' token.
   end ->
+  'flatten' -> call cmd_flatten_tree()
   '[' -> call cmd_criteria_init(); CRITERIA
   'remove_parent' -> call cmd_remove_parent()
   'move' -> MOVE

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -14,6 +14,7 @@ state INITIAL:
   # function without using an explicit 'end' token.
   end ->
   '[' -> call cmd_criteria_init(); CRITERIA
+  'remove_parent' -> call cmd_remove_parent()
   'move' -> MOVE
   'exec' -> EXEC
   'exit' -> call cmd_exit()

--- a/src/commands.c
+++ b/src/commands.c
@@ -144,13 +144,13 @@ typedef TAILQ_HEAD(owindows_head, owindow) owindows_head;
 static owindows_head owindows;
 
 void cmd_remove_parent(I3_CMD) {
-  // TODO is this possible?
-  if (focused == NULL)
-    return;
-  if (focused->parent->type == CT_WORKSPACE)
-    return;
+    // TODO is this possible?
+    if (focused == NULL)
+        return;
+    if (focused->parent->type == CT_WORKSPACE)
+        return;
 
-  tree_remove_node(focused->parent);
+    tree_remove_node(focused->parent);
 }
 
 /*

--- a/src/commands.c
+++ b/src/commands.c
@@ -143,6 +143,16 @@ typedef TAILQ_HEAD(owindows_head, owindow) owindows_head;
 
 static owindows_head owindows;
 
+void cmd_remove_parent(I3_CMD) {
+  // TODO is this possible?
+  if (focused == NULL)
+    return;
+  if (focused->parent->type == CT_WORKSPACE)
+    return;
+
+  tree_remove_node(focused->parent);
+}
+
 /*
  * Initializes the specified 'Match' data structure and the initial state of
  * commands.c for matching target windows of a command.

--- a/src/commands.c
+++ b/src/commands.c
@@ -154,7 +154,7 @@ void cmd_remove_parent(I3_CMD) {
 }
 
 void cmd_flatten_tree(I3_CMD) {
-  tree_flatten(croot);
+    tree_flatten(croot);
 }
 
 /*

--- a/src/commands.c
+++ b/src/commands.c
@@ -153,6 +153,10 @@ void cmd_remove_parent(I3_CMD) {
   tree_remove_node(focused->parent);
 }
 
+void cmd_flatten_tree(I3_CMD) {
+  tree_flatten(croot);
+}
+
 /*
  * Initializes the specified 'Match' data structure and the initial state of
  * commands.c for matching target windows of a command.

--- a/src/con.c
+++ b/src/con.c
@@ -1811,6 +1811,7 @@ void con_set_layout(Con *con, layout_t layout) {
             DLOG("Creating new split container\n");
             /* 1: create a new split container */
             Con *new = con_new(NULL, NULL);
+            DLOG("Created container: %p\n", new);
             new->parent = con;
 
             /* 2: Set the requested layout on the split container and mark it as
@@ -1836,7 +1837,8 @@ void con_set_layout(Con *con, layout_t layout) {
             DLOG("Attaching new split to ws\n");
             con_attach(new, con, false);
 
-            tree_flatten(croot);
+            // whoops this could be called during tree_flatten
+            //tree_flatten(croot);
         }
         con_force_split_parents_redraw(con);
         return;

--- a/src/move.c
+++ b/src/move.c
@@ -236,7 +236,7 @@ static void move_to_output_directed(Con *con, direction_t direction) {
     /* force re-painting the indicators */
     FREE(con->deco_render_params);
 
-    tree_flatten(croot);
+    //tree_flatten(croot);
     ipc_send_window_event("move", con);
     ewmh_update_wm_desktop();
 }
@@ -384,7 +384,7 @@ end:
     /* force re-painting the indicators */
     FREE(con->deco_render_params);
 
-    tree_flatten(croot);
+    //tree_flatten(croot);
     ipc_send_window_event("move", con);
     ewmh_update_wm_desktop();
 }

--- a/src/tree.c
+++ b/src/tree.c
@@ -775,7 +775,7 @@ static bool is_headerless(Con *con) {
 /* because of con.c:con_set_layout we cant flatten a stacked/tabbed child of workspace 
  * NOTE: apparently splith/v are bad too, will not flatten workspace children (from tree_flatten)
  */
-void tree_flatten_ws(Con *fixed) {
+static void tree_flatten_ws(Con *fixed) {
     DLOG("Considering children of fixed = %p / %s\n", fixed, fixed->name);
 
     // TODO is this the good spot for this check?

--- a/src/tree.c
+++ b/src/tree.c
@@ -326,7 +326,7 @@ bool tree_close_internal(Con *con, kill_window_t kill_window, bool dont_kill_par
  *
  */
 static void tree_close_empty(Con *con) {
-  /* bool dont_kill_parent = false */
+    /* bool dont_kill_parent = false */
     Con *parent = con->parent;
 
     /* remove the urgency hint of the workspace (if set) */
@@ -714,22 +714,22 @@ void tree_next(char way, orientation_t orientation) {
 // TODO manage focus and size correctly
 // TODO could specialize this for to=from->parent
 static void tree_transfer_children(Con *from, Con *to) {
-  Con *curr, *next;
-  curr = TAILQ_FIRST(&(from->nodes_head));
-  while (curr != NULL) {
-    next = TAILQ_NEXT(curr, nodes);
+    Con *curr, *next;
+    curr = TAILQ_FIRST(&(from->nodes_head));
+    while (curr != NULL) {
+        next = TAILQ_NEXT(curr, nodes);
 
-    DLOG("Transferring %p / %s from %p / %s to %p / %s\n",
-         curr, curr->name,
-         curr->parent, curr->parent->name,
-         to, to->name);
+        DLOG("Transferring %p / %s from %p / %s to %p / %s\n",
+             curr, curr->name,
+             curr->parent, curr->parent->name,
+             to, to->name);
 
-    con_detach(curr);
-    // TODO ignore_focus - false or true?
-    con_attach(curr, to, false);
+        con_detach(curr);
+        // TODO ignore_focus - false or true?
+        con_attach(curr, to, false);
 
-    curr = next;
-  }
+        curr = next;
+    }
 }
 
 /* Remove a node while moving its children to its parent
@@ -739,10 +739,10 @@ static void tree_transfer_children(Con *from, Con *to) {
 // (S[C1 S[C2] C3] -> S[C1 C2 C3])
 // TODO it shouldnt change sizes when possible
 void tree_remove_node(Con *target) {
-  //collapse_chain(target->parent, target);
-  tree_transfer_children(target, target->parent);
+    //collapse_chain(target->parent, target);
+    tree_transfer_children(target, target->parent);
 
-  tree_close_empty(target);
+    tree_close_empty(target);
 }
 
 /*


### PR DESCRIPTION
Complete rework of `tree_flatten`. Also includes code for https://github.com/i3/i3/issues/3500 because they share common functions - I'll remove appropriate parts if we don't want it.

## Principles
A container is redundant if at the same time:
1. It's not focused
2. None of its children is focused (optional?)
3. Its layout is split horizontal/vertical
4. Either:
    - its layout is the same as its parent
    - it has only one child

I'm currently having problems when the parent is a workspace because sometimes there is a container being implicitly created when you change the layout of a workspace and I would try to flatten it ending up in an endless loop. So I'm not flattening workspaces' children until I figure out how exactly that works.

### Reasoning for the rules
1. If a container is focused the user might want to perform some action on it.
2. Similar to (1.) but I'm not sure what's being focused when we create a new container so it might be not needed or needed only in certain cases
3. Tabbed/stack containers always are possibly desired by the user to label and structurize things
4. Assuming (3.) it just seems right

## State of the implementation
Seems to transform the tree correctly but messes up the order of containers and their sizes. I temporarily removed regular calls to tree_flatten on certain events (because they were in functions that I currently use in `tree_flatten` and ended up in endless loops) and made a binding to call it on-demand for testing.

TODO:
- scale container scales (uh, their percentage size) so that they don't actually change in absolute size
- keep the order of containers (is this the focus list?)
- decide when to call `tree_flatten`

## Alternative approach
I'm considering whether it wouldn't be possible to keep the tree flattened at all times by running some smaller function checking invariants at every change instead of walking the whole tree every few operations. I think that approach could be complicated so I'm sticking with `tree_flatten` for now.
