### PR TITLE
Remove outdated comment from Rect

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -144,8 +144,6 @@ typedef enum {
 
 /**
  * Stores a rectangle, for example the size of a window, the child window etc.
- * It needs to be packed so that the compiler will not add any padding bytes.
- * (it is used in src/ewmh.c for example)
  *
  * Note that x and y can contain signed values in some cases (for example when
  * used for the coordinates of a window, which can be set outside of the


### PR DESCRIPTION
This has changed after #3787.

The packed attribute was added in 75aac5bc02f07f1b1b1814e488926d22173e3594 for _NET_WORKAREA. However, eec80838ab39377f18e3f68dc8a27923ae19e57e removed _NET_WORKAREA support. I did some quick greping for `memcpy.+Rect` and didn't find any similar
code that could theoretically lead to problems.

@stapelberg FYI