### PR TITLE
etc/config: don't focus notifications in default config

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -192,6 +192,8 @@ bar {
         status_command i3status
 }
 
+no_focus [window_type="notification"]
+
 #######################################################################
 # automatically start i3-config-wizard to offer the user to create a
 # keysym-based config which used their favorite modifier (alt or windows)


### PR DESCRIPTION
People usually don't want notifications to take focus, because that introduces lots of problems *(cursor moves as someone recently reported, transparency goes to the wrong window, keyboard layout suddenly changes…)*.

While the correct way to fix that would probably be in a core, but I figured it gonna bring many discussions about changing default behavior, and then someone has to do the job, etc… I figured adding the `no_focus` switch for notifications in the default configuration should be a good compromise.