### PR TITLE
feat: support transparency (RGBA) in i3bar

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1744,6 +1744,26 @@ bar {
 }
 --------------------------------------
 
+=== Transparency
+
+i3bar can support transparency by passing the +--transparency+ flag in the
+configuration:
+
+*Syntax*:
+--------------------------------------
+bar {
+    i3bar_command i3bar --transparency
+}
+--------------------------------------
+
+In the i3bar color configuration and i3bar status block color attribute you can
+then use colors in the RGBA format, i.e. the last two (hexadecimal) digits
+specify the opacity. For example, +#00000000+ will be completely transparent,
+while +#000000FF+ will be a fully opaque black (the same as +#000000+).
+
+Please note that due to the way the tray specification works, enabling this
+flag will cause all tray icons to have a transparent background.
+
 [[list_of_commands]]
 == List of commands
 

--- a/i3bar/include/configuration.h
+++ b/i3bar/include/configuration.h
@@ -48,6 +48,7 @@ typedef struct config_t {
 
     position_t position;
     bool verbose;
+    bool transparency;
     struct xcb_color_strings_t colors;
     bool disable_binding_mode_indicator;
     bool disable_ws;

--- a/i3bar/src/main.c
+++ b/i3bar/src/main.c
@@ -56,13 +56,14 @@ static char *expand_path(char *path) {
 }
 
 static void print_usage(char *elf_name) {
-    printf("Usage: %s -b bar_id [-s sock_path] [-h] [-v]\n", elf_name);
+    printf("Usage: %s -b bar_id [-s sock_path] [-t] [-h] [-v]\n", elf_name);
     printf("\n");
-    printf("-b, --bar_id  <bar_id>\tBar ID for which to get the configuration\n");
-    printf("-s, --socket  <sock_path>\tConnect to i3 via <sock_path>\n");
-    printf("-h, --help    Display this help message and exit\n");
-    printf("-v, --version Display version number and exit\n");
-    printf("-V, --verbose Enable verbose mode\n");
+    printf("-b, --bar_id       <bar_id>\tBar ID for which to get the configuration\n");
+    printf("-s, --socket       <sock_path>\tConnect to i3 via <sock_path>\n");
+    printf("-t, --transparency Enable transparency (RGBA colors)\n");
+    printf("-h, --help         Display this help message and exit\n");
+    printf("-v, --version      Display version number and exit\n");
+    printf("-V, --verbose      Enable verbose mode\n");
     printf("\n");
     printf(" PLEASE NOTE that i3bar will be automatically started by i3\n"
            " as soon as there is a 'bar' configuration block in your\n"
@@ -105,12 +106,13 @@ int main(int argc, char **argv) {
     static struct option long_opt[] = {
         {"socket", required_argument, 0, 's'},
         {"bar_id", required_argument, 0, 'b'},
+        {"transparency", no_argument, 0, 't'},
         {"help", no_argument, 0, 'h'},
         {"version", no_argument, 0, 'v'},
         {"verbose", no_argument, 0, 'V'},
         {NULL, 0, 0, 0}};
 
-    while ((opt = getopt_long(argc, argv, "b:s:hvV", long_opt, &option_index)) != -1) {
+    while ((opt = getopt_long(argc, argv, "b:s:thvV", long_opt, &option_index)) != -1) {
         switch (opt) {
             case 's':
                 socket_path = expand_path(optarg);
@@ -121,6 +123,9 @@ int main(int argc, char **argv) {
                 break;
             case 'b':
                 config.bar_id = sstrdup(optarg);
+                break;
+            case 't':
+                config.transparency = true;
                 break;
             case 'V':
                 config.verbose = true;


### PR DESCRIPTION
We introduce a -t flag for i3bar in order to enable a mode which
supports the use of RGBA colors.

An important constraint here is that tray icons will always have
a fully transparent background.

fixes #3723