### PR TITLE
fix lcov support

### DIFF
--- a/m4/ax_code_coverage.m4
+++ b/m4/ax_code_coverage.m4
@@ -107,7 +107,7 @@ AC_DEFUN([AX_CODE_COVERAGE],[
 		])
 
 		# List of supported lcov versions.
-		lcov_version_list="1.6 1.7 1.8 1.9 1.10 1.11 1.12"
+		lcov_version_list="1.6 1.7 1.8 1.9 1.10 1.11 1.12 1.13"
 
 		AC_CHECK_PROG([LCOV], [lcov], [lcov])
 		AC_CHECK_PROG([GENHTML], [genhtml], [genhtml])


### PR DESCRIPTION
Ubuntu 18.10 comes with lcov 1.13, which is now added.