### PR TITLE
Improved documentation for "window_properties" field in GET_TREE reply.

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -348,7 +348,8 @@ window (integer)::
 	containers. This ID corresponds to what xwininfo(1) and other
 	X11-related tools display (usually in hex).
 window_properties (map)::
-	X11 window properties title, instance, class, window_role and transient_for.
+	This optional field contains all available X11 window properties from the
+	following list: *title*, *instance*, *class*, *window_role* and *transient_for*.
 window_type (string)::
 	The window type (_NET_WM_WINDOW_TYPE). Possible values are undefined, normal,
 	dialog, utility, toolbar, splash, menu, dropdown_menu, popup_menu, tooltip and


### PR DESCRIPTION
Pointed out the fact that whole `window_properties` field or any of its attributes might be missing from JSON reply for GET_TREE request.