### PR TITLE
Add explicit reference to glib2 in automake

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -277,6 +277,7 @@ i3_LDADD = \
 
 libi3_CFLAGS = \
 	$(AM_CFLAGS) \
+	$(GLIBGOBJECT_CFLAGS) \
 	$(XCB_CFLAGS) \
 	$(XCB_UTIL_CFLAGS) \
 	$(XCB_UTIL_XRM_CFLAGS) \
@@ -285,6 +286,7 @@ libi3_CFLAGS = \
 
 libi3_LIBS = \
 	$(top_builddir)/libi3.a \
+	$(GLIBGOBJECT_LIBS) \
 	$(XCB_LIBS) \
 	$(XCB_UTIL_LIBS) \
 	$(XCB_UTIL_XRM_LIBS) \

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,7 @@ PKG_CHECK_MODULES([XKBCOMMON], [xkbcommon xkbcommon-x11])
 PKG_CHECK_MODULES([YAJL], [yajl])
 PKG_CHECK_MODULES([LIBPCRE], [libpcre >= 8.10])
 PKG_CHECK_MODULES([PANGOCAIRO], [cairo >= 1.14.4 pangocairo])
+PKG_CHECK_MODULES([GLIBGOBJECT], [glib-2.0 gobject-2.0])
 
 # Checks for programs.
 AC_PROG_AWK


### PR DESCRIPTION
fix for issue #3652 which was exposed by pango update 1.43.0