### PR TITLE
Allow splitting into any kind of layout

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -159,7 +159,7 @@ void cmd_floating(I3_CMD, const char *floating_mode);
 void cmd_move_workspace_to_output(I3_CMD, const char *name);
 
 /**
- * Implementation of 'split v|h|t|vertical|horizontal|toggle'.
+ * Implementation of 'split v|h|t|vertical|horizontal|toggle|tabbed|stacked|stacking'.
  *
  */
 void cmd_split(I3_CMD, const char *direction);

--- a/include/tree.h
+++ b/include/tree.h
@@ -33,11 +33,11 @@ void tree_init(xcb_get_geometry_reply_t *geometry);
 Con *tree_open_con(Con *con, i3Window *window);
 
 /**
- * Splits (horizontally or vertically) the given container by creating a new
+ * Splits (using the given layout) the given container by creating a new
  * container which contains the old one and the future ones.
  *
  */
-void tree_split(Con *con, orientation_t orientation);
+void tree_split(Con *con, layout_t layout);
 
 /**
  * Moves focus one level up. Returns true if focus changed.

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -202,9 +202,9 @@ state STICKY:
   action = 'enable', 'disable', 'toggle'
       -> call cmd_sticky($action)
 
-# split v|h|t|vertical|horizontal|toggle
+# split v|h|t|vertical|horizontal|toggle|tabbed|stacked|stacking
 state SPLIT:
-  direction = 'horizontal', 'vertical', 'toggle', 'v', 'h', 't'
+  direction = 'horizontal', 'vertical', 'toggle', 'tabbed', 'stacked', 'stacking', 'v', 'h', 't'
       -> call cmd_split($direction)
 
 # floating enable|disable|toggle

--- a/src/commands.c
+++ b/src/commands.c
@@ -1127,14 +1127,14 @@ void cmd_move_workspace_to_output(I3_CMD, const char *name) {
 }
 
 /*
- * Implementation of 'split v|h|t|vertical|horizontal|toggle'.
+ * Implementation of 'split v|h|t|vertical|horizontal|toggle|tabbed|stacked|stacking'.
  *
  */
 void cmd_split(I3_CMD, const char *direction) {
     HANDLE_EMPTY_MATCH;
 
     owindow *current;
-    LOG("splitting in direction %c\n", direction[0]);
+    LOG("splitting in direction %s\n", direction);
     TAILQ_FOREACH (current, &owindows, owindows) {
         if (con_is_docked(current->con)) {
             ELOG("Cannot split a docked container, skipping.\n");
@@ -1142,7 +1142,9 @@ void cmd_split(I3_CMD, const char *direction) {
         }
 
         DLOG("matching: %p / %s\n", current->con, current->con->name);
-        if (direction[0] == 't') {
+        if (strcmp(direction, "tabbed") == 0) {
+            tree_split(current->con, L_TABBED);
+        } else if (direction[0] == 't') {
             layout_t current_layout;
             if (current->con->type == CT_WORKSPACE) {
                 current_layout = current->con->layout;
@@ -1151,12 +1153,17 @@ void cmd_split(I3_CMD, const char *direction) {
             }
             /* toggling split orientation */
             if (current_layout == L_SPLITH) {
-                tree_split(current->con, VERT);
+                tree_split(current->con, L_SPLITV);
             } else {
-                tree_split(current->con, HORIZ);
+                tree_split(current->con, L_SPLITH);
             }
-        } else {
-            tree_split(current->con, (direction[0] == 'v' ? VERT : HORIZ));
+        } else if (direction[0] == 'v') {
+            tree_split(current->con, L_SPLITV);
+        } else if (direction[0] == 'h') {
+            tree_split(current->con, L_SPLITH);
+        } else if (strcmp(direction, "stacking") == 0 ||
+                   strcmp(direction, "stacked") == 0) {
+            tree_split(current->con, L_STACKED);
         }
     }
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -320,11 +320,11 @@ bool tree_close_internal(Con *con, kill_window_t kill_window, bool dont_kill_par
 }
 
 /*
- * Splits (horizontally or vertically) the given container by creating a new
+ * Splits (using the given layout) the given container by creating a new
  * container which contains the old one and the future ones.
  *
  */
-void tree_split(Con *con, orientation_t orientation) {
+void tree_split(Con *con, layout_t layout) {
     if (con_is_floating(con)) {
         DLOG("Floating containers can't be split.\n");
         return;
@@ -337,7 +337,7 @@ void tree_split(Con *con, orientation_t orientation) {
                 con->workspace_layout = L_DEFAULT;
             }
             DLOG("Changing orientation of workspace\n");
-            con->layout = (orientation == HORIZ) ? L_SPLITH : L_SPLITV;
+            con->layout = layout;
             return;
         } else {
             /* if there is more than one container on the workspace
@@ -354,22 +354,20 @@ void tree_split(Con *con, orientation_t orientation) {
     /* if we are in a container whose parent contains only one
      * child (its split functionality is unused so far), we just change the
      * orientation (more intuitive than splitting again) */
-    if (con_num_children(parent) == 1 &&
-        (parent->layout == L_SPLITH ||
-         parent->layout == L_SPLITV)) {
-        parent->layout = (orientation == HORIZ) ? L_SPLITH : L_SPLITV;
+    if (con_num_children(parent) == 1) {
+        parent->layout = layout;
         DLOG("Just changing orientation of existing container\n");
         return;
     }
 
-    DLOG("Splitting in orientation %d\n", orientation);
+    DLOG("Splitting in orientation %d\n", layout);
 
     /* 2: replace it with a new Con */
     Con *new = con_new(NULL, NULL);
     TAILQ_REPLACE(&(parent->nodes_head), con, new, nodes);
     TAILQ_REPLACE(&(parent->focus_head), con, new, focused);
     new->parent = parent;
-    new->layout = (orientation == HORIZ) ? L_SPLITH : L_SPLITV;
+    new->layout = layout;
 
     /* 3: swap 'percent' (resize factor) */
     new->percent = con->percent;


### PR DESCRIPTION
This should solve #4207, I've successfully tested this as a patch to 4.18.2.

This change introduces `tabbed`, `stacking`, `stacked` modes to `split` command in a backward compatible way (`t` still works as `toggle`).

Additionaly, this changes behavior which replaces the layout of current container (instead of creating a nested container) if the container only has one child: while before it only worked for splits, now it works for all layouts which is IMO more consistent.

Fixes #4207 
Closes #3001