### PR TITLE
Respect match criteria for exec command

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1207,10 +1207,26 @@ void cmd_kill(I3_CMD, const char *kill_mode_str) {
 void cmd_exec(I3_CMD, const char *nosn, const char *command) {
     bool no_startup_id = (nosn != NULL);
 
-    DLOG("should execute %s, no_startup_id = %d\n", command, no_startup_id);
-    start_application(command, no_startup_id);
+    HANDLE_EMPTY_MATCH;
 
-    ysuccess(true);
+    int count = 0;
+    owindow *current;
+    TAILQ_FOREACH(current, &owindows, owindows) {
+        count++;
+    }
+
+    if (count > 1) {
+        LOG("WARNING: Your criteria for the exec command match %d containers, "
+            "so the command will execute this many times.\n",
+            count);
+    }
+
+    TAILQ_FOREACH(current, &owindows, owindows) {
+        DLOG("should execute %s, no_startup_id = %d\n", command, no_startup_id);
+        start_application(command, no_startup_id);
+    }
+
+    ysuccess(count > 0);
 }
 
 #define CMD_FOCUS_WARN_CHILDREN                                                        \


### PR DESCRIPTION
We currently do not evaluate match criteria for the exec command
since generally executing the same command multiple times is
unlikely to make sense.

However, it does make sense when the match is empty and this should
prevent the command from running, which currently does not happen.

For consisteny we execute the command as many times as there are
matched criteria, but print a warning if it matches more than one
container.

fixes #3903

---

This PR is not yet tested.