### PR TITLE
Make binding modes case sensitive

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -621,7 +621,7 @@ void switch_mode(const char *new_mode) {
     DLOG("Switching to mode %s\n", new_mode);
 
     SLIST_FOREACH(mode, &modes, modes) {
-        if (strcasecmp(mode->name, new_mode) != 0)
+        if (strcmp(mode->name, new_mode) != 0)
             continue;
 
         ungrab_all_keys(conn);

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -122,7 +122,7 @@ CFGFUN(mode_binding, const char *bindtype, const char *modifiers, const char *ke
 }
 
 CFGFUN(enter_mode, const char *pango_markup, const char *modename) {
-    if (strcasecmp(modename, DEFAULT_BINDING_MODE) == 0) {
+    if (strcmp(modename, DEFAULT_BINDING_MODE) == 0) {
         ELOG("You cannot use the name %s for your mode\n", DEFAULT_BINDING_MODE);
         return;
     }


### PR DESCRIPTION
Proposal for issue #3587 
Changed `strcasecmp` to `strcmp` where it's used with binding modes