### PR TITLE
userguide: Add missing anchor

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1985,6 +1985,7 @@ bindsym $mod+h split horizontal
 bindsym $mod+t split toggle
 -------------------------------
 
+[[manipulating_layout]]
 === Manipulating layout
 
 Use +layout toggle split+, +layout stacking+, +layout tabbed+, +layout splitv+


### PR DESCRIPTION
This fixes the missing anchor for the existing cross reference `<<manipulating_layout>>`.