### PR TITLE
Remove \n from errx and die messages

### DIFF
--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -822,7 +822,7 @@ int main(int argc, char *argv[]) {
     int screen;
     if ((conn = xcb_connect(NULL, &screen)) == NULL ||
         xcb_connection_has_error(conn))
-        errx(1, "Cannot open display\n");
+        errx(1, "Cannot open display");
 
     if (xkb_x11_setup_xkb_extension(conn,
                                     XKB_X11_MIN_MAJOR_XKB_VERSION,
@@ -859,7 +859,7 @@ int main(int argc, char *argv[]) {
     root = root_screen->root;
 
     if (!(modmap_reply = xcb_get_modifier_mapping_reply(conn, modmap_cookie, NULL)))
-        errx(EXIT_FAILURE, "Could not get modifier mapping\n");
+        errx(EXIT_FAILURE, "Could not get modifier mapping");
 
     xcb_numlock_mask = get_mod_mask_for(XCB_NUM_LOCK, symbols, modmap_reply);
 
@@ -899,7 +899,7 @@ int main(int argc, char *argv[]) {
     do {                                                                                   \
         xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(conn, name##_cookie, NULL); \
         if (!reply)                                                                        \
-            errx(EXIT_FAILURE, "Could not get atom " #name "\n");                          \
+            errx(EXIT_FAILURE, "Could not get atom " #name);                               \
                                                                                            \
         A_##name = reply->atom;                                                            \
         free(reply);                                                                       \

--- a/i3-input/main.c
+++ b/i3-input/main.c
@@ -435,7 +435,7 @@ int main(int argc, char *argv[]) {
     int screen;
     conn = xcb_connect(NULL, &screen);
     if (!conn || xcb_connection_has_error(conn))
-        die("Cannot open display\n");
+        die("Cannot open display");
 
     sockfd = ipc_connect(socket_path);
 

--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -418,7 +418,7 @@ int main(int argc, char *argv[]) {
     int screens;
     if ((conn = xcb_connect(NULL, &screens)) == NULL ||
         xcb_connection_has_error(conn))
-        die("Cannot open display\n");
+        die("Cannot open display");
 
 /* Place requests for the atoms we need as soon as possible */
 #define xmacro(atom) \
@@ -512,7 +512,7 @@ int main(int argc, char *argv[]) {
     do {                                                                                   \
         xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(conn, name##_cookie, NULL); \
         if (!reply)                                                                        \
-            die("Could not get atom " #name "\n");                                         \
+            die("Could not get atom " #name);                                              \
                                                                                            \
         A_##name = reply->atom;                                                            \
         free(reply);                                                                       \

--- a/src/main.c
+++ b/src/main.c
@@ -515,7 +515,7 @@ int main(int argc, char *argv[]) {
 
     conn = xcb_connect(NULL, &conn_screen);
     if (xcb_connection_has_error(conn))
-        errx(EXIT_FAILURE, "Cannot open display\n");
+        errx(EXIT_FAILURE, "Cannot open display");
 
     sndisplay = sn_xcb_display_new(conn, NULL, NULL);
 

--- a/src/restore_layout.c
+++ b/src/restore_layout.c
@@ -115,7 +115,7 @@ void restore_connect(void) {
 #ifdef I3_ASAN_ENABLED
         __lsan_do_leak_check();
 #endif
-        errx(EXIT_FAILURE, "Cannot open display\n");
+        errx(EXIT_FAILURE, "Cannot open display");
     }
 
     xcb_watcher = scalloc(1, sizeof(struct ev_io));

--- a/testcases/inject_randr1.5.c
+++ b/testcases/inject_randr1.5.c
@@ -402,7 +402,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (optind >= argc) {
-        errx(EXIT_FAILURE, "syntax: %s [options] <command>\n", argv[0]);
+        errx(EXIT_FAILURE, "syntax: %s [options] <command>", argv[0]);
     }
 
     int fd = socket(AF_LOCAL, SOCK_STREAM, 0);


### PR DESCRIPTION
errx() already appends \n internally. "\n" in the error message will
result in a blank line after the message. die() is just a wrapper around
errx() so it receives the same treatment.