### PR TITLE
Accurately consider inactive displays when signaling child

### DIFF
--- a/i3bar/include/child.h
+++ b/i3bar/include/child.h
@@ -76,6 +76,13 @@ void stop_child(void);
 void cont_child(void);
 
 /*
+ * Send a SIGSTOP or SIGCONT as necessary in response to a change in
+ * window visibility or output activity.
+ *
+ */
+void stop_or_cont_child(void);
+
+/*
  * Whether or not the child want click events
  *
  */

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -731,6 +731,21 @@ void cont_child(void) {
 }
 
 /*
+ * Send a SIGSTOP or SIGCONT as necessary in response to a change in
+ * window visibility or output activity.
+ *
+ */
+void stop_or_cont_child(void) {
+    i3_output *output;
+    SLIST_FOREACH(output, outputs, slist) {
+        if (output->active && output->visible) {
+            cont_child();
+            return;
+        }
+    }
+    stop_child();
+}
+/*
  * Whether or not the child want click events
  *
  */

--- a/i3bar/src/outputs.c
+++ b/i3bar/src/outputs.c
@@ -46,7 +46,11 @@ static int outputs_boolean_cb(void *params_, int val) {
     struct outputs_json_params *params = (struct outputs_json_params *)params_;
 
     if (!strcmp(params->cur_key, "active")) {
-        params->outputs_walk->active = val;
+        bool changed = params->outputs_walk->active != (bool)val;
+        if (changed) {
+            params->outputs_walk->active = val;
+            stop_or_cont_child();
+        }
         FREE(params->cur_key);
         return 1;
     }

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -657,29 +657,17 @@ static void handle_button(xcb_button_press_event_t *event) {
  */
 static void handle_visibility_notify(xcb_visibility_notify_event_t *event) {
     bool visible = (event->state != XCB_VISIBILITY_FULLY_OBSCURED);
-    int num_visible = 0;
     i3_output *output;
 
     SLIST_FOREACH(output, outputs, slist) {
-        if (!output->active) {
-            continue;
-        }
         if (output->bar.id == event->window) {
-            if (output->visible == visible) {
-                return;
+            bool changed = output->visible != visible;
+            if (changed) {
+                output->visible = visible;
+                stop_or_cont_child();
             }
-            output->visible = visible;
+            return;
         }
-        num_visible += output->visible;
-    }
-
-    if (num_visible == 0) {
-        stop_child();
-    } else if (num_visible == visible) {
-        /* Wake the child only when transitioning from 0 to 1 visible bar.
-         * We cannot transition from 0 to 2 or more visible bars at once since
-         * visibility events are delivered to each window separately */
-        cont_child();
     }
 }
 


### PR DESCRIPTION
This should fix #3242. Marked as draft because I haven't tested this yet.