### PR TITLE
Makefile.am: make sure i3-config-wizard depends on libi3.a

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -442,7 +442,8 @@ i3_config_wizard_i3_config_wizard_SOURCES = \
 	i3-config-wizard/xcb.h
 
 i3_config_wizard_i3_config_wizard_DEPENDENCIES = \
-	$(config_parser_SOURCES)
+	$(config_parser_SOURCES) \
+	$(top_builddir)/libi3.a
 
 test_inject_randr15_CPPFLAGS = \
 	$(AM_CPPFLAGS)


### PR DESCRIPTION
i3-config-wizard uses libi3.a as part of its build process. When
parallel build is enabled, build of i3-config-wizard may start before
libi3.a finished building. Fix this by adding dependency on libi3.a

Fixes: #4020