### PR TITLE
refresh tree and update WM on workspace moving to output

### DIFF
--- a/src/workspace.c
+++ b/src/workspace.c
@@ -1044,6 +1044,9 @@ void workspace_move_to_output(Con *ws, Output *output) {
         workspace_show(ws);
     }
 
+    tree_flatten(croot);
+    ewmh_update_wm_desktop();
+
     if (!previously_visible_ws) {
         return;
     }


### PR DESCRIPTION
There was a problem while using multi-head setup with 2 monitors (via intel-virtual-output). Focusing a workspace going crazy after moving workspace to that virtual output. A wrong workspace was focused instead of. Commands like these were used ```wmctrl -a 'HttpRequester'```, ```jumpapp -i Chromium /usr/bin/chromium```