### PR TITLE
Assume xcb_cursor_context_new never fails

### DIFF
--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -38,10 +38,6 @@ xcb_visualtype_t *visual_type = NULL;
 
 #include "i3-nagbar.h"
 
-/** This is the equivalent of XC_left_ptr. I’m not sure why xcb doesn’t have a
- * constant for that. */
-#define XCB_CURSOR_LEFT_PTR 68
-
 #define MSG_PADDING logical_px(8)
 #define BTN_PADDING logical_px(3)
 #define BTN_BORDER logical_px(3)
@@ -469,24 +465,12 @@ int main(int argc, char *argv[]) {
 
     xcb_rectangle_t win_pos = get_window_position();
 
-    xcb_cursor_t cursor;
     xcb_cursor_context_t *cursor_ctx;
-    if (xcb_cursor_context_new(conn, root_screen, &cursor_ctx) == 0) {
-        cursor = xcb_cursor_load_cursor(cursor_ctx, "left_ptr");
-        xcb_cursor_context_free(cursor_ctx);
-    } else {
-        cursor = xcb_generate_id(conn);
-        i3Font cursor_font = load_font("cursor", false);
-        xcb_create_glyph_cursor(
-            conn,
-            cursor,
-            cursor_font.specific.xcb.id,
-            cursor_font.specific.xcb.id,
-            XCB_CURSOR_LEFT_PTR,
-            XCB_CURSOR_LEFT_PTR + 1,
-            0, 0, 0,
-            65535, 65535, 65535);
+    if (xcb_cursor_context_new(conn, root_screen, &cursor_ctx) < 0) {
+        errx(EXIT_FAILURE, "Cannot allocate xcursor context");
     }
+    xcb_cursor_t cursor = xcb_cursor_load_cursor(cursor_ctx, "left_ptr");
+    xcb_cursor_context_free(cursor_ctx);
 
     /* Open an input window */
     win = xcb_generate_id(conn);

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -36,10 +36,6 @@
 
 #include "libi3.h"
 
-/** This is the equivalent of XC_left_ptr. I’m not sure why xcb doesn’t have a
- * constant for that. */
-#define XCB_CURSOR_LEFT_PTR 68
-
 /* We save the atoms in an easy to access array, indexed by an enum */
 enum {
 #define ATOM_DO(name) name,
@@ -1305,22 +1301,11 @@ char *init_xcb_early(void) {
     }
 
     xcb_cursor_context_t *cursor_ctx;
-    if (xcb_cursor_context_new(conn, root_screen, &cursor_ctx) == 0) {
-        cursor = xcb_cursor_load_cursor(cursor_ctx, "left_ptr");
-        xcb_cursor_context_free(cursor_ctx);
-    } else {
-        cursor = xcb_generate_id(xcb_connection);
-        i3Font cursor_font = load_font("cursor", false);
-        xcb_create_glyph_cursor(
-            xcb_connection,
-            cursor,
-            cursor_font.specific.xcb.id,
-            cursor_font.specific.xcb.id,
-            XCB_CURSOR_LEFT_PTR,
-            XCB_CURSOR_LEFT_PTR + 1,
-            0, 0, 0,
-            65535, 65535, 65535);
+    if (xcb_cursor_context_new(conn, root_screen, &cursor_ctx) < 0) {
+        errx(EXIT_FAILURE, "Cannot allocate xcursor context");
     }
+    cursor = xcb_cursor_load_cursor(cursor_ctx, "left_ptr");
+    xcb_cursor_context_free(cursor_ctx);
 
     /* The various watchers to communicate with xcb */
     xcb_io = smalloc(sizeof(ev_io));

--- a/include/i3.h
+++ b/include/i3.h
@@ -71,7 +71,7 @@ extern uint8_t root_depth;
 extern xcb_visualid_t visual_id;
 extern xcb_colormap_t colormap;
 
-extern bool xcursor_supported, xkb_supported, shape_supported;
+extern bool xkb_supported, shape_supported;
 extern xcb_window_t root;
 extern struct ev_loop *main_loop;
 extern bool only_check_config;

--- a/include/xcb.h
+++ b/include/xcb.h
@@ -18,13 +18,6 @@
 #define _NET_WM_STATE_ADD 1
 #define _NET_WM_STATE_TOGGLE 2
 
-/** This is the equivalent of XC_left_ptr. I’m not sure why xcb doesn’t have a
- * constant for that. */
-#define XCB_CURSOR_LEFT_PTR 68
-#define XCB_CURSOR_SB_H_DOUBLE_ARROW 108
-#define XCB_CURSOR_SB_V_DOUBLE_ARROW 116
-#define XCB_CURSOR_WATCH 150
-
 /* from X11/keysymdef.h */
 #define XCB_NUM_LOCK 0xff7f
 
@@ -100,14 +93,6 @@ xcb_atom_t xcb_get_preferred_window_type(xcb_get_property_reply_t *reply);
  *
  */
 bool xcb_reply_contains_atom(xcb_get_property_reply_t *prop, xcb_atom_t atom);
-
-/**
- * Set the cursor of the root window to the given cursor id.
- * This function should only be used if xcursor_supported == false.
- * Otherwise, use xcursor_set_root_cursor().
- *
- */
-void xcb_set_root_cursor(int cursor);
 
 /**
  * Get depth of visual specified by visualid

--- a/include/xcursor.h
+++ b/include/xcursor.h
@@ -28,7 +28,6 @@ enum xcursor_cursor_t {
 
 void xcursor_load_cursors(void);
 xcb_cursor_t xcursor_get_cursor(enum xcursor_cursor_t c);
-int xcursor_get_xcb_cursor(enum xcursor_cursor_t c);
 
 /**
  * Sets the cursor of the root window to the 'pointer' cursor.

--- a/src/drag.c
+++ b/src/drag.c
@@ -175,7 +175,7 @@ drag_result_t drag_pointer(Con *con, const xcb_button_press_event_t *event,
                            xcb_window_t confine_to, int cursor,
                            bool use_threshold, callback_t callback,
                            const void *extra) {
-    xcb_cursor_t xcursor = (cursor && xcursor_supported) ? xcursor_get_cursor(cursor) : XCB_NONE;
+    xcb_cursor_t xcursor = cursor ? xcursor_get_cursor(cursor) : XCB_NONE;
 
     /* Grab the pointer */
     xcb_grab_pointer_cookie_t cookie;

--- a/src/main.c
+++ b/src/main.c
@@ -87,7 +87,6 @@ struct assignments_head assignments = TAILQ_HEAD_INITIALIZER(assignments);
 struct ws_assignments_head ws_assignments = TAILQ_HEAD_INITIALIZER(ws_assignments);
 
 /* We hope that those are supported and set them to true */
-bool xcursor_supported = true;
 bool xkb_supported = true;
 bool shape_supported = true;
 
@@ -641,10 +640,7 @@ int main(int argc, char *argv[]) {
 
     /* Set a cursor for the root window (otherwise the root window will show no
        cursor until the first client is launched). */
-    if (xcursor_supported)
-        xcursor_set_root_cursor(XCURSOR_CURSOR_POINTER);
-    else
-        xcb_set_root_cursor(XCURSOR_CURSOR_POINTER);
+    xcursor_set_root_cursor(XCURSOR_CURSOR_POINTER);
 
     const xcb_query_extension_reply_t *extreply;
     xcb_prefetch_extension_data(conn, &xcb_xkb_id);

--- a/src/startup.c
+++ b/src/startup.c
@@ -201,10 +201,7 @@ void start_application(const char *command, bool no_startup_id) {
 
     if (!no_startup_id) {
         /* Change the pointer of the root window to indicate progress */
-        if (xcursor_supported)
-            xcursor_set_root_cursor(XCURSOR_CURSOR_WATCH);
-        else
-            xcb_set_root_cursor(XCURSOR_CURSOR_WATCH);
+        xcursor_set_root_cursor(XCURSOR_CURSOR_WATCH);
     }
 }
 
@@ -246,10 +243,7 @@ void startup_monitor_event(SnMonitorEvent *event, void *userdata) {
             if (_prune_startup_sequences() == 0) {
                 DLOG("No more startup sequences running, changing root window cursor to default pointer.\n");
                 /* Change the pointer of the root window to indicate progress */
-                if (xcursor_supported)
-                    xcursor_set_root_cursor(XCURSOR_CURSOR_POINTER);
-                else
-                    xcb_set_root_cursor(XCURSOR_CURSOR_POINTER);
+                xcursor_set_root_cursor(XCURSOR_CURSOR_POINTER);
             }
             break;
         default:

--- a/src/xcb.c
+++ b/src/xcb.c
@@ -45,20 +45,8 @@ xcb_window_t create_window(xcb_connection_t *conn, Rect dims,
     }
 
     /* Set the cursor */
-    if (xcursor_supported) {
-        mask = XCB_CW_CURSOR;
-        values[0] = xcursor_get_cursor(cursor);
-        xcb_change_window_attributes(conn, result, mask, values);
-    } else {
-        xcb_cursor_t cursor_id = xcb_generate_id(conn);
-        i3Font cursor_font = load_font("cursor", false);
-        int xcb_cursor = xcursor_get_xcb_cursor(cursor);
-        xcb_create_glyph_cursor(conn, cursor_id, cursor_font.specific.xcb.id,
-                                cursor_font.specific.xcb.id, xcb_cursor, xcb_cursor + 1, 0, 0, 0,
-                                65535, 65535, 65535);
-        xcb_change_window_attributes(conn, result, XCB_CW_CURSOR, &cursor_id);
-        xcb_free_cursor(conn, cursor_id);
-    }
+    uint32_t cursor_values[] = {xcursor_get_cursor(cursor)};
+    xcb_change_window_attributes(conn, result, XCB_CW_CURSOR, cursor_values);
 
     /* Map the window (= make it visible) */
     if (map)
@@ -173,24 +161,6 @@ bool xcb_reply_contains_atom(xcb_get_property_reply_t *prop, xcb_atom_t atom) {
             return true;
 
     return false;
-}
-
-/*
- * Set the cursor of the root window to the given cursor id.
- * This function should only be used if xcursor_supported == false.
- * Otherwise, use xcursor_set_root_cursor().
- *
- */
-void xcb_set_root_cursor(int cursor) {
-    xcb_cursor_t cursor_id = xcb_generate_id(conn);
-    i3Font cursor_font = load_font("cursor", false);
-    int xcb_cursor = xcursor_get_xcb_cursor(cursor);
-    xcb_create_glyph_cursor(conn, cursor_id, cursor_font.specific.xcb.id,
-                            cursor_font.specific.xcb.id, xcb_cursor, xcb_cursor + 1, 0, 0, 0,
-                            65535, 65535, 65535);
-    xcb_change_window_attributes(conn, root, XCB_CW_CURSOR, &cursor_id);
-    xcb_free_cursor(conn, cursor_id);
-    xcb_flush(conn);
 }
 
 /*

--- a/src/xcursor.c
+++ b/src/xcursor.c
@@ -10,6 +10,7 @@
 #include <config.h>
 
 #include <assert.h>
+#include <err.h>
 #include <xcb/xcb_cursor.h>
 
 #include "i3.h"
@@ -19,17 +20,9 @@
 static xcb_cursor_context_t *ctx;
 static xcb_cursor_t cursors[XCURSOR_CURSOR_MAX];
 
-static const int xcb_cursors[XCURSOR_CURSOR_MAX] = {
-    XCB_CURSOR_LEFT_PTR,
-    XCB_CURSOR_SB_H_DOUBLE_ARROW,
-    XCB_CURSOR_SB_V_DOUBLE_ARROW,
-    XCB_CURSOR_WATCH};
-
 void xcursor_load_cursors(void) {
     if (xcb_cursor_context_new(conn, root_screen, &ctx) < 0) {
-        ELOG("xcursor support unavailable\n");
-        xcursor_supported = false;
-        return;
+        errx(EXIT_FAILURE, "Cannot allocate xcursor context");
     }
 #define LOAD_CURSOR(constant, name)                            \
     do {                                                       \
@@ -62,9 +55,4 @@ void xcursor_set_root_cursor(int cursor_id) {
 xcb_cursor_t xcursor_get_cursor(enum xcursor_cursor_t c) {
     assert(c < XCURSOR_CURSOR_MAX);
     return cursors[c];
-}
-
-int xcursor_get_xcb_cursor(enum xcursor_cursor_t c) {
-    assert(c < XCURSOR_CURSOR_MAX);
-    return xcb_cursors[c];
 }


### PR DESCRIPTION
As I can see in `libxcb-cursor` code, the only way of `xcb_cursor_context_new()` returning non-zero is memory allocation failure ([src]); and `libxcb-cursor` already [falls back to `xcb_create_glyph_cursor`](https://gitlab.freedesktop.org/xorg/lib/libxcb-cursor/blob/0.1.3/cursor/load_cursor.c#L214) if it can't load the cursor.

Can we just assume that `xcursor_supported` is always true, and refactor out places [like this](https://github.com/i3/i3/blob/4.18/src/xcb.c#L47-L61)?

[src]: https://gitlab.freedesktop.org/xorg/lib/libxcb-cursor/blob/0.1.3/cursor/cursor.c#L131-132
