### PR TITLE
contrib: Add auto-mark script

### DIFF
--- a/contrib/auto-mark
+++ b/contrib/auto-mark
@@ -1,0 +1,29 @@
+#!/bin/sh -e
+scope=$1
+shift 2>&- ||:
+automarks=${*:-a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I J K L M N O P Q R S T U V W X Y Z}
+
+i3-msg -t get_tree \
+| jq \
+--arg scope "$scope" \
+--arg v0 "${0##*/}" \
+--argjson workspace "$(i3-msg -t get_workspaces | jq '.[]|select(.focused)|.id')" \
+--arg automarks "$automarks" \
+-r '
+[
+	[if $scope == "workspace" then
+		..|select(.id? == $workspace)|
+		..|select(.window? and .name and .floating != "user_on" and (.marks | length) == 0)|
+		"[id=\(.window)]"
+	elif $scope == "" or $scope == "window" then
+		"[]"
+	else
+		"Usage: \($v0) {workspace|window} [MARK...]\n"|halt_error(1)
+	end],
+	[([..|.marks?|select(.)]|flatten) as $winmarks |
+	$automarks|split(" ")|.[]|select(IN($winmarks[])|not)]
+]|transpose|map("\(.[0] // empty) mark \(.[1] // empty)")|join(";")
+' | {
+	read -r msg
+	i3-msg "$msg" >&-
+}


### PR DESCRIPTION
For lightning fast navigation between windows, one can use marks. It can
be orders of magnitude faster than stepping through intermediate windows
and workspaces to reach target window.

However, marking (ad-hoc) windows manually is tedious, so this script is
here to automatize this task.

---

I just would like to share this scriptlet, maybe someone will find it useful. If you do not like it just close the PR.
