### PR TITLE
remanage_window: avoid crash when nc->window == NULL

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -698,7 +698,7 @@ out:
 Con *remanage_window(Con *con) {
     Match *match;
     Con *nc = con_for_window(croot, con->window, &match);
-    if (nc == NULL || nc->window == con->window) {
+    if (nc == NULL || nc->window == NULL || nc->window == con->window) {
         run_assignments(con->window);
         return con;
     }


### PR DESCRIPTION
Temporary solution until we find the root cause. Not that it is a bad idea to check for `NULL` either way.

Related to #3731