### PR TITLE
x.c: correctly free con->frame_buffer in _x_con_kill

### DIFF
--- a/src/x.c
+++ b/src/x.c
@@ -268,6 +268,7 @@ static void _x_con_kill(Con *con) {
     draw_util_surface_free(conn, &(con->frame));
     draw_util_surface_free(conn, &(con->frame_buffer));
     xcb_free_pixmap(conn, con->frame_buffer.id);
+    con->frame_buffer.id = XCB_NONE;
     state = state_for_frame(con->frame.id);
     CIRCLEQ_REMOVE(&state_head, state, state);
     CIRCLEQ_REMOVE(&old_state_head, state, old_state);


### PR DESCRIPTION
This fixes a crash which I could not reproduce in a testcase with reasonable effort, but the user reported the fix works.

Compare with src/x.c:946.

Fixes #3554
Fixes #3645