### PR TITLE
Fix: render_con shows floating containers on wrong workspace

### DIFF
--- a/src/floating.c
+++ b/src/floating.c
@@ -955,8 +955,7 @@ bool floating_reposition(Con *con, Rect newrect) {
 
     /* Workspace change will already result in a tree_render. */
     if (!reassigned) {
-        render_con(con);
-        x_push_node(con);
+        tree_render();
     }
     return true;
 }

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -981,8 +981,7 @@ static bool handle_normal_hints(void *data, xcb_connection_t *conn, uint8_t stat
         Con *floating = con_inside_floating(con);
         if (floating) {
             floating_check_size(con, false);
-            render_con(con);
-            x_push_changes(croot);
+            tree_render();
         }
     }
 


### PR DESCRIPTION
Fixes #3567