### PR TITLE
Fix #ifndef statements: HAVE_ variables are all upper case

### DIFF
--- a/include/libi3.h
+++ b/include/libi3.h
@@ -347,7 +347,7 @@ gchar *g_utf8_make_valid(const gchar *str, gssize len);
  */
 uint32_t get_colorpixel(const char *hex) __attribute__((const));
 
-#ifndef HAVE_strndup
+#ifndef HAVE_STRNDUP
 /**
  * Taken from FreeBSD
  * Returns a pointer to a new string which is a duplicate of the
@@ -532,7 +532,7 @@ char *resolve_tilde(const char *path);
  */
 char *get_config_path(const char *override_configpath, bool use_system_paths);
 
-#ifndef HAVE_mkdirp
+#ifndef HAVE_MKDIRP
 /**
  * Emulates mkdir -p (creates any missing folders)
  *

--- a/libi3/mkdirp.c
+++ b/libi3/mkdirp.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <sys/stat.h>
 
-#ifndef HAVE_mkdirp
+#ifndef HAVE_MKDIRP
 /*
  * Emulates mkdir -p (creates any missing folders)
  *

--- a/libi3/strndup.c
+++ b/libi3/strndup.c
@@ -9,7 +9,7 @@
 
 #include <string.h>
 
-#ifndef HAVE_strndup
+#ifndef HAVE_STRNDUP
 /*
  * Taken from FreeBSD
  * Returns a pointer to a new string which is a duplicate of the


### PR DESCRIPTION
The autoconf manual states:

   define HAVE_function (in all capitals) if it is available

https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Generic-Functions.html#Generic-Functions