### PR TITLE
i3bar: add support for nonprimary output

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -29,6 +29,7 @@ working. Please reach out to us in that case!
   • i3-input: add different exit codes for when i3-input fails
   • allow ppt values in move direction and move position commands
   • i3bar: add coordinates relative to the current output in i3bar click events
+  • i3bar: add “nonprimary” output option
 
  ┌────────────────────────────┐
  │ Bugfixes                   │

--- a/docs/userguide
+++ b/docs/userguide
@@ -1484,9 +1484,16 @@ options for different outputs by using multiple 'bar' blocks.
 To make a particular i3bar instance handle multiple outputs, specify the output
 directive multiple times.
 
+These output names have a special meaning:
+
+primary::
+    Selects the output that is configured as primary in the X server.
+nonprimary::
+    Selects every output that is not configured as primary in the X server.
+
 *Syntax*:
 ---------------
-output primary|<output>
+output primary|nonprimary|<output>
 ---------------
 
 *Example*:

--- a/i3bar/src/outputs.c
+++ b/i3bar/src/outputs.c
@@ -192,11 +192,12 @@ static int outputs_end_map_cb(void *params_) {
 
     /* See if we actually handle that output */
     if (config.num_outputs > 0) {
+        const bool is_primary = params->outputs_walk->primary;
         bool handle_output = false;
         for (int c = 0; c < config.num_outputs; c++) {
-            if (strcasecmp(params->outputs_walk->name, config.outputs[c]) == 0 ||
-                (strcasecmp(config.outputs[c], "primary") == 0 &&
-                 params->outputs_walk->primary)) {
+            if ((strcasecmp(params->outputs_walk->name, config.outputs[c]) == 0) ||
+                (strcasecmp(config.outputs[c], "primary") == 0 && is_primary) ||
+                (strcasecmp(config.outputs[c], "nonprimary") == 0 && !is_primary)) {
                 handle_output = true;
                 break;
             }


### PR DESCRIPTION
Adds support for a `nonprimary` output to i3bar. This is useful when configuring your bar using `primary`, as you can have one config for your main display and another for any additional display.

Fixes #4083