### PR TITLE
Fixed location of the IPC socket in the docs

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1005,7 +1005,8 @@ programs to get information from i3, such as the current workspaces
 (to display a workspace bar), and to control i3.
 
 The IPC socket is enabled by default and will be created in
-+/tmp/i3-%u.XXXXXX/ipc-socket.%p+ where +%u+ is your UNIX username, +%p+ is
++$XDG_RUNTIME_DIR/i3/ipc-socket.%p+ if the directory is available, falling back
+to +/tmp/i3-%u.XXXXXX/ipc-socket.%p+, where +%u+ is your UNIX username, +%p+ is
 the PID of i3 and XXXXXX is a string of random characters from the portable
 filename character set (see mkdtemp(3)).
 


### PR DESCRIPTION
Socket gets created by default in `$XDG_RUNTIME_DIR` rather than in `/tmp/`, see 8a40dc0011828f57661a6bd9e2df09c138f4a1a9