### PR TITLE
Sanitize window dimensions and handle decoration overlap

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -65,6 +65,7 @@ bool rect_contains(Rect rect, uint32_t x, uint32_t y);
 Rect rect_add(Rect a, Rect b);
 Rect rect_sub(Rect a, Rect b);
 bool rect_equals(Rect a, Rect b);
+Rect rect_sanitize_dimensions(Rect rect);
 
 /**
  * Returns true if the name consists of only digits.

--- a/src/click.c
+++ b/src/click.c
@@ -361,7 +361,7 @@ int handle_button_press(xcb_button_press_event_t *event) {
 
     /* Check if the click was on the decoration of a child */
     Con *child;
-    TAILQ_FOREACH (child, &(con->nodes_head), nodes) {
+    TAILQ_FOREACH_REVERSE (child, &(con->nodes_head), nodes_head, nodes) {
         if (!rect_contains(child->deco_rect, event->event_x, event->event_y))
             continue;
 

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -160,7 +160,7 @@ static void handle_enter_notify(xcb_enter_notify_event_t *event) {
     layout_t layout = (enter_child ? con->parent->layout : con->layout);
     if (layout == L_DEFAULT) {
         Con *child;
-        TAILQ_FOREACH (child, &(con->nodes_head), nodes) {
+        TAILQ_FOREACH_REVERSE (child, &(con->nodes_head), nodes_head, nodes) {
             if (rect_contains(child->deco_rect, event->event_x, event->event_y)) {
                 LOG("using child %p / %s instead!\n", child, child->name);
                 con = child;
@@ -217,7 +217,7 @@ static void handle_motion_notify(xcb_motion_notify_event_t *event) {
 
     /* see over which rect the user is */
     Con *current;
-    TAILQ_FOREACH (current, &(con->nodes_head), nodes) {
+    TAILQ_FOREACH_REVERSE (current, &(con->nodes_head), nodes_head, nodes) {
         if (!rect_contains(current->deco_rect, event->event_x, event->event_y))
             continue;
 

--- a/src/render.c
+++ b/src/render.c
@@ -64,6 +64,8 @@ void render_con(Con *con) {
         inset->width -= (2 * con->border_width);
         inset->height -= (2 * con->border_width);
 
+        *inset = rect_sanitize_dimensions(*inset);
+
         /* NB: We used to respect resize increment size hints for tiling
          * windows up until commit 0db93d9 here. However, since all terminal
          * emulators cope with ignoring the size hints in a better way than we
@@ -120,6 +122,8 @@ void render_con(Con *con) {
             } else if (con->layout == L_DOCKAREA) {
                 render_con_dockarea(con, child, &params);
             }
+
+            child->rect = rect_sanitize_dimensions(child->rect);
 
             DLOG("child at (%d, %d) with (%d x %d)\n",
                  child->rect.x, child->rect.y, child->rect.width, child->rect.height);

--- a/src/util.c
+++ b/src/util.c
@@ -53,6 +53,12 @@ Rect rect_sub(Rect a, Rect b) {
                   a.height - b.height};
 }
 
+Rect rect_sanitize_dimensions(Rect rect) {
+    rect.width = (int32_t)rect.width <= 0 ? 1 : rect.width;
+    rect.height = (int32_t)rect.height <= 0 ? 1 : rect.height;
+    return rect;
+}
+
 bool rect_equals(Rect a, Rect b) {
     return a.x == b.x && a.y == b.y && a.width == b.width && a.height == b.height;
 }


### PR DESCRIPTION
This branch is based on #3948, so it should be merged after. Although it is ready for review (check last two commits).

### To reproduce the bug
1. Disable compositor.
2. Open a few windows in split mode.
3. Shrink all of them except the last one. It should look [like this](https://user-images.githubusercontent.com/5121426/74793594-b1e11600-52b8-11ea-915f-83b20b20a4dd.png) (this is still a split layout, not stack).

#### Old behavior
[screenshot](https://user-images.githubusercontent.com/5121426/74794580-801d7e80-52bb-11ea-87b9-a9ebb791e06b.png)
* Glitched window decorations (both rendering and mouse event handling).
* Some apps (like gnome-terminal) may become unresponsive.

#### New behavior
[screenshot](https://user-images.githubusercontent.com/5121426/74793595-b4437000-52b8-11ea-81a3-b7f0e5bbb3b4.png)