### PR TITLE
configure.ac: test for iconv_open with #include <iconv.h>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,8 +84,11 @@ AC_SEARCH_LIBS([ev_run], [ev], , [AC_MSG_FAILURE([cannot find the required ev_ru
 
 AC_SEARCH_LIBS([shm_open], [rt], [], [], [-pthread])
 
-AC_SEARCH_LIBS([iconv_open], [iconv], ,
-AC_SEARCH_LIBS([libiconv_open], [iconv], , [AC_MSG_FAILURE([cannot find the required iconv_open() function despite trying to link with -liconv])]))
+AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <iconv.h>], [iconv_open(0, 0)])], ,
+  [LIBS="-liconv $LIBS"
+   AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <iconv.h>], [iconv_open(0, 0)])], ,
+     [AC_MSG_FAILURE([cannot find the required iconv_open() function despite trying to link with -liconv])])]
+)
 
 AX_PTHREAD
 


### PR DESCRIPTION
The previously used AC_SEARCH_LIBS uses AC_LANG_CALL, which is discouraged
because it intentionally violates the C type system: it has no way of specifying
function parameters, so it does not include the required headers to suppress
type warnings:
https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Generating-Sources.html

The new code does what AC_SEARCH_LIBS does, but uses AC_LANG_PROGRAM instead of
AC_LANG_CALL. It explicitly includes iconv.h and calls iconv_open with the
correct number and type of arguments.

This fixes compilation on systems where libiconv’s iconv.h is discovered first,
but glibc also provides iconv. Previously, this would result in configure
discovering glibc’s iconv, and make failing to compile because -liconv wasn’t
specified, but iconv.h pulled in libiconv.