### PR TITLE
docs/i3bar-protocol: add markup to all possible entries example

### DIFF
--- a/docs/i3bar-protocol
+++ b/docs/i3bar-protocol
@@ -221,7 +221,8 @@ An example of a block which uses all possible entries follows:
  "name": "ethernet",
  "instance": "eth0",
  "separator": true,
- "separator_block_width": 9
+ "separator_block_width": 9,
+ "markup": "none"
 }
 ------------------------------------------
 


### PR DESCRIPTION
>An example of a block which uses all possible entries follows:

This adds a missing entry `markup`. 