### PR TITLE
Use OVER operator for drawing text

### DIFF
--- a/libi3/font.c
+++ b/libi3/font.c
@@ -105,7 +105,7 @@ static void draw_text_pango(const char *text, size_t text_len,
         pango_layout_set_text(layout, text, text_len);
 
     /* Do the drawing */
-    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+    cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
     cairo_set_source_rgb(cr, pango_font_red, pango_font_green, pango_font_blue);
     pango_cairo_update_layout(cr, layout);
     pango_layout_get_pixel_size(layout, NULL, &height);


### PR DESCRIPTION
Bring back commit 16160462a30f186f5b72bb551ba2188670d4e45c which is reverted by commit eba177342f00ee6efdc3eff05665f317e1a837ca.

Advantages of OVER over SOURCE:

* Subpixel font rendering (#3604).
* No transparent garbage around color emoji characters.

---

See https://github.com/i3/i3/pull/2925#issuecomment-556411728

**Renders**:
[before.png](https://user-images.githubusercontent.com/5121426/74693396-9fe17380-51e3-11ea-9037-2393d8a0b86a.png)
[after.png](https://user-images.githubusercontent.com/5121426/74693395-9d7f1980-51e3-11ea-8619-d79028cd6b23.png)

Fixes #3604 