### PR TITLE
feat: add window_type to ipc response

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -528,6 +528,36 @@ void dump_node(yajl_gen gen, struct Con *con, bool inplace_restart) {
     else
         y(null);
 
+    ystr("window_type");
+    if (con->window) {
+        if (con->window->window_type == A__NET_WM_WINDOW_TYPE_NORMAL) {
+            ystr("normal");
+        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_DOCK) {
+            ystr("dock");
+        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_DIALOG) {
+            ystr("dialog");
+        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_UTILITY) {
+            ystr("utility");
+        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_TOOLBAR) {
+            ystr("toolbar");
+        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_SPLASH) {
+            ystr("splash");
+        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_MENU) {
+            ystr("menu");
+        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_DROPDOWN_MENU) {
+            ystr("dropdown_menu");
+        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_POPUP_MENU) {
+            ystr("popup_menu");
+        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_TOOLTIP) {
+            ystr("tooltip");
+        } else if (con->window->window_type == A__NET_WM_WINDOW_TYPE_NOTIFICATION) {
+            ystr("notification");
+        } else {
+            ystr("unknown");
+        }
+    } else
+        y(null);
+
     if (con->window && !inplace_restart) {
         /* Window properties are useless to preserve when restarting because
          * they will be queried again anyway. However, for i3-save-tree(1),

--- a/testcases/t/116-nestedcons.t
+++ b/testcases/t/116-nestedcons.t
@@ -53,6 +53,7 @@ my $expected = {
     name => 'root',
     orientation => $ignore,
     type => 'root',
+    window_type => undef,
     id => $ignore,
     rect => $ignore,
     deco_rect => $ignore,


### PR DESCRIPTION
Hi :wave: 

I wanted to have the `window_type` property available to `i3` via IPC, so I added this small change.
I'm not very familiar with C and its tooling, so please let me know if there's anything extra I should do.

I've compiled and run this locally, and it works when I test it manually (via `i3-msg`).
~~I have not yet, however, been able to run `i3`'s tests locally - the tools used are completely unfamiliar to me.~~ Nevermind, the tests and builds pass - I figured it out. :+1: 

---

Please let me know what I can do to help get this across the line! :slightly_smiling_face: 