### PR TITLE
Unset _I3_RESTART_FD after restart

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -868,6 +868,7 @@ int main(int argc, char *argv[]) {
             DLOG("serving restart fd %d", restart_fd);
             ipc_client *client = ipc_new_client_on_fd(main_loop, restart_fd);
             ipc_confirm_restart(client);
+            unsetenv("_I3_RESTART_FD");
         }
     }
 


### PR DESCRIPTION
i3 sends a response for the restart command to the ipc file descriptor saved in the _I3_RESTART_FD environment variable. When `restart` is run from a keybinding, there is no ipc file descriptor, but without unsetting _I3_RESTART_FD i3 still tries to send the response to the last used, now closed, file descriptor.

Closes #3764 
Closes #3765