### PR TITLE
Apply title_align to non-leaf containers

### DIFF
--- a/src/x.c
+++ b/src/x.c
@@ -613,31 +613,6 @@ void x_draw_decoration(Con *con) {
     /* 6: draw the title */
     int text_offset_y = (con->deco_rect.height - config.font.height) / 2;
 
-    struct Window *win = con->window;
-    if (win == NULL) {
-        i3String *title;
-        if (con->title_format == NULL) {
-            char *_title;
-            char *tree = con_get_tree_representation(con);
-            sasprintf(&_title, "i3: %s", tree);
-            free(tree);
-
-            title = i3string_from_utf8(_title);
-            FREE(_title);
-        } else {
-            title = con_parse_title_format(con);
-        }
-
-        draw_util_text(title, &(parent->frame_buffer),
-                       p->color->text, p->color->background,
-                       con->deco_rect.x + logical_px(2),
-                       con->deco_rect.y + text_offset_y,
-                       con->deco_rect.width - 2 * logical_px(2));
-        I3STRING_FREE(title);
-
-        goto after_title;
-    }
-
     const int title_padding = logical_px(2);
     const int deco_width = (int)con->deco_rect.width;
     int mark_width = 0;
@@ -677,7 +652,23 @@ void x_draw_decoration(Con *con) {
         FREE(formatted_mark);
     }
 
-    i3String *title = con->title_format == NULL ? win->name : con_parse_title_format(con);
+    i3String *title = NULL;
+    struct Window *win = con->window;
+    if (win == NULL) {
+        if (con->title_format == NULL) {
+            char *_title;
+            char *tree = con_get_tree_representation(con);
+            sasprintf(&_title, "i3: %s", tree);
+            free(tree);
+
+            title = i3string_from_utf8(_title);
+            FREE(_title);
+        } else {
+            title = con_parse_title_format(con);
+        }
+    } else {
+        title = con->title_format == NULL ? win->name : con_parse_title_format(con);
+    }
     if (title == NULL) {
         goto copy_pixmaps;
     }
@@ -710,11 +701,10 @@ void x_draw_decoration(Con *con) {
                    con->deco_rect.y + text_offset_y,
                    deco_width - mark_width - 2 * title_padding);
 
-    if (con->title_format != NULL) {
+    if (win == NULL || con->title_format != NULL) {
         I3STRING_FREE(title);
     }
 
-after_title:
     x_draw_decoration_after_title(con, p);
 copy_pixmaps:
     draw_util_copy_surface(&(con->frame_buffer), &(con->frame), 0, 0, 0, 0, con->rect.width, con->rect.height);


### PR DESCRIPTION
Additionally, marks will now display for non-leaf containers.

Seems simple enough but I'll revisit it to see if I missed anything, seems to work will run it on my desktop for a bit.

Fixes #3540.