### PR TITLE
docs: describe for_window with the correct term

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -657,7 +657,7 @@ hide_edge_borders vertical
 [[for_window]]
 === Arbitrary commands for specific windows (for_window)
 
-With the +for_window+ command, you can let i3 execute any command when it
+With the +for_window+ directive, you can let i3 execute any command when it
 encounters a specific window. This can be used to set windows to floating or to
 change their border style, for example.
 


### PR DESCRIPTION
for_window is a directive or option, not a command. Otherwise, people might want to use it in a keybinding: https://www.reddit.com/r/i3wm/comments/bw3d02/toggle_whether_new_windows_are_tiled_or_floating/