### PR TITLE
For resizing, convert pixel diff to percentage, based on parent.

### DIFF
--- a/include/con.h
+++ b/include/con.h
@@ -533,3 +533,10 @@ i3String *con_parse_title_format(Con *con);
  *
  */
 bool con_swap(Con *first, Con *second);
+
+/**
+ * Returns given container's rect size depending on its orientation.
+ * i.e. its width when horizontal, its height when vertical.
+ *
+ */
+uint32_t con_rect_size_in_orientation(Con *con);

--- a/include/resize.h
+++ b/include/resize.h
@@ -31,9 +31,3 @@ bool resize_neighboring_cons(Con *first, Con *second, int px, int ppt);
  *
  */
 double percent_for_1px(Con *con);
-
-/**
- * Calculate the given container's new percent given a change in pixels.
- *
- */
-double px_resize_to_percent(Con *con, int px_diff);

--- a/src/commands.c
+++ b/src/commands.c
@@ -537,8 +537,9 @@ static bool cmd_resize_tiling_width_height(I3_CMD, Con *current, const char *dir
     if (ppt != 0.0) {
         new_current_percent = current->percent + ppt;
     } else {
-        new_current_percent = px_resize_to_percent(current, px);
-        ppt = new_current_percent - current->percent;
+        /* Convert px change to change in percentages */
+        ppt = (double)px / (double)con_rect_size_in_orientation(current->parent);
+        new_current_percent = current->percent + ppt;
     }
     subtract_percent = ppt / (children - 1);
     if (ppt < 0.0 && new_current_percent < percent_for_1px(current)) {

--- a/src/con.c
+++ b/src/con.c
@@ -2430,3 +2430,12 @@ bool con_swap(Con *first, Con *second) {
 
     return true;
 }
+
+/*
+ * Returns container's rect size depending on its orientation.
+ * i.e. its width when horizontal, its height when vertical.
+ *
+ */
+uint32_t con_rect_size_in_orientation(Con *con) {
+    return (con_orientation(con) == HORIZ ? con->rect.width : con->rect.height);
+}

--- a/src/render.c
+++ b/src/render.c
@@ -192,7 +192,7 @@ static int *precalculate_sizes(Con *con, render_params *p) {
 
     Con *child;
     int i = 0, assigned = 0;
-    int total = con_orientation(con) == HORIZ ? p->rect.width : p->rect.height;
+    int total = con_rect_size_in_orientation(con);
     TAILQ_FOREACH(child, &(con->nodes_head), nodes) {
         double percentage = child->percent > 0.0 ? child->percent : 1.0 / p->children;
         assigned += sizes[i++] = lround(percentage * total);


### PR DESCRIPTION
Previously, it first calculated one of the containers' next percentage, and then subtracted the previous percentage to find the actual change.

Now it directly calculates the change, and subtracts and adds the change to the two affected containers.

Also, prematurely return when pixel diff is 0, as no action is necessary.

This is related to [this issue on i3-gaps](Airblader/i3#247).