### PR TITLE
i3-nagbar: Use _PATH_BSHELL

### DIFF
--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -353,7 +353,7 @@ int main(int argc, char *argv[]) {
         unlink(argv[0]);
         cmd = sstrdup(argv[0]);
         *(cmd + argv0_len - strlen(".nagbar_cmd")) = '\0';
-        execl("/bin/sh", "/bin/sh", cmd, NULL);
+        execl(_PATH_BSHELL, _PATH_BSHELL, cmd, NULL);
         err(EXIT_FAILURE, "execv(/bin/sh, /bin/sh, %s)", cmd);
     }
 


### PR DESCRIPTION
It seems like this may have been forgotten in f691a55923850a4d315450925fc98733d07b69c9