### PR TITLE
Move parent nodes in scratchpad correctly

### DIFF
--- a/src/scratchpad.c
+++ b/src/scratchpad.c
@@ -138,7 +138,7 @@ bool scratchpad_show(Con *con) {
             floating->scratchpad_state != SCRATCHPAD_NONE) {
             DLOG("Found a visible scratchpad window on another workspace,\n");
             DLOG("moving it to this workspace: con = %p\n", walk_con);
-            con_move_to_workspace(walk_con, focused_ws, true, false, false);
+            con_move_to_workspace(floating, focused_ws, true, false, false);
             con_activate(con_descend_focused(walk_con));
             return true;
         }

--- a/testcases/t/185-scratchpad.t
+++ b/testcases/t/185-scratchpad.t
@@ -548,5 +548,31 @@ is ($x->input_focus, $second->id, 'moving scratchpad window does not show it');
 cmd '[id=' . $first->id . '] move position center';
 is ($x->input_focus, $second->id, 'centering scratchpad window does not show it');
 
+###################################################################################
+# Verify that a scratchpad container with child containers that was open in
+# another workspace is moved to the current workspace (with all its children)
+# after a scratchpad show.
+################################################################################
+
+kill_all_windows;
+open_window;
+open_window;
+# This is to dodge the edge case were the whole workspace is moved
+# window-by-window into the scratchpad.
+cmd 'layout tabbed';
+cmd 'focus parent';
+cmd 'move to scratchpad';
+$ws = fresh_workspace;
+cmd 'scratchpad show';
+# Case 1: a parent node in the scratchpad does not lose children
+# Note on the layout: there should be a floating tabbed container, which is
+# represented as follows:
+#    [workspace object] -> [floating_nodes] -> [tabbed node container] -> [the 2 children we expect]
+is(scalar @{get_ws($ws)->{floating_nodes}->[0]->{nodes}->[0]->{nodes}}, 2, 'both windows moved from scratchpad to this workspace');
+
+# Case 2: a parent node in the scratchpad from another workspace does not lose children
+$ws = fresh_workspace;
+cmd 'scratchpad show';
+is(scalar @{get_ws($ws)->{floating_nodes}->[0]->{nodes}->[0]->{nodes}}, 2, 'both windows moved from scratchpad focused on other workspace to this workspace');
 
 done_testing;

--- a/testcases/t/299-regress-scratchpad-focus.t
+++ b/testcases/t/299-regress-scratchpad-focus.t
@@ -29,5 +29,6 @@ open_window;
 cmd 'scratchpad show';
 sync_with_i3;
 is($x->input_focus, $expected_focus->id, 'scratchpad window brought from other workspace is focused');
+kill_all_windows;
 
 done_testing;

--- a/testcases/t/299-regress-scratchpad-focus.t
+++ b/testcases/t/299-regress-scratchpad-focus.t
@@ -29,6 +29,5 @@ open_window;
 cmd 'scratchpad show';
 sync_with_i3;
 is($x->input_focus, $expected_focus->id, 'scratchpad window brought from other workspace is focused');
-kill_all_windows;
 
 done_testing;


### PR DESCRIPTION
Should fix #3679 : to move subtrees in the scratchpad from one workspace to another.

Also tries (and fails) to add a test for this behavior.