### PR TITLE
Add situational exit codes

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -26,7 +26,7 @@ working. Please reach out to us in that case!
     to their definition order in the config file
   • update i3bar config when necessary (reduces redraws on bar mode changes)
   • mention rofi in default config file
-  • i3-input: added different exit codes for when i3-input fails
+  • i3-input: add different exit codes for when i3-input fails
 
  ┌────────────────────────────┐
  │ Bugfixes                   │

--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -26,6 +26,7 @@ working. Please reach out to us in that case!
     to their definition order in the config file
   • update i3bar config when necessary (reduces redraws on bar mode changes)
   • mention rofi in default config file
+  • i3-input: added different exit codes for when i3-input fails
 
  ┌────────────────────────────┐
  │ Bugfixes                   │


### PR DESCRIPTION
Closes #3705.

I used `autoconfigure` to generate the `Makefile` and compile as specified in the instructions, but the generated binary seems to be a memory leak check wrapped around the actual executable so I can't test the exit codes. It seems there's a memory leak in one of the dependencies and whenever I run the executable, no matter what happens within `i3-input` I get the following output regarding the memory leaks and exit code 1.

How can I just run the newly compiled `i3-input` without the memory leak checker?

```
==417634==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 3840 byte(s) in 6 object(s) allocated from:
    #0 0x7fe22a0dbfa0 in __interceptor_realloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:163
    #1 0x7fe229315661  (/usr/lib/libfontconfig.so.1+0x21661)

Indirect leak of 7040 byte(s) in 220 object(s) allocated from:
    #0 0x7fe22a0dbb3a in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7fe229301780  (/usr/lib/libfontconfig.so.1+0xd780)

Indirect leak of 3635 byte(s) in 287 object(s) allocated from:
    #0 0x7fe22a0628e6 in __interceptor_strdup /build/gcc/src/gcc/libsanitizer/asan/asan_interceptors.cc:445
    #1 0x7fe229314e45 in FcValueSave (/usr/lib/libfontconfig.so.1+0x20e45)

Indirect leak of 3328 byte(s) in 104 object(s) allocated from:
    #0 0x7fe22a0dbd48 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:153
    #1 0x7fe229315c09  (/usr/lib/libfontconfig.so.1+0x21c09)

Indirect leak of 2304 byte(s) in 72 object(s) allocated from:
    #0 0x7fe22a0dbd48 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:153
    #1 0x7fe2293150d9  (/usr/lib/libfontconfig.so.1+0x210d9)

Indirect leak of 576 byte(s) in 18 object(s) allocated from:
    #0 0x7fe22a0dbd48 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:153
    #1 0x7fe229314f77  (/usr/lib/libfontconfig.so.1+0x20f77)

Indirect leak of 144 byte(s) in 3 object(s) allocated from:
    #0 0x7fe22a0dbb3a in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7fe22930f03e in FcLangSetCreate (/usr/lib/libfontconfig.so.1+0x1b03e)

SUMMARY: AddressSanitizer: 20867 byte(s) leaked in 710 allocation(s).
```