### PR TITLE
Only swallow windows once

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -494,6 +494,9 @@ struct Window {
     /* Time when the window became managed. Used to determine whether a window
      * should be swallowed after initial management. */
     time_t managed_since;
+
+    /* The window has been swallowed. */
+    bool swallowed;
 };
 
 /**

--- a/src/manage.c
+++ b/src/manage.c
@@ -273,6 +273,7 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
     DLOG("Initial geometry: (%d, %d, %d, %d)\n", geom->x, geom->y, geom->width, geom->height);
 
     /* See if any container swallows this new window */
+    cwindow->swallowed = false;
     Match *match = NULL;
     Con *nc = con_for_window(search_at, cwindow, &match);
     const bool match_from_restart_mode = (match && match->restart_mode);
@@ -361,6 +362,8 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
             match_free(match);
             FREE(match);
         }
+
+        cwindow->swallowed = true;
     }
 
     DLOG("new container = %p\n", nc);
@@ -696,6 +699,11 @@ out:
  *
  */
 Con *remanage_window(Con *con) {
+    /* Make sure this windows hasn't already been swallowed. */
+    if (con->window->swallowed) {
+        run_assignments(con->window);
+        return con;
+    }
     Match *match;
     Con *nc = con_for_window(croot, con->window, &match);
     if (nc == NULL || nc->window == NULL || nc->window == con->window) {
@@ -741,5 +749,6 @@ Con *remanage_window(Con *con) {
         ewmh_update_wm_desktop();
     }
 
+    nc->window->swallowed = true;
     return nc;
 }


### PR DESCRIPTION
fixes #3888. Some windows "update" some of their properties like window names when their dimensions change. They don't actually update the properties, but the handlers get called in any case. Which calls remanage_window again. There's also the fact that a window can change its name after it gets mapped and get re-swallowed. So this PR only allows a window to get swallowed once.