### PR TITLE
Update userguide- describe border style distinction

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -603,8 +603,8 @@ This option determines which border style new windows will have. The default is
 +normal+. Note that default_floating_border applies only to windows which are starting out as
 floating windows, e.g., dialog windows, but not windows that are floated later on.
 
-Setting border style to pixel eliminates title bars. The normal style allows you to adjust
-edge borders down to 0 while still keeping your title bar.
+Setting border style to +pixel+ eliminates title bars. The border style +normal+ allows you to
+adjust edge border width while keeping your title bar.
 
 *Syntax*:
 ---------------------------------------------

--- a/docs/userguide
+++ b/docs/userguide
@@ -603,6 +603,9 @@ This option determines which border style new windows will have. The default is
 +normal+. Note that default_floating_border applies only to windows which are starting out as
 floating windows, e.g., dialog windows, but not windows that are floated later on.
 
+Setting border style to pixel eliminates title bars. The normal style allows you to adjust
+edge borders down to 0 while still keeping your title bar.
+
 *Syntax*:
 ---------------------------------------------
 default_border normal|none|pixel


### PR DESCRIPTION
When setting up my config, I seeked to adjust window borders to zero while keeping my title bars. I found nothing in the docs that noted the distinction between the border styles. These couple sentences on that distinction might help clarify that.