### PR TITLE
Implement context-sensitive tab-clicking behavior

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -13,6 +13,7 @@ strongly encouraged to upgrade.
 
   • i3-nagbar: position on focused monitor by default
   • i3-nagbar: add option to position on primary monitor
+  • alternate focusing tab/stack children-parent containers by clicking on their titlebars
 
  ┌────────────────────────────┐
  │ Bugfixes                   │

--- a/src/click.c
+++ b/src/click.c
@@ -218,8 +218,20 @@ static void route_click(Con *con, xcb_button_press_event_t *event, const bool mo
         goto done;
     }
 
-    /* 2: focus this con. */
-    con_activate(con);
+    /* 2: focus this con or one of its children. */
+    Con *con_to_focus = con;
+    if (in_stacked && dest == CLICK_DECORATION) {
+        /* If the container is a tab/stacked container and the click happened
+         * on a tab, switch to the tab. If the tab contents were already
+         * focused, focus the tab container itself. If the tab container was
+         * already focused, cycle back to focusing the tab contents. */
+        if (was_focused || !con_has_parent(focused, con)) {
+            while (!TAILQ_EMPTY(&(con_to_focus->focus_head))) {
+                con_to_focus = TAILQ_FIRST(&(con_to_focus->focus_head));
+            }
+        }
+    }
+    con_activate(con_to_focus);
 
     /* 3: For floating containers, we also want to raise them on click.
      * We will skip handling events on floating cons in fullscreen mode */


### PR DESCRIPTION
This commit makes it so that when clicking on a tab for the first time,
its inactive-focused child is focused. This matches i3 behavior when
scrolling on tabs.

A second click on the tab titlebar focuses the tab container itself.

Subsequent clicks cycle between these two states.

Closes #4225.