### PR TITLE
Fix: delete decoration cache after swap

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -2385,6 +2385,8 @@ bool con_swap(Con *first, Con *second) {
     con_fix_percent(first->parent);
     con_fix_percent(second->parent);
 
+    FREE(first->deco_render_params);
+    FREE(second->deco_render_params);
     con_force_split_parents_redraw(first);
     con_force_split_parents_redraw(second);
 


### PR DESCRIPTION
Tested this quickly, don't think I am missing something