### PR TITLE
Change config order in manpage

### DIFF
--- a/man/i3.man
+++ b/man/i3.man
@@ -166,7 +166,7 @@ Exits i3.
 
 == FILES
 
-=== \~/.i3/config (or ~/.config/i3/config)
+=== \~/.config/i3/config (or ~/.i3/config)
 
 When starting, i3 looks for configuration files in the following order:
 


### PR DESCRIPTION
This brings the headline for the configuration files inline with the
recent move to XDG directories.