### PR TITLE
handlers.c: new focus should not end up behind fullscreen

### DIFF
--- a/include/con.h
+++ b/include/con.h
@@ -46,6 +46,13 @@ void con_focus(Con *con);
 void con_activate(Con *con);
 
 /**
+ * Activates the container like in con_activate but removes fullscreen
+ * restrictions and properly warps the pointer if needed.
+ *
+ */
+void con_activate_unblock(Con *con);
+
+/**
  * Closes the given container.
  *
  */

--- a/src/con.c
+++ b/src/con.c
@@ -266,6 +266,41 @@ void con_activate(Con *con) {
 }
 
 /*
+ * Activates the container like in con_activate but removes fullscreen
+ * restrictions and properly warps the pointer if needed.
+ *
+ */
+void con_activate_unblock(Con *con) {
+    Con *ws = con_get_workspace(con);
+    Con *previous_focus = focused;
+    Con *fullscreen_on_ws = con_get_fullscreen_covering_ws(ws);
+
+    if (fullscreen_on_ws && fullscreen_on_ws != con && !con_has_parent(con, fullscreen_on_ws)) {
+        con_disable_fullscreen(fullscreen_on_ws);
+    }
+
+    con_activate(con);
+
+    /* If the container is not on the current workspace, workspace_show() will
+     * switch to a different workspace and (if enabled) trigger a mouse pointer
+     * warp to the currently focused container (!) on the target workspace.
+     *
+     * Therefore, before calling workspace_show(), we make sure that 'con' will
+     * be focused on the workspace. However, we cannot just con_focus(con)
+     * because then the pointer will not be warped at all (the code thinks we
+     * are already there).
+     *
+     * So we focus 'con' to make it the currently focused window of the target
+     * workspace, then revert focus. */
+    if (ws != con_get_workspace(previous_focus)) {
+        con_activate(previous_focus);
+        /* Now switch to the workspace, then focus */
+        workspace_show(ws);
+        con_activate(con);
+    }
+}
+
+/*
  * Closes the given container.
  *
  */

--- a/testcases/t/195-net-active-window.t
+++ b/testcases/t/195-net-active-window.t
@@ -150,6 +150,22 @@ send_net_active_window($scratch->id, 'pager');
 is($x->input_focus, $scratch->id, 'scratchpad window is shown');
 
 ################################################################################
+# Send a _NET_ACTIVE_WINDOW ClientMessage for a window behind a fullscreen
+# window
+################################################################################
+
+$ws1 = fresh_workspace;
+$win1 = open_window;
+$win2 = open_window;
+cmd 'fullscreen enable';
+is_num_fullscreen($ws1, 1, '1 fullscreen window in workspace');
+
+send_net_active_window($win1->id);
+
+is($x->input_focus, $win1->id, 'window behind fullscreen window is now focused');
+is_num_fullscreen($ws1, 0, 'no fullscreen windows in workspace');
+
+################################################################################
 # Verify that the _NET_ACTIVE_WINDOW property is updated on the root window
 # correctly.
 ################################################################################


### PR DESCRIPTION
Alternatively, we could deny focus for windows that are behind fullscreened windows. But, since we don't do this with `cmd_focus`, I thought that this is more consistent.