### PR TITLE
i3bar: Add default bar_id

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -14,6 +14,7 @@ strongly encouraged to upgrade.
   • i3-nagbar: position on focused monitor by default
   • i3-nagbar: add option to position on primary monitor
   • alternate focusing tab/stack children-parent containers by clicking on their titlebars
+  • i3bar: use first bar config by default
 
  ┌────────────────────────────┐
  │ Bugfixes                   │

--- a/i3bar/include/configuration.h
+++ b/i3bar/include/configuration.h
@@ -75,6 +75,13 @@ extern config_t config;
 void parse_config_json(char *json);
 
 /**
+ * Start parsing the received bar configuration list. The only usecase right
+ * now is to automatically get the first bar id.
+ *
+ */
+void parse_get_first_i3bar_config(char *json);
+
+/**
  * free()s the color strings as soon as they are not needed anymore.
  *
  */

--- a/i3bar/include/ipc.h
+++ b/i3bar/include/ipc.h
@@ -18,7 +18,7 @@
  * socket_path must be a valid path to the ipc_socket of i3
  *
  */
-int init_connection(const char *socket_path);
+void init_connection(const char *socket_path);
 
 /*
  * Destroy the connection to i3.

--- a/i3bar/src/config.c
+++ b/i3bar/src/config.c
@@ -367,14 +367,12 @@ static yajl_callbacks outputs_callbacks = {
  *
  */
 void parse_config_json(char *json) {
-    yajl_handle handle;
-    yajl_status state;
-    handle = yajl_alloc(&outputs_callbacks, NULL, NULL);
+    yajl_handle handle = yajl_alloc(&outputs_callbacks, NULL, NULL);
 
     TAILQ_INIT(&(config.bindings));
     TAILQ_INIT(&(config.tray_outputs));
 
-    state = yajl_parse(handle, (const unsigned char *)json, strlen(json));
+    yajl_status state = yajl_parse(handle, (const unsigned char *)json, strlen(json));
 
     /* FIXME: Proper error handling for JSON parsing */
     switch (state) {
@@ -387,6 +385,25 @@ void parse_config_json(char *json) {
             break;
     }
 
+    yajl_free(handle);
+}
+
+static int i3bar_config_string_cb(void *params_, const unsigned char *val, size_t _len) {
+    sasprintf(&config.bar_id, "%.*s", (int)_len, val);
+    return 0; /* Stop parsing */
+}
+
+/*
+ * Start parsing the received bar configuration list. The only usecase right
+ * now is to automatically get the first bar id.
+ *
+ */
+void parse_get_first_i3bar_config(char *json) {
+    yajl_callbacks configs_callbacks = {
+        .yajl_string = i3bar_config_string_cb,
+    };
+    yajl_handle handle = yajl_alloc(&configs_callbacks, NULL, NULL);
+    yajl_parse(handle, (const unsigned char *)json, strlen(json));
     yajl_free(handle);
 }
 

--- a/i3bar/src/main.c
+++ b/i3bar/src/main.c
@@ -56,7 +56,7 @@ static char *expand_path(char *path) {
 }
 
 static void print_usage(char *elf_name) {
-    printf("Usage: %s -b bar_id [-s sock_path] [-t] [-h] [-v]\n", elf_name);
+    printf("Usage: %s -b bar_id [-s sock_path] [-t] [-h] [-v] [-V]\n", elf_name);
     printf("\n");
     printf("-b, --bar_id       <bar_id>\tBar ID for which to get the configuration\n");
     printf("-s, --socket       <sock_path>\tConnect to i3 via <sock_path>\n");

--- a/man/i3bar.man
+++ b/man/i3bar.man
@@ -9,7 +9,7 @@ i3bar - xcb-based status- and workspace-bar
 
 == SYNOPSIS
 
-*i3bar* *-b* 'bar_id' [*-s* 'sock_path'] [*-t*] [*-h*] [*-v*] [*-V*]
+*i3bar* [*-b* 'bar_id'] [*-s* 'sock_path'] [*-t*] [*-h*] [*-v*] [*-V*]
 
 == WARNING
 
@@ -25,7 +25,8 @@ You have been warned!
 Overwrites the path to the i3 IPC socket.
 
 *-b, --bar_id* 'bar_id'::
-Specifies the bar ID for which to get the configuration from i3.
+Specifies the bar ID for which to get the configuration from i3. By default,
+i3bar will use the first bar block as configured in i3.
 
 *-t, --transparency*::
 Enable transparency (RGBA colors)

--- a/man/i3bar.man
+++ b/man/i3bar.man
@@ -9,7 +9,7 @@ i3bar - xcb-based status- and workspace-bar
 
 == SYNOPSIS
 
-*i3bar* [*-s* 'sock_path'] [*-b* 'bar_id'] [*-v*] [*-h*]
+*i3bar* *-b* 'bar_id' [*-s* 'sock_path'] [*-t*] [*-h*] [*-v*] [*-V*]
 
 == WARNING
 
@@ -27,11 +27,17 @@ Overwrites the path to the i3 IPC socket.
 *-b, --bar_id* 'bar_id'::
 Specifies the bar ID for which to get the configuration from i3.
 
-*-v, --version*::
-Display version number and exit.
+*-t, --transparency*::
+Enable transparency (RGBA colors)
 
 *-h, --help*::
 Display a short help-message and exit
+
+*-v, --version*::
+Display version number and exit.
+
+*-V*::
+Be verbose.
 
 == DESCRIPTION
 


### PR DESCRIPTION
Instead of erroring, request the list of bar configs from i3 and use the
first one.