### PR TITLE
implementation for bisect command

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -159,6 +159,12 @@ void cmd_floating(I3_CMD, const char *floating_mode);
 void cmd_move_workspace_to_output(I3_CMD, const char *name);
 
 /**
+ * Implementation of 'bisect v|h|vertical|horizontal'.
+ *
+ */
+void cmd_bisect(I3_CMD, const char *direction);
+
+/**
  * Implementation of 'split v|h|t|vertical|horizontal|toggle'.
  *
  */

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -30,6 +30,7 @@ state INITIAL:
   'open' -> call cmd_open()
   'fullscreen' -> FULLSCREEN
   'sticky' -> STICKY
+  'bisect' -> BISECT
   'split' -> SPLIT
   'floating' -> FLOATING
   'mark' -> MARK
@@ -206,6 +207,11 @@ state STICKY:
 state SPLIT:
   direction = 'horizontal', 'vertical', 'toggle', 'v', 'h', 't'
       -> call cmd_split($direction)
+
+# bisect v|h|vertical|horizontal
+state BISECT:
+  direction = 'horizontal', 'vertical', 'v', 'h'
+      -> call cmd_bisect($direction)
 
 # floating enable|disable|toggle
 state FLOATING:

--- a/testcases/t/187-commands-parser.t
+++ b/testcases/t/187-commands-parser.t
@@ -161,6 +161,7 @@ is(parser_calls('unknown_literal'),
        open
        fullscreen
        sticky
+       bisect
        split
        floating
        mark


### PR DESCRIPTION
bisect horizontal | vertical | h | v

takes a tabbed/stacked container, splits its currently-used space into
two new tabbed/stacked containers, puts currently-focused window in one
of them, the other windows in the other one.