### PR TITLE
i3-dump-log: make log message a little more clear

### DIFF
--- a/i3-dump-log/main.c
+++ b/i3-dump-log/main.c
@@ -155,7 +155,7 @@ int main(int argc, char *argv[]) {
             exit(1);
         }
         if (root_atom_contents("I3_CONFIG_PATH", conn, screen) != NULL) {
-            fprintf(stderr, "i3-dump-log: ERROR: i3 is running, but SHM logging is not enabled. Enabling SHM log until cancelled\n\n");
+            fprintf(stderr, "i3-dump-log: i3 is running, but SHM logging is not enabled. Enabling SHM log now while i3-dump-log is running\n\n");
             ipcfd = ipc_connect(NULL);
             const char *enablecmd = "debuglog on; shmlog 5242880";
             if (ipc_send_message(ipcfd, strlen(enablecmd),

--- a/testcases/t/207-shmlog.t
+++ b/testcases/t/207-shmlog.t
@@ -31,7 +31,7 @@ run [ 'i3-dump-log' ],
     '>', \$stdout,
     '2>', \$stderr;
 
-like($stderr, qr#^i3-dump-log: ERROR: i3 is running, but SHM logging is not enabled\.#,
+like($stderr, qr#^i3-dump-log: i3 is running, but SHM logging is not enabled\.#,
     'shm logging not enabled');
 
 ################################################################################
@@ -73,7 +73,7 @@ run [ 'i3-dump-log' ],
     '>', \$stdout,
     '2>', \$stderr;
 
-like($stderr, qr#^i3-dump-log: ERROR: i3 is running, but SHM logging is not enabled\.#,
+like($stderr, qr#^i3-dump-log: i3 is running, but SHM logging is not enabled\.#,
     'shm logging not enabled');
 
 done_testing;


### PR DESCRIPTION
This came up when trying to debug an issue.