### PR TITLE
Updated docs for COMMAND reply.

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -137,6 +137,12 @@ TICK (10)::
 The reply consists of a list of serialized maps for each command that was
 parsed. Each has the property +success (bool)+ and may also include a
 human-readable error message in the property +error (string)+.
+Note that when you send multiple commands, separated by semicolon,
+commands are parsed and executed one by one.
+This means that commands like +restart+ and +exit+ are special cases
+because after reading them, i3 will restart/shutdown and close sockets.
+Therefore, you should NOT try to read +success (bool)+ or +error (string)+
+status for them.
 
 *Example:*
 -------------------


### PR DESCRIPTION
Note that my findings are observed from responses over sockets, I haven't looked in source code of i3.
Therefore, I am not 100% sure about i3 closing the sockets on restart/shutdown and you should correct me if I'm wrong.
However, I am sure that reading response from same socket for restart/shutdown command is invalid.
While debugging this, there was never even "i3-ipc" magic string in the socket which was successfully used for communication previously.