### PR TITLE
Call cont_child() more liberally

### DIFF
--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -673,9 +673,6 @@ static void handle_visibility_notify(xcb_visibility_notify_event_t *event) {
             continue;
         }
         if (output->bar.id == event->window) {
-            if (output->visible == visible) {
-                return;
-            }
             output->visible = visible;
         }
         num_visible += output->visible;
@@ -683,10 +680,7 @@ static void handle_visibility_notify(xcb_visibility_notify_event_t *event) {
 
     if (num_visible == 0) {
         stop_child();
-    } else if (num_visible == visible) {
-        /* Wake the child only when transitioning from 0 to 1 visible bar.
-         * We cannot transition from 0 to 2 or more visible bars at once since
-         * visibility events are delivered to each window separately */
+    } else {
         cont_child();
     }
 }


### PR DESCRIPTION
Following the reproduction instructions from
https://github.com/i3/i3/issues/3242#issuecomment-436175346

For me, #3242 happened when the following sequence executed:
1. Fullscreening window correctly calls `stop_child()` in
https://github.com/i3/i3/blob/6e24e2ad6f4b1e32cfa27805a3a948d0de50f3b1/i3bar/src/xcb.c#L685
2. Xrandr change, `reconfig_windows()` is called and `output->visible` is
set to `true` in this line:
https://github.com/i3/i3/blob/6e24e2ad6f4b1e32cfa27805a3a948d0de50f3b1/i3bar/src/xcb.c#L1791
3. When the window's fullscreen is disabled,
`handle_visibility_notify()` returns in this line:
https://github.com/i3/i3/blob/6e24e2ad6f4b1e32cfa27805a3a948d0de50f3b1/i3bar/src/xcb.c#L677
because previously `output->visible` was set to `true`

To fix this, I call `cont_child()` more leniently since it is a no-op
when the child is not stopped.

Fixes #3242
Closes #3761