### PR TITLE
travis: fix bintray deploy step

### DIFF
--- a/travis/bintray-autobuild-debian.json
+++ b/travis/bintray-autobuild-debian.json
@@ -13,7 +13,7 @@
 
     "files": [
         {
-            "includePattern": "build/deb/debian-amd64/(.*\\.deb)$",
+            "includePattern": "distbuild/deb/debian-amd64/(.*\\.deb)$",
 	    "matrixParams": {
                 "deb_distribution": "sid",
                 "deb_component": "main",
@@ -22,7 +22,7 @@
 	    "uploadPattern": "$1"
         },
         {
-            "includePattern": "build/deb/debian-i386/(.*\\.deb)$",
+            "includePattern": "distbuild/deb/debian-i386/(.*\\.deb)$",
 	    "matrixParams": {
                 "deb_distribution": "sid",
                 "deb_component": "main",

--- a/travis/bintray-autobuild-ubuntu.json
+++ b/travis/bintray-autobuild-ubuntu.json
@@ -13,7 +13,7 @@
 
     "files": [
         {
-            "includePattern": "build/deb/ubuntu-amd64/(.*\\.deb)$",
+            "includePattern": "distbuild/deb/ubuntu-amd64/(.*\\.deb)$",
 	    "matrixParams": {
                 "deb_distribution": "bionic",
                 "deb_component": "main",
@@ -22,7 +22,7 @@
 	    "uploadPattern": "$1"
         },
         {
-            "includePattern": "build/deb/ubuntu-i386/(.*\\.deb)$",
+            "includePattern": "distbuild/deb/ubuntu-i386/(.*\\.deb)$",
 	    "matrixParams": {
                 "deb_distribution": "bionic",
                 "deb_component": "main",


### PR DESCRIPTION
Commit be1065f62d156fb825f566b7e1e6ab4937dc9db4 moved the Debian/Ubuntu package
builds into the distbuild/ directory.

fixes #4179