### PR TITLE
Bugfix: use restore_conn, not conn

### DIFF
--- a/src/restore_layout.c
+++ b/src/restore_layout.c
@@ -180,8 +180,8 @@ static void update_placeholder_contents(placeholder_state *state) {
     int y = (state->rect.height / 2) - (config.font.height / 2);
     draw_util_text(line, &(state->surface), foreground, background, x, y, text_width);
     i3string_free(line);
-    xcb_flush(conn);
-    xcb_aux_sync(conn);
+    xcb_flush(restore_conn);
+    xcb_aux_sync(restore_conn);
 }
 
 static void open_placeholder_window(Con *con) {
@@ -221,7 +221,7 @@ static void open_placeholder_window(Con *con) {
         state->con = con;
         state->rect = con->rect;
 
-        draw_util_surface_init(conn, &(state->surface), placeholder, get_visualtype(root_screen), state->rect.width, state->rect.height);
+        draw_util_surface_init(restore_conn, &(state->surface), placeholder, get_visualtype(root_screen), state->rect.width, state->rect.height);
         update_placeholder_contents(state);
         TAILQ_INSERT_TAIL(&state_head, state, state);
 


### PR DESCRIPTION
Using the wrong X11 connection breaks the libev event handling model:
xcb_flush() must be called immediately before handing control to libev.

Before this fix:

1. xcb_prepare_cb would read and flush conn
2. restore_xcb_prepare_cb would read and flush restore_conn,
   BUT also inadvertantly call xcb_flush(conn), resulting in new
   events being filled into the XCB event queue
3. libev waits for new events
4. after 1 minute, libev times out and the events are processed

Diagnosed using strace on testcases/complete-run.pl.

related to commit 0d8b6714e39af81cbd6f4fbad500872a715dea24

related to #3510