### PR TITLE
Document floating properties in get_tree reply

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -440,6 +440,9 @@ focus (array of integer)::
 	order. Traversing the tree by following the first entry in this array
 	will result in eventually reaching the one node with +focused+ set to
 	true.
+sticky (bool)::
+	Whether this window is "sticky". If it is also floating, this window will
+	be present on all workspaces on the same output.
 fullscreen_mode (integer)::
 	Whether this container is in fullscreen state or not.
     Possible values are


### PR DESCRIPTION
Update `doc/ipc` get_tree reply docs to include: `sticky` and `floating`.