### PR TITLE
fix travis build by switching away from deprecated-2017Q3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-sudo: false
 dist: trusty
-# TODO: remove “group” once trusty kernel is no longer affected by
-# https://github.com/google/sanitizers/issues/837
-group: deprecated-2017Q3
 services:
   - docker
 language: c


### PR DESCRIPTION
Also remove “sudo: false” as per
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration