### PR TITLE
autotools: place binaries in top level of build dir, not in subdirs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,12 +5,12 @@ echo-version:
 
 bin_PROGRAMS = \
 	i3 \
-	i3bar/i3bar \
-	i3-config-wizard/i3-config-wizard \
-	i3-dump-log/i3-dump-log \
-	i3-input/i3-input \
-	i3-msg/i3-msg \
-	i3-nagbar/i3-nagbar
+	i3bar \
+	i3-config-wizard \
+	i3-dump-log \
+	i3-input \
+	i3-msg \
+	i3-nagbar
 
 install-exec-hook:
 	$(LN_S) -f i3 $(DESTDIR)$(bindir)/i3-with-shmlog
@@ -331,61 +331,61 @@ libi3_a_SOURCES = \
 	libi3/strndup.c \
 	libi3/ucs2_conversion.c
 
-i3_dump_log_i3_dump_log_CFLAGS = \
+i3_dump_log_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(PTHREAD_CFLAGS) \
 	$(libi3_CFLAGS)
 
-i3_dump_log_i3_dump_log_LDADD = \
+i3_dump_log_LDADD = \
 	$(PTHREAD_LIBS) \
 	$(libi3_LIBS)
 
-i3_dump_log_i3_dump_log_SOURCES = \
+i3_dump_log_SOURCES = \
 	i3-dump-log/main.c
 
-i3_input_i3_input_CFLAGS = \
+i3_input_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(libi3_CFLAGS)
 
-i3_input_i3_input_LDADD = \
+i3_input_LDADD = \
 	$(libi3_LIBS) \
 	$(XCB_UTIL_KEYSYMS_LIBS)
 
-i3_input_i3_input_SOURCES = \
+i3_input_SOURCES = \
 	i3-input/i3-input.h \
 	i3-input/keysym2ucs.c \
 	i3-input/keysym2ucs.h \
 	i3-input/main.c
 
-i3_msg_i3_msg_CFLAGS = \
+i3_msg_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(libi3_CFLAGS)
 
-i3_msg_i3_msg_LDADD = \
+i3_msg_LDADD = \
 	$(libi3_LIBS)
 
-i3_msg_i3_msg_SOURCES = \
+i3_msg_SOURCES = \
 	i3-msg/main.c
 
-i3_nagbar_i3_nagbar_CFLAGS = \
+i3_nagbar_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(LIBSN_CFLAGS) \
 	$(libi3_CFLAGS)
 
-i3_nagbar_i3_nagbar_LDADD = \
+i3_nagbar_LDADD = \
 	$(libi3_LIBS) \
 	$(LIBSN_LIBS) \
 	$(XCB_UTIL_CURSOR_LIBS)
 
-i3_nagbar_i3_nagbar_SOURCES = \
+i3_nagbar_SOURCES = \
 	i3-nagbar/i3-nagbar-atoms.xmacro.h \
 	i3-nagbar/main.c
 
-i3bar_i3bar_CPPFLAGS = \
+i3bar_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	-I$(top_srcdir)/i3bar/include
 
-i3bar_i3bar_CFLAGS = \
+i3bar_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(libi3_CFLAGS) \
 	$(XCB_CFLAGS) \
@@ -393,7 +393,7 @@ i3bar_i3bar_CFLAGS = \
 	$(PANGOCAIRO_CFLAGS) \
 	$(YAJL_CFLAGS)
 
-i3bar_i3bar_LDADD = \
+i3bar_LDADD = \
 	$(libi3_LIBS) \
 	$(XCB_LIBS) \
 	$(XCB_UTIL_CURSOR_LIBS) \
@@ -401,7 +401,7 @@ i3bar_i3bar_LDADD = \
 	$(PANGOCAIRO_LIBS) \
 	$(YAJL_LIBS)
 
-i3bar_i3bar_SOURCES = \
+i3bar_SOURCES = \
 	i3bar/include/child.h \
 	i3bar/include/common.h \
 	i3bar/include/configuration.h \
@@ -424,24 +424,24 @@ i3bar_i3bar_SOURCES = \
 	i3bar/src/workspaces.c \
 	i3bar/src/xcb.c
 
-i3_config_wizard_i3_config_wizard_CFLAGS = \
+i3_config_wizard_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(libi3_CFLAGS) \
 	$(LIBSN_CFLAGS) \
 	$(XKBCOMMON_CFLAGS)
 
-i3_config_wizard_i3_config_wizard_LDADD = \
+i3_config_wizard_LDADD = \
 	$(libi3_LIBS) \
 	$(LIBSN_LIBS) \
 	$(XCB_UTIL_KEYSYMS_LIBS) \
 	$(XKBCOMMON_LIBS)
 
-i3_config_wizard_i3_config_wizard_SOURCES = \
+i3_config_wizard_SOURCES = \
 	i3-config-wizard/i3-config-wizard-atoms.xmacro.h \
 	i3-config-wizard/main.c \
 	i3-config-wizard/xcb.h
 
-i3_config_wizard_i3_config_wizard_DEPENDENCIES = \
+i3_config_wizard_DEPENDENCIES = \
 	$(top_builddir)/libi3.a
 
 test_inject_randr15_CPPFLAGS = \

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.69])
 AC_INIT([i3], [4.18.1], [https://github.com/i3/i3/issues])
 # For AX_EXTEND_SRCDIR
 AX_ENABLE_BUILDDIR
-AM_INIT_AUTOMAKE([foreign subdir-objects -Wall no-dist-gzip dist-bzip2])
+AM_INIT_AUTOMAKE([foreign -Wall no-dist-gzip dist-bzip2])
 # Default to silent rules, use V=1 to get verbose compilation output.
 AM_SILENT_RULES([yes])
 # Make it possible to disable maintainer mode to disable re-generation of build

--- a/testcases/complete-run.pl.in
+++ b/testcases/complete-run.pl.in
@@ -78,12 +78,12 @@ pod2usage(-verbose => 2, -exitcode => 0) if $help;
 # Check for missing executables
 my @binaries = qw(
                    @abs_top_builddir@/i3
-                   @abs_top_builddir@/i3bar/i3bar
-                   @abs_top_builddir@/i3-config-wizard/i3-config-wizard
-                   @abs_top_builddir@/i3-dump-log/i3-dump-log
-                   @abs_top_builddir@/i3-input/i3-input
-                   @abs_top_builddir@/i3-msg/i3-msg
-                   @abs_top_builddir@/i3-nagbar/i3-nagbar
+                   @abs_top_builddir@/i3bar
+                   @abs_top_builddir@/i3-config-wizard
+                   @abs_top_builddir@/i3-dump-log
+                   @abs_top_builddir@/i3-input
+                   @abs_top_builddir@/i3-msg
+                   @abs_top_builddir@/i3-nagbar
                );
 
 foreach my $binary (@binaries) {
@@ -103,12 +103,6 @@ foreach my $binary (@test_binaries) {
 }
 
 $ENV{PATH} = join(':',
-    '@abs_top_builddir@/i3-nagbar',
-    '@abs_top_builddir@/i3-msg',
-    '@abs_top_builddir@/i3-input',
-    '@abs_top_builddir@/i3-dump-log',
-    '@abs_top_builddir@/i3-config-wizard',
-    '@abs_top_builddir@/i3bar',
     '@abs_top_builddir@',
     '@abs_top_srcdir@',
     $ENV{PATH});

--- a/travis/check-spelling.pl
+++ b/travis/check-spelling.pl
@@ -33,12 +33,12 @@ my $binary_spelling_exceptions = {
 };
 my @binaries = qw(
     build/i3
-    build/i3-config-wizard/i3-config-wizard
-    build/i3-dump-log/i3-dump-log
-    build/i3-input/i3-input
-    build/i3-msg/i3-msg
-    build/i3-nagbar/i3-nagbar
-    build/i3bar/i3bar
+    build/i3-config-wizard
+    build/i3-dump-log
+    build/i3-input
+    build/i3-msg
+    build/i3-nagbar
+    build/i3bar
 );
 for my $binary (@binaries) {
     check_spelling(slurp($binary), $binary_spelling_exceptions, sub {


### PR DESCRIPTION
meson only supports the top level (no subdirs), so this makes the transition
easier.

For this to work with autotools, we need to *disable* the subdir-objects option,
that autotools wants us to enable for forward-compatibility.

This results in a bunch of warnings at autoreconf-time, but we don’t care, given
that we intend to switch away from autotools. Both build systems working next to
each other (as best as they can) is more important.

related to #4086