### PR TITLE
Use I3_IPC_MESSAGE_TYPE_RUN_COMMAND and define it.

### DIFF
--- a/i3-dump-log/main.c
+++ b/i3-dump-log/main.c
@@ -50,7 +50,7 @@ static void sighandler(int signal) {
 static void disable_shmlog(void) {
     const char *disablecmd = "debuglog off; shmlog off";
     if (ipc_send_message(ipcfd, strlen(disablecmd),
-                         I3_IPC_MESSAGE_TYPE_COMMAND, (uint8_t *)disablecmd) != 0)
+                         I3_IPC_MESSAGE_TYPE_RUN_COMMAND, (uint8_t *)disablecmd) != 0)
         err(EXIT_FAILURE, "IPC send");
 
     /* Ensure the command was sent by waiting for the reply: */
@@ -159,7 +159,7 @@ int main(int argc, char *argv[]) {
             ipcfd = ipc_connect(NULL);
             const char *enablecmd = "debuglog on; shmlog 5242880";
             if (ipc_send_message(ipcfd, strlen(enablecmd),
-                                 I3_IPC_MESSAGE_TYPE_COMMAND, (uint8_t *)enablecmd) != 0)
+                                 I3_IPC_MESSAGE_TYPE_RUN_COMMAND, (uint8_t *)enablecmd) != 0)
                 err(EXIT_FAILURE, "IPC send");
             /* By the time we receive a reply, I3_SHMLOG_PATH is set: */
             uint32_t reply_length = 0;

--- a/include/i3/ipc.h
+++ b/include/i3/ipc.h
@@ -71,6 +71,7 @@ typedef struct i3_ipc_header {
  *
  */
 #define I3_IPC_REPLY_TYPE_COMMAND 0
+#define I3_IPC_MESSAGE_TYPE_RUN_COMMAND 0
 #define I3_IPC_REPLY_TYPE_WORKSPACES 1
 #define I3_IPC_REPLY_TYPE_SUBSCRIBE 2
 #define I3_IPC_REPLY_TYPE_OUTPUTS 3


### PR DESCRIPTION
As We know I3_IPC_MESSAGE_TYPE_COMMAND is deprecated,
that's why we need to use the function that isnt deprecated and
define it.