### PR TITLE
 cmd_move_to_mark: fix move to scratchpad hidden

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -1298,6 +1298,13 @@ bool con_move_to_mark(Con *con, const char *mark) {
         return false;
     }
 
+    /* For target containers in the scratchpad, we just send the window to the scratchpad. */
+    if (con_get_workspace(target) == workspace_get("__i3_scratch", NULL)) {
+        DLOG("target container is in the scratchpad, moving container to scratchpad.\n");
+        scratchpad_move(con);
+        return true;
+    }
+
     /* For floating target containers, we just send the window to the same workspace. */
     if (con_is_floating(target)) {
         DLOG("target container is floating, moving container to target's workspace.\n");

--- a/testcases/t/243-move-to-mark.t
+++ b/testcases/t/243-move-to-mark.t
@@ -24,6 +24,7 @@ use i3test;
 
 my ($A, $B, $S, $M, $F, $source_ws, $target_ws, $ws);
 my ($nodes, $focus);
+my $__i3_scratch;
 my $cmd_result;
 
 my $_NET_WM_STATE_REMOVE = 0;
@@ -400,6 +401,29 @@ sync_with_i3;
 is(@{$nodes}, 2, 'there is a window and a container with the contents of the original workspace');
 is($nodes->[0]->{window}, $M->{id}, 'M remains the first window');
 is(@{get_ws($target_ws)->{floating_nodes}}, 1, 'target workspace has the floating container');
+
+###############################################################################
+# Given 'S' and 'M', where 'S' is a container and 'M' is a container hidden in
+# the scratchpad, then move 'S' to the scratchpad
+###############################################################################
+
+$ws = fresh_workspace;
+$S = open_window;
+cmd 'mark S';
+$M = open_window;
+cmd 'mark target';
+cmd 'move container to scratchpad';
+
+cmd '[con_mark=S] move container to mark target';
+sync_with_i3;
+
+($nodes, $focus) = get_ws_content($ws);
+is(@{$nodes}, 0, 'there are no tiling windows on the workspace');
+is(@{get_ws($ws)->{floating_nodes}}, 0, 'there are no floating containers on the workspace');
+
+$__i3_scratch = get_ws('__i3_scratch');
+is(@{$__i3_scratch->{nodes}}, 0, 'there are no tiling windows on the scratchpad workspace');
+is(@{$__i3_scratch->{floating_nodes}}, 2, 'there are two floating containers in the scratchpad');
 
 ###############################################################################
 


### PR DESCRIPTION
_I actually found this due to a sway issue (https://github.com/swaywm/sway/issues/4473). I went to test i3's behavior to replicate in sway. If this is actually working as intended, sorry for the noise. Also, if neither the current behavior or this PR are the desired behavior, just let me know and I'll change it_

This fixes the case where moving a container to a scratchpad hidden container via a mark would cause the container to be tiling on the `__i3_scratch` workspace. This still moves the container to the `__i3_scratch` workspace, but properly adds it to the scratchpad so that it becomes usable instead of requiring criteria to regain access to.

Reproduction steps for the issue (tested using commit a4b5deed7396163009275b581d8ce77e291b86d0):
1. Open two windows
2. Run `i3-msg 'mark target, move to scratchpad'` on one of them
3. Run `i3-msg 'move container to mark target'` on the other

Without this change, the second window is moved to the scratchpad workspace, but as a tiling window (as shown with `i3-msg -t get_tree | jq '.. | objects | select(.name=="__i3_scratch") | .nodes'`). The only way of accessing the window is with criteria.

With this change, the second window is correctly moved to the scratchpad and is accessible like any other container in the scratchpad.