### PR TITLE
i3bar: improve docs for battery saving feature

### DIFF
--- a/docs/i3bar-protocol
+++ b/docs/i3bar-protocol
@@ -103,9 +103,11 @@ https://github.com/i3/i3/blob/next/contrib/trivial-bar-script.sh
 version::
 	The version number (as an integer) of the i3bar protocol you will use.
 stop_signal::
-	Specify to i3bar the signal (as an integer) to send to stop your
-	processing.
-	The default value (if none is specified) is SIGSTOP.
+	Specify the signal (as an integer) that i3bar should send to request that you
+	pause your output. This is used to conserve battery power when the bar is
+	hidden by not unnecessarily computing bar updates. The default value is SIGSTOP,
+	which will unconditionally stop your process. If this is an issue, this feature
+	can be disabled by setting the value to 0.
 cont_signal::
 	Specify to i3bar the signal (as an integer) to send to continue your
 	processing.

--- a/docs/userguide
+++ b/docs/userguide
@@ -1350,9 +1350,11 @@ mode). The modifier key can be configured using the +modifier+ option.
 The mode option can be changed during runtime through the +bar mode+ command.
 On reload the mode will be reverted to its configured value.
 
-The hide mode maximizes screen space that can be used for actual windows. Also,
-i3bar sends the +SIGSTOP+ and +SIGCONT+ signals to the statusline process to
-save battery power.
+The hide mode maximizes screen space that can be used for actual windows. When
+the bar is hidden, i3bar sends the +SIGSTOP+ and +SIGCONT+ signals to the
++status_command+ process in order to conserve battery power. This feature can
+be disabled by the +status_command+ process by setting the appropriate values
+in its JSON header message.
 
 Invisible mode allows to permanently maximize screen space, as the bar is never
 shown. Thus, you can configure i3bar to not disturb you by popping up because


### PR DESCRIPTION
Document that `stop_signal` can be set to `0` to disable the battery saving feature, as discussed in #4110.