### PR TITLE
Remove comment referencing old source code

### DIFF
--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -104,10 +104,6 @@ void debuglog(char *fmt, ...) {
  * fork to avoid zombie processes. As the started application’s parent exits
  * (immediately), the application is reparented to init (process-id 1), which
  * correctly handles children, so we don’t have to do it :-).
- *
- * The shell is determined by looking for the SHELL environment variable. If it
- * does not exist, /bin/sh is used.
- *
  */
 static void start_application(const char *command) {
     printf("executing: %s\n", command);

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -528,7 +528,7 @@ static void child_write_output(void) {
 
 /*
  * Start a child process with the specified command and reroute stdin.
- * We actually start a $SHELL to execute the command so we don't have to care
+ * We actually start a shell to execute the command so we don't have to care
  * about arguments and such.
  *
  * If `command' is NULL, such as in the case when no `status_command' is given


### PR DESCRIPTION
Behaviour was changed in f691a55923850a4d315450925fc98733d07b69c9, so the comment is invalid.