### PR TITLE
x_draw_decoration: always clear parent pixmap when rendering the first child

### DIFF
--- a/src/x.c
+++ b/src/x.c
@@ -590,11 +590,6 @@ void x_draw_decoration(Con *con) {
         }
     }
 
-    /* if this is a borderless/1pixel window, we don’t need to render the
-     * decoration. */
-    if (p->border_style != BS_NORMAL)
-        goto copy_pixmaps;
-
     /* If the parent hasn't been set up yet, skip the decoration rendering
      * for now. */
     if (parent->frame_buffer.id == XCB_NONE)
@@ -607,6 +602,11 @@ void x_draw_decoration(Con *con) {
         draw_util_clear_surface(&(con->parent->frame_buffer), COLOR_TRANSPARENT);
         FREE(con->parent->deco_render_params);
     }
+
+    /* if this is a borderless/1pixel window, we don’t need to render the
+     * decoration. */
+    if (p->border_style != BS_NORMAL)
+        goto copy_pixmaps;
 
     /* 4: paint the bar */
     draw_util_rectangle(&(parent->frame_buffer), p->color->background,


### PR DESCRIPTION
See the commit message.

## Steps to reproduce:

1. Enable transparent borders and titlebars, and use a compositor.

2. Make this layout: `H[x V[a b]]`
  * `a` is 32-bit window, has `border pixel 50`
  * `b` has `border normal 50`

3. Resize `a` (top right window) and see visual garbage in the background.

![2020-04-18_04:18:09](https://user-images.githubusercontent.com/5121426/79628367-e265f480-812f-11ea-88ca-d320f7080a61.png)
