### PR TITLE
Prepend "exec " to default i3bar_command

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1008,7 +1008,7 @@ int main(int argc, char *argv[]) {
     TAILQ_FOREACH(barconfig, &barconfigs, configs) {
         char *command = NULL;
         sasprintf(&command, "%s %s --bar_id=%s --socket=\"%s\"",
-                  barconfig->i3bar_command ? barconfig->i3bar_command : "i3bar",
+                  barconfig->i3bar_command ? barconfig->i3bar_command : "exec i3bar",
                   barconfig->verbose ? "-V" : "",
                   barconfig->id, current_socketpath);
         LOG("Starting bar process: %s\n", command);


### PR DESCRIPTION
Avoids leaving around a useless shell process.

Closes #3925.