### PR TITLE
Fix regression: floating xterm created partially off screen

### DIFF
--- a/src/floating.c
+++ b/src/floating.c
@@ -371,6 +371,7 @@ void floating_enable(Con *con, bool automatic) {
     if (nc->rect.x == 0 && nc->rect.y == 0) {
         Con *leader;
         if (con->window && con->window->leader != XCB_NONE &&
+            con->window->id != con->window->leader &&
             (leader = con_by_window_id(con->window->leader)) != NULL) {
             DLOG("Centering above leader\n");
             floating_center(nc, leader->rect);


### PR DESCRIPTION
Fixes #3606

Xterm starts with a `WM_CLIENT_LEADER` property containing its own window ID.
Before this fix, i3 tried to center such windows onto itself and did it wrong since `leader->rect == {0,0,0,0}` at this moment.
Before 128122e7663a5a1f38bd8f921ecaef55ff2a4b13 such windows already was misplaced, but [got sanitized afterwards](https://github.com/i3/i3/blob/8a3ef3a81bd4946777c7e3585384283bf12d89be/src/floating.c#L329-L335).