### PR TITLE
get_output_by_name: guard output->primary with require_active

### DIFF
--- a/src/randr.c
+++ b/src/randr.c
@@ -51,11 +51,11 @@ Output *get_output_by_name(const char *name, const bool require_active) {
     Output *output;
     bool get_primary = (strcasecmp("primary", name) == 0);
     TAILQ_FOREACH (output, &outputs, outputs) {
-        if (output->primary && get_primary) {
-            return output;
-        }
         if (require_active && !output->active) {
             continue;
+        }
+        if (output->primary && get_primary) {
+            return output;
         }
         struct output_name *output_name;
         SLIST_FOREACH (output_name, &output->names_head, names) {


### PR DESCRIPTION
This is related to #4048 but might not fix it completely. Either way, this should be the correct behaviour of the function.