### PR TITLE
randr_query_outputs: call ewmh_update_desktop_properties

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -33,3 +33,4 @@ strongly encouraged to upgrade.
   • i3-dmenu-desktop: Support symlinks in search path
   • build: correctly provide auxiliary functions when needed
   • build: fix issues with parallel build
+  • set _NET_DESKTOP_VIEWPORT after randr changes

--- a/src/randr.c
+++ b/src/randr.c
@@ -1023,6 +1023,7 @@ void randr_query_outputs(void) {
     }
 
     /* render_layout flushes */
+    ewmh_update_desktop_properties();
     tree_render();
 
     FREE(primary);


### PR DESCRIPTION
Fixes #4053

At this point, we might be better off if we put `ewmh_update_desktop_properties` in `tree_render`. We had quite a few bug reports related to this one.