### PR TITLE
Add reverse layouts

### DIFF
--- a/i3-save-tree
+++ b/i3-save-tree
@@ -89,6 +89,7 @@ my %allowed_keys = map { ($_, 1) } qw(
     type
     fullscreen_mode
     layout
+    layout_fill_order
     border
     current_border_width
     floating
@@ -105,8 +106,9 @@ my %allowed_keys = map { ($_, 1) } qw(
 sub strip_containers {
     my ($tree) = @_;
 
-    # layout is not relevant for a leaf container
+    # layout and fill order are not relevant for a leaf container
     delete $tree->{layout} if leaf_node($tree);
+    delete $tree->{layout_fill_order} if leaf_node($tree);
 
     # fullscreen_mode conveys no state at all, it can either be 0 or 1 and the
     # default is _always_ 0, so skip noop entries.

--- a/include/commands.h
+++ b/include/commands.h
@@ -236,6 +236,12 @@ void cmd_layout(I3_CMD, const char *layout_str);
  */
 void cmd_layout_toggle(I3_CMD, const char *toggle_mode);
 
+/*
+ * Implementation of 'layout fill_order [default|reverse|toggle]'.
+ *
+ */
+void cmd_layout_fill_order(I3_CMD, const char *fill_order);
+
 /**
  * Implementation of 'exit'.
  *

--- a/include/commands.h
+++ b/include/commands.h
@@ -225,10 +225,10 @@ void cmd_sticky(I3_CMD, const char *action);
 void cmd_move_direction(I3_CMD, const char *direction_str, long amount, const char *mode);
 
 /**
- * Implementation of 'layout default|stacked|stacking|tabbed|splitv|splith'.
+ * Implementation of 'layout default|stacked|stacking|tabbed|splitv|splith [reverse]'.
  *
  */
-void cmd_layout(I3_CMD, const char *layout_str);
+void cmd_layout(I3_CMD, const char *layout_str, const char *reverse);
 
 /**
  * Implementation of 'layout toggle [all|split]'.

--- a/include/commands.h
+++ b/include/commands.h
@@ -159,7 +159,7 @@ void cmd_floating(I3_CMD, const char *floating_mode);
 void cmd_move_workspace_to_output(I3_CMD, const char *name);
 
 /**
- * Implementation of 'split v|h|t|vertical|horizontal|toggle'.
+ * Implementation of 'split v|h|t|vertical|horizontal|toggle|left|right|up|down'.
  *
  */
 void cmd_split(I3_CMD, const char *direction);

--- a/include/con.h
+++ b/include/con.h
@@ -462,6 +462,15 @@ void con_set_layout(Con *con, layout_t layout);
 void con_toggle_layout(Con *con, const char *toggle_mode);
 
 /**
+ * This function changes the way new containers get added to layouts. The
+ * 'default' means the layout is filled left-to-right or top-to-bottom
+ * depending on orientation. 'reverse' changes that to right-to-left or
+ * bottom-to-top. 'toggle' inverts the setting depending on its previous value.
+ *
+ */
+void con_set_layout_fill_order(Con *con, const char *fill_order);
+
+/**
  * Determines the minimum size of the given con by looking at its children (for
  * split/stacked/tabbed cons). Will be called when resizing floating cons
  *

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -45,7 +45,7 @@ CFGFUN(for_window, const char *command);
 CFGFUN(floating_minimum_size, const long width, const long height);
 CFGFUN(floating_maximum_size, const long width, const long height);
 CFGFUN(default_orientation, const char *orientation);
-CFGFUN(workspace_layout, const char *layout);
+CFGFUN(workspace_layout, const char *layout, const char *fill_order);
 CFGFUN(workspace_back_and_forth, const char *value);
 CFGFUN(focus_follows_mouse, const char *value);
 CFGFUN(mouse_warping, const char *value);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -96,6 +96,7 @@ struct Config {
     char *restart_state_path;
 
     layout_t default_layout;
+    layout_fill_t default_layout_fill_order;
     int container_stack_limit;
     int container_stack_limit_value;
     int default_border_width;

--- a/include/data.h
+++ b/include/data.h
@@ -98,6 +98,14 @@ typedef enum {
 } layout_t;
 
 /**
+ * Layout fill order. See Con::layout_fill_order.
+ */
+typedef enum {
+    LF_DEFAULT = 0,
+    LF_REVERSE = 1
+} layout_fill_t;
+
+/**
  * Binding input types. See Binding::input_type.
  */
 typedef enum {
@@ -195,6 +203,7 @@ struct deco_render_params {
     Rect con_deco_rect;
     color_t background;
     layout_t parent_layout;
+    layout_fill_t parent_layout_fill_order;
     bool con_is_leaf;
 };
 
@@ -706,7 +715,14 @@ struct Con {
      * layout in workspace_layout and creates a new split container with that
      * layout whenever a new container is attached to the workspace. */
     layout_t layout, last_split_layout, workspace_layout;
+
+    /* fill_order defines how layouts get filled with new containers. 'default'
+     * fills them left-to-right (or top-to-bottom for vertical layouts).
+     * 'reverse' fills them right-to-left (or bottom-to-top if vertical). */
+    layout_fill_t layout_fill_order;
+
     border_style_t border_style;
+
     /** floating? (= not in tiling layout) This cannot be simply a bool
      * because we want to keep track of whether the status was set by the
      * application (by setting _NET_WM_WINDOW_TYPE appropriately) or by the

--- a/include/tree.h
+++ b/include/tree.h
@@ -33,11 +33,11 @@ void tree_init(xcb_get_geometry_reply_t *geometry);
 Con *tree_open_con(Con *con, i3Window *window);
 
 /**
- * Splits (horizontally or vertically) the given container by creating a new
- * container which contains the old one and the future ones.
+ * Splits the given container in any direction by creating a new container
+ * which contains the old one and the future ones.
  *
  */
-void tree_split(Con *con, orientation_t orientation);
+void tree_split(Con *con, direction_t direction);
 
 /**
  * Moves focus one level up. Returns true if focus changed.

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -99,16 +99,22 @@ state BORDER_WIDTH:
   border_width = number
     -> call cmd_border($border_style, &border_width)
 
-# layout default|stacked|stacking|tabbed|splitv|splith
+# layout default|stacked|stacking|tabbed|splitv|splith [reverse]
 # layout toggle [split|all]
 # layout fill_order [default|reverse|toggle]
 state LAYOUT:
   layout_mode = 'default', 'stacked', 'stacking', 'tabbed', 'splitv', 'splith'
-      -> call cmd_layout($layout_mode)
+      -> LAYOUT_REVERSE
   'toggle'
       -> LAYOUT_TOGGLE
   'fill_order'
       -> LAYOUT_FILL_ORDER
+
+state LAYOUT_REVERSE:
+  end
+      -> call cmd_layout($layout_mode, $layout_reverse)
+  layout_reverse = 'reverse'
+      -> call cmd_layout($layout_mode, $layout_reverse)
 
 # layout toggle [split|all]
 state LAYOUT_TOGGLE:

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -101,11 +101,14 @@ state BORDER_WIDTH:
 
 # layout default|stacked|stacking|tabbed|splitv|splith
 # layout toggle [split|all]
+# layout fill_order [default|reverse|toggle]
 state LAYOUT:
   layout_mode = 'default', 'stacked', 'stacking', 'tabbed', 'splitv', 'splith'
       -> call cmd_layout($layout_mode)
   'toggle'
       -> LAYOUT_TOGGLE
+  'fill_order'
+      -> LAYOUT_FILL_ORDER
 
 # layout toggle [split|all]
 state LAYOUT_TOGGLE:
@@ -113,6 +116,13 @@ state LAYOUT_TOGGLE:
       -> call cmd_layout_toggle($toggle_mode)
   toggle_mode = string
       -> call cmd_layout_toggle($toggle_mode)
+
+# layout fill_order [default|reverse|toggle]
+state LAYOUT_FILL_ORDER:
+  end
+      -> call cmd_layout_fill_order($fill_order)
+  fill_order = 'default', 'reverse', 'toggle'
+      -> call cmd_layout_fill_order($fill_order)
 
 # append_layout <path>
 state APPEND_LAYOUT:

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -218,9 +218,11 @@ state STICKY:
   action = 'enable', 'disable', 'toggle'
       -> call cmd_sticky($action)
 
-# split v|h|t|vertical|horizontal|toggle
+# split v|vertical|up|down
+# split h|horizontal|left|right
+# split t|toggle
 state SPLIT:
-  direction = 'horizontal', 'vertical', 'toggle', 'v', 'h', 't'
+  direction = 'horizontal', 'vertical', 'toggle', 'v', 'h', 't', 'left', 'right', 'up', 'down'
       -> call cmd_split($direction)
 
 # floating enable|disable|toggle

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -103,10 +103,16 @@ state DEFAULT_ORIENTATION:
   orientation = 'horizontal', 'vertical', 'auto'
       -> call cfg_default_orientation($orientation)
 
-# workspace_layout <default|stacking|tabbed>
+# workspace_layout <default|stacking|tabbed> [reverse]
 state WORKSPACE_LAYOUT:
   layout = 'default', 'stacking', 'stacked', 'tabbed'
-      -> call cfg_workspace_layout($layout)
+      -> WORKSPACE_LAYOUT_FILL_ORDER
+
+state WORKSPACE_LAYOUT_FILL_ORDER:
+  end
+      -> call cfg_workspace_layout($layout, $fill_order)
+  fill_order = 'reverse'
+      -> call cfg_workspace_layout($layout, $fill_order)
 
 # <default_border|new_window> <normal|1pixel|none>
 # <default_floating_border|new_float> <normal|1pixel|none>

--- a/src/commands.c
+++ b/src/commands.c
@@ -1600,6 +1600,33 @@ void cmd_layout_toggle(I3_CMD, const char *toggle_mode) {
 }
 
 /*
+ * Implementation of 'layout fill_order [default|reverse|toggle]'.
+ *
+ */
+void cmd_layout_fill_order(I3_CMD, const char *fill_order) {
+    owindow *current;
+
+    if (fill_order == NULL)
+        fill_order = "default";
+
+    DLOG("setting layout fill order to %s\n", fill_order);
+
+    /* check if the match is empty, not if the result is empty */
+    if (match_is_empty(current_match))
+        con_set_layout_fill_order(focused, fill_order);
+    else {
+        TAILQ_FOREACH (current, &owindows, owindows) {
+            DLOG("matching: %p / %s\n", current->con, current->con->name);
+            con_set_layout_fill_order(current->con, fill_order);
+        }
+    }
+
+    cmd_output->needs_tree_render = true;
+    // XXX: default reply for now, make this a better reply
+    ysuccess(true);
+}
+
+/*
  * Implementation of 'exit'.
  *
  */

--- a/src/commands.c
+++ b/src/commands.c
@@ -1542,10 +1542,10 @@ void cmd_move_direction(I3_CMD, const char *direction_str, long amount, const ch
 }
 
 /*
- * Implementation of 'layout default|stacked|stacking|tabbed|splitv|splith'.
+ * Implementation of 'layout default|stacked|stacking|tabbed|splitv|splith [reverse]'.
  *
  */
-void cmd_layout(I3_CMD, const char *layout_str) {
+void cmd_layout(I3_CMD, const char *layout_str, const char *reverse) {
     HANDLE_EMPTY_MATCH;
 
     layout_t layout;
@@ -1565,6 +1565,8 @@ void cmd_layout(I3_CMD, const char *layout_str) {
 
         DLOG("matching: %p / %s\n", current->con, current->con->name);
         con_set_layout(current->con, layout);
+        if (reverse != NULL)
+            con_set_layout_fill_order(current->con, reverse);
     }
 
     cmd_output->needs_tree_render = true;

--- a/src/commands.c
+++ b/src/commands.c
@@ -1125,14 +1125,14 @@ void cmd_move_workspace_to_output(I3_CMD, const char *name) {
 }
 
 /*
- * Implementation of 'split v|h|t|vertical|horizontal|toggle'.
+ * Implementation of 'split v|h|t|vertical|horizontal|toggle|left|right|up|down'.
  *
  */
 void cmd_split(I3_CMD, const char *direction) {
     HANDLE_EMPTY_MATCH;
 
     owindow *current;
-    LOG("splitting in direction %c\n", direction[0]);
+    LOG("splitting in direction %s\n", direction);
     TAILQ_FOREACH (current, &owindows, owindows) {
         if (con_is_docked(current->con)) {
             ELOG("Cannot split a docked container, skipping.\n");
@@ -1149,12 +1149,18 @@ void cmd_split(I3_CMD, const char *direction) {
             }
             /* toggling split orientation */
             if (current_layout == L_SPLITH) {
-                tree_split(current->con, VERT);
+                tree_split(current->con, (current->con->layout_fill_order == LF_DEFAULT) ? D_DOWN : D_UP);
             } else {
-                tree_split(current->con, HORIZ);
+                tree_split(current->con, (current->con->layout_fill_order == LF_DEFAULT) ? D_RIGHT : D_LEFT);
             }
-        } else {
-            tree_split(current->con, (direction[0] == 'v' ? VERT : HORIZ));
+        } else if (direction[0] == 'h' || direction[0] == 'r') {
+            tree_split(current->con, D_RIGHT);
+        } else if (direction[0] == 'l') {
+            tree_split(current->con, D_LEFT);
+        } else if (direction[0] == 'v' || direction[0] == 'd') {
+            tree_split(current->con, D_DOWN);
+        } else if (direction[0] == 'u') {
+            tree_split(current->con, D_UP);
         }
     }
 

--- a/src/con.c
+++ b/src/con.c
@@ -191,11 +191,16 @@ static void _con_attach(Con *con, Con *parent, Con *previous, bool ignore_focus)
             DLOG("done\n");
         }
 
-        /* Insert the container after the tiling container, if found.
+        /* Insert the container before/after the tiling container, if found.
          * When adding to a CT_OUTPUT, just append one after another. */
         if (current != NULL && parent->type != CT_OUTPUT) {
-            DLOG("Inserting con = %p after con %p\n", con, current);
-            TAILQ_INSERT_AFTER(nodes_head, current, con, nodes);
+            if (parent->layout_fill_order == LF_REVERSE) {
+                DLOG("Inserting con = %p before con %p\n", con, current);
+                TAILQ_INSERT_BEFORE(current, con, nodes);
+            } else {
+                DLOG("Inserting con = %p after con %p\n", con, current);
+                TAILQ_INSERT_AFTER(nodes_head, current, con, nodes);
+            }
         } else
             TAILQ_INSERT_TAIL(nodes_head, con, nodes);
     }
@@ -1870,9 +1875,9 @@ void con_set_layout(Con *con, layout_t layout) {
         /* In case last_split_layout was not initialized… */
         if (con->layout == L_DEFAULT)
             con->layout = L_SPLITH;
-    } else {
+    } else
         con->layout = layout;
-    }
+
     con_force_split_parents_redraw(con);
 }
 

--- a/src/con.c
+++ b/src/con.c
@@ -2252,19 +2252,36 @@ char *con_get_tree_representation(Con *con) {
 
     char *buf;
     /* 1) add the Layout type to buf */
-    if (con->layout == L_DEFAULT)
-        buf = sstrdup("D[");
-    else if (con->layout == L_SPLITV)
-        buf = sstrdup("V[");
-    else if (con->layout == L_SPLITH)
-        buf = sstrdup("H[");
-    else if (con->layout == L_TABBED)
-        buf = sstrdup("T[");
-    else if (con->layout == L_STACKED)
-        buf = sstrdup("S[");
-    else {
-        ELOG("BUG: Code not updated to account for new layout type\n");
-        assert(false);
+    if (con->layout_fill_order == LF_DEFAULT) {
+        if (con->layout == L_DEFAULT)
+            buf = sstrdup("D[");
+        else if (con->layout == L_SPLITV)
+            buf = sstrdup("V[");
+        else if (con->layout == L_SPLITH)
+            buf = sstrdup("H[");
+        else if (con->layout == L_TABBED)
+            buf = sstrdup("T[");
+        else if (con->layout == L_STACKED)
+            buf = sstrdup("S[");
+        else {
+            ELOG("BUG: Code not updated to account for new layout type\n");
+            assert(false);
+        }
+    } else {
+        if (con->layout == L_DEFAULT)
+            buf = sstrdup("Dr[");
+        else if (con->layout == L_SPLITV)
+            buf = sstrdup("Vr[");
+        else if (con->layout == L_SPLITH)
+            buf = sstrdup("Hr[");
+        else if (con->layout == L_TABBED)
+            buf = sstrdup("Tr[");
+        else if (con->layout == L_STACKED)
+            buf = sstrdup("Sr[");
+        else {
+            ELOG("BUG: Code not updated to account for new layout type\n");
+            assert(false);
+        }
     }
 
     /* 2) append representation of children */

--- a/src/con.c
+++ b/src/con.c
@@ -1970,6 +1970,31 @@ void con_toggle_layout(Con *con, const char *toggle_mode) {
     }
 }
 
+/**
+ * This function changes the way new containers get added to layouts. The
+ * 'default' means the layout is filled left-to-right or top-to-bottom
+ * depending on orientation. 'reverse' changes that to right-to-left or
+ * bottom-to-top. 'toggle' inverts the setting depending on its previous value.
+ *
+ */
+void con_set_layout_fill_order(Con *con, const char *fill_order) {
+    Con *parent = con;
+    /* Users can focus workspaces, but not any higher in the hierarchy.
+     * Focus on the workspace is a special case, since in every other case, the
+     * user means "change the layout of the parent split container". */
+    if (con->type != CT_WORKSPACE)
+        parent = con->parent;
+    DLOG("con_set_fill_order(%p, %s), parent = %p\n", con, fill_order, parent);
+
+    if (strcasecmp(fill_order, "default") == 0) {
+        parent->layout_fill_order = LF_DEFAULT;
+    } else if (strcasecmp(fill_order, "reverse") == 0) {
+        parent->layout_fill_order = LF_REVERSE;
+    } else if (strcasecmp(fill_order, "toggle") == 0) {
+        parent->layout_fill_order = (parent->layout_fill_order == LF_DEFAULT) ? LF_REVERSE : LF_DEFAULT;
+    }
+}
+
 /*
  * Callback which will be called when removing a child from the given con.
  * Kills the container if it is empty and replaces it with the child if there

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -184,7 +184,7 @@ CFGFUN(default_orientation, const char *orientation) {
         config.default_orientation = NO_ORIENTATION;
 }
 
-CFGFUN(workspace_layout, const char *layout) {
+CFGFUN(workspace_layout, const char *layout, const char *fill_order) {
     if (strcmp(layout, "default") == 0)
         config.default_layout = L_DEFAULT;
     else if (strcmp(layout, "stacking") == 0 ||
@@ -192,6 +192,12 @@ CFGFUN(workspace_layout, const char *layout) {
         config.default_layout = L_STACKED;
     else
         config.default_layout = L_TABBED;
+
+    if (fill_order != NULL && strcmp(fill_order, "reverse") == 0) {
+        config.default_layout_fill_order = LF_REVERSE;
+    } else {
+        config.default_layout_fill_order = LF_DEFAULT;
+    }
 }
 
 CFGFUN(default_border, const char *windowtype, const char *border, const long width) {

--- a/src/floating.c
+++ b/src/floating.c
@@ -446,7 +446,10 @@ void floating_disable(Con *con) {
         con->percent = 0.0;
         con_fix_percent(con->parent);
     } else {
-        insert_con_into(con, tiling_focused, AFTER);
+        insert_con_into(con, tiling_focused,
+                        (tiling_focused->parent->layout_fill_order == LF_DEFAULT)
+                            ? AFTER
+                            : BEFORE);
     }
 
     con->floating = FLOATING_USER_OFF;

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -453,6 +453,16 @@ void dump_node(yajl_gen gen, struct Con *con, bool inplace_restart) {
             break;
     }
 
+    ystr("layout_fill_order");
+    switch (con->layout_fill_order) {
+        case LF_DEFAULT:
+            ystr("default");
+            break;
+        case LF_REVERSE:
+            ystr("reverse");
+            break;
+    }
+
     ystr("workspace_layout");
     switch (con->workspace_layout) {
         case L_DEFAULT:

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -317,98 +317,105 @@ static int json_string(void *ctx, const unsigned char *val, size_t len) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);
             if (strcasecmp(buf, "none") == 0 ||
-                strcasecmp(buf, "horizontal") == 0)
+                strcasecmp(buf, "horizontal") == 0) {
                 json_node->last_split_layout = L_SPLITH;
-            else if (strcasecmp(buf, "vertical") == 0)
+            } else if (strcasecmp(buf, "vertical") == 0) {
                 json_node->last_split_layout = L_SPLITV;
-            else
+            } else {
                 LOG("Unhandled orientation: %s\n", buf);
+            }
             free(buf);
         } else if (strcasecmp(last_key, "border") == 0) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);
-            if (strcasecmp(buf, "none") == 0)
+            if (strcasecmp(buf, "none") == 0) {
                 json_node->border_style = BS_NONE;
-            else if (strcasecmp(buf, "1pixel") == 0) {
+            } else if (strcasecmp(buf, "1pixel") == 0) {
                 json_node->border_style = BS_PIXEL;
                 json_node->current_border_width = 1;
-            } else if (strcasecmp(buf, "pixel") == 0)
+            } else if (strcasecmp(buf, "pixel") == 0) {
                 json_node->border_style = BS_PIXEL;
-            else if (strcasecmp(buf, "normal") == 0)
+            } else if (strcasecmp(buf, "normal") == 0) {
                 json_node->border_style = BS_NORMAL;
-            else
+            } else {
                 LOG("Unhandled \"border\": %s\n", buf);
+            }
             free(buf);
         } else if (strcasecmp(last_key, "type") == 0) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);
-            if (strcasecmp(buf, "root") == 0)
+            if (strcasecmp(buf, "root") == 0) {
                 json_node->type = CT_ROOT;
-            else if (strcasecmp(buf, "output") == 0)
+            } else if (strcasecmp(buf, "output") == 0) {
                 json_node->type = CT_OUTPUT;
-            else if (strcasecmp(buf, "con") == 0)
+            } else if (strcasecmp(buf, "con") == 0) {
                 json_node->type = CT_CON;
-            else if (strcasecmp(buf, "floating_con") == 0)
+            } else if (strcasecmp(buf, "floating_con") == 0) {
                 json_node->type = CT_FLOATING_CON;
-            else if (strcasecmp(buf, "workspace") == 0)
+            } else if (strcasecmp(buf, "workspace") == 0) {
                 json_node->type = CT_WORKSPACE;
-            else if (strcasecmp(buf, "dockarea") == 0)
+            } else if (strcasecmp(buf, "dockarea") == 0) {
                 json_node->type = CT_DOCKAREA;
-            else
+            } else {
                 LOG("Unhandled \"type\": %s\n", buf);
+            }
             free(buf);
         } else if (strcasecmp(last_key, "layout") == 0) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);
-            if (strcasecmp(buf, "default") == 0)
+            if (strcasecmp(buf, "default") == 0) {
                 /* This set above when we read "orientation". */
                 json_node->layout = json_node->last_split_layout;
-            else if (strcasecmp(buf, "stacked") == 0)
+            } else if (strcasecmp(buf, "stacked") == 0) {
                 json_node->layout = L_STACKED;
-            else if (strcasecmp(buf, "tabbed") == 0)
+            } else if (strcasecmp(buf, "tabbed") == 0) {
                 json_node->layout = L_TABBED;
-            else if (strcasecmp(buf, "dockarea") == 0)
+            } else if (strcasecmp(buf, "dockarea") == 0) {
                 json_node->layout = L_DOCKAREA;
-            else if (strcasecmp(buf, "output") == 0)
+            } else if (strcasecmp(buf, "output") == 0) {
                 json_node->layout = L_OUTPUT;
-            else if (strcasecmp(buf, "splith") == 0)
+            } else if (strcasecmp(buf, "splith") == 0) {
                 json_node->layout = L_SPLITH;
-            else if (strcasecmp(buf, "splitv") == 0)
+            } else if (strcasecmp(buf, "splitv") == 0) {
                 json_node->layout = L_SPLITV;
-            else
+            } else {
                 LOG("Unhandled \"layout\": %s\n", buf);
+            }
             free(buf);
         } else if (strcasecmp(last_key, "workspace_layout") == 0) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);
-            if (strcasecmp(buf, "default") == 0)
+            if (strcasecmp(buf, "default") == 0) {
                 json_node->workspace_layout = L_DEFAULT;
-            else if (strcasecmp(buf, "stacked") == 0)
+            } else if (strcasecmp(buf, "stacked") == 0) {
                 json_node->workspace_layout = L_STACKED;
-            else if (strcasecmp(buf, "tabbed") == 0)
+            } else if (strcasecmp(buf, "tabbed") == 0) {
                 json_node->workspace_layout = L_TABBED;
-            else
+            } else {
                 LOG("Unhandled \"workspace_layout\": %s\n", buf);
+            }
             free(buf);
         } else if (strcasecmp(last_key, "last_split_layout") == 0) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);
-            if (strcasecmp(buf, "splith") == 0)
+            if (strcasecmp(buf, "splith") == 0) {
                 json_node->last_split_layout = L_SPLITH;
-            else if (strcasecmp(buf, "splitv") == 0)
+            } else if (strcasecmp(buf, "splitv") == 0) {
                 json_node->last_split_layout = L_SPLITV;
-            else
+            } else {
                 LOG("Unhandled \"last_split_layout\": %s\n", buf);
+            }
             free(buf);
         } else if (strcasecmp(last_key, "layout_fill_order") == 0) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);
-            if (strcasecmp(buf, "default") == 0)
+            if (strcasecmp(buf, "default") == 0) {
                 json_node->layout_fill_order = LF_DEFAULT;
-            else if (strcasecmp(buf, "reverse") == 0)
+            } else if (strcasecmp(buf, "reverse") == 0) {
                 json_node->layout_fill_order = LF_REVERSE;
-            else
+            } else {
                 LOG("Unhandled \"layout_fill_order\": %s\n", buf);
+            }
             free(buf);
         } else if (strcasecmp(last_key, "mark") == 0) {
             DLOG("Found deprecated key \"mark\".\n");
@@ -420,24 +427,26 @@ static int json_string(void *ctx, const unsigned char *val, size_t len) {
         } else if (strcasecmp(last_key, "floating") == 0) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);
-            if (strcasecmp(buf, "auto_off") == 0)
+            if (strcasecmp(buf, "auto_off") == 0) {
                 json_node->floating = FLOATING_AUTO_OFF;
-            else if (strcasecmp(buf, "auto_on") == 0)
+            } else if (strcasecmp(buf, "auto_on") == 0) {
                 json_node->floating = FLOATING_AUTO_ON;
-            else if (strcasecmp(buf, "user_off") == 0)
+            } else if (strcasecmp(buf, "user_off") == 0) {
                 json_node->floating = FLOATING_USER_OFF;
-            else if (strcasecmp(buf, "user_on") == 0)
+            } else if (strcasecmp(buf, "user_on") == 0) {
                 json_node->floating = FLOATING_USER_ON;
+            }
             free(buf);
         } else if (strcasecmp(last_key, "scratchpad_state") == 0) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);
-            if (strcasecmp(buf, "none") == 0)
+            if (strcasecmp(buf, "none") == 0) {
                 json_node->scratchpad_state = SCRATCHPAD_NONE;
-            else if (strcasecmp(buf, "fresh") == 0)
+            } else if (strcasecmp(buf, "fresh") == 0) {
                 json_node->scratchpad_state = SCRATCHPAD_FRESH;
-            else if (strcasecmp(buf, "changed") == 0)
+            } else if (strcasecmp(buf, "changed") == 0) {
                 json_node->scratchpad_state = SCRATCHPAD_CHANGED;
+            }
             free(buf);
         } else if (strcasecmp(last_key, "previous_workspace_name") == 0) {
             FREE(previous_workspace_name);

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -398,7 +398,17 @@ static int json_string(void *ctx, const unsigned char *val, size_t len) {
             else if (strcasecmp(buf, "splitv") == 0)
                 json_node->last_split_layout = L_SPLITV;
             else
-                LOG("Unhandled \"last_splitlayout\": %s\n", buf);
+                LOG("Unhandled \"last_split_layout\": %s\n", buf);
+            free(buf);
+        } else if (strcasecmp(last_key, "layout_fill_order") == 0) {
+            char *buf = NULL;
+            sasprintf(&buf, "%.*s", (int)len, val);
+            if (strcasecmp(buf, "default") == 0)
+                json_node->layout_fill_order = LF_DEFAULT;
+            else if (strcasecmp(buf, "reverse") == 0)
+                json_node->layout_fill_order = LF_REVERSE;
+            else
+                LOG("Unhandled \"layout_fill_order\": %s\n", buf);
             free(buf);
         } else if (strcasecmp(last_key, "mark") == 0) {
             DLOG("Found deprecated key \"mark\".\n");

--- a/src/move.c
+++ b/src/move.c
@@ -305,11 +305,12 @@ void tree_move(Con *con, direction_t direction) {
                 if (!con_is_leaf(swap)) {
                     DLOG("Moving into our bordering branch\n");
                     target = con_descend_direction(swap, direction);
-                    position = (con_orientation(target->parent) != o ||
-                                        direction == D_UP ||
-                                        direction == D_LEFT
-                                    ? AFTER
-                                    : BEFORE);
+                    position = (con_orientation(target->parent) == o &&
+                                (direction == D_LEFT || direction == D_UP)) ||
+                                       (con_orientation(target->parent) != o &&
+                                        target->parent->layout_fill_order == LF_DEFAULT)
+                                   ? AFTER
+                                   : BEFORE;
                     insert_con_into(con, target, position);
                     goto end;
                 }
@@ -358,11 +359,12 @@ void tree_move(Con *con, direction_t direction) {
     if (next && !con_is_leaf(next)) {
         DLOG("Moving into the bordering branch of our adjacent container\n");
         target = con_descend_direction(next, direction);
-        position = (con_orientation(target->parent) != o ||
-                            direction == D_UP ||
-                            direction == D_LEFT
-                        ? AFTER
-                        : BEFORE);
+        position = (con_orientation(target->parent) == o &&
+                    (direction == D_LEFT || direction == D_UP)) ||
+                           (con_orientation(target->parent) != o &&
+                            target->parent->layout_fill_order == LF_DEFAULT)
+                       ? AFTER
+                       : BEFORE;
         insert_con_into(con, target, position);
     } else if (!next &&
                con->parent->parent->type == CT_WORKSPACE &&

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -862,6 +862,7 @@ void ws_force_orientation(Con *ws, orientation_t orientation) {
 
     /* 2: copy layout from workspace */
     split->layout = ws->layout;
+    split->layout_fill_order = ws->layout_fill_order;
 
     /* 3: move the existing cons of this workspace below the new con */
     Con **focus_order = get_focus_order(ws);
@@ -913,6 +914,7 @@ Con *workspace_attach_to(Con *ws) {
 
     /* 2: set the requested layout on the split con */
     new->layout = ws->workspace_layout;
+    new->layout_fill_order = ws->layout_fill_order;
 
     /* 4: attach the new split container to the workspace */
     DLOG("Attaching new split %p to workspace %p\n", new, ws);
@@ -939,6 +941,7 @@ Con *workspace_encapsulate(Con *ws) {
     Con *new = con_new(NULL, NULL);
     new->parent = ws;
     new->layout = ws->layout;
+    new->layout_fill_order = ws->layout_fill_order;
 
     Con **focus_order = get_focus_order(ws);
 

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -154,6 +154,7 @@ Con *workspace_get(const char *num) {
     FREE(workspace->name);
     workspace->name = sstrdup(num);
     workspace->workspace_layout = config.default_layout;
+    workspace->layout_fill_order = config.default_layout_fill_order;
     workspace->num = parsed_num;
     workspace->type = CT_WORKSPACE;
 
@@ -288,6 +289,7 @@ Con *create_workspace_on_output(Output *output, Con *content) {
     ws->fullscreen_mode = CF_OUTPUT;
 
     ws->workspace_layout = config.default_layout;
+    ws->layout_fill_order = config.default_layout_fill_order;
     _workspace_apply_default_orientation(ws);
 
     ipc_send_workspace_event("init", ws, NULL);

--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -10,6 +10,7 @@ use X11::XCB qw(:all);
 use lib qw(@abs_top_builddir@/AnyEvent-I3/blib/lib);
 use AnyEvent::I3;
 use List::Util qw(first);
+use List::MoreUtils qw(any);
 use Time::HiRes qw(sleep);
 use Cwd qw(abs_path);
 use POSIX ':sys_wait_h';
@@ -1096,7 +1097,7 @@ The following arguments can be passed:
 =item layout_before
 
 Required argument. The initial layout to be created. For example,
-'H[ V[ a* S[ b c ] d ] e ]' or 'V[a b] T[c d*]'.
+'H[ V[ a* S[ b c ] d ] e ]' or 'V[a b] Tr[c d*]'.
 The layout will be converted to a JSON file which will be passed to i3's
 append_layout command.
 
@@ -1107,12 +1108,13 @@ The syntax's rules, assertions and limitations are:
 =item 1.
 
 Upper case letters H, V, S, T mean horizontal, vertical, stacked and tabbed
-layout respectively. They must be followed by an opening square bracket and must
-be closed with a closing square bracket.
-Each of the non-leaf containers is marked with their corresponding letter
-followed by a number indicating the position of the container relative to other
-containers of the same type. For example, 'H[V[xxx] V[xxx] H[xxx]]' will mark
-the non-leaf containers as H1, V1, V2, H2.
+layout respectively. They must be followed by either the letter r to specify
+reverse fill order for this container, or an opening square bracket. Opening
+square backets must be closed with a closing square bracket.  Each of the
+non-leaf containers is marked with their corresponding letter followed by a
+number indicating the position of the container relative to other containers of
+the same type. For example, 'H[V[xxx] V[xxx] H[xxx]]' will mark the non-leaf
+containers as H1, V1, V2, H2.
 
 =item 2.
 
@@ -1199,22 +1201,42 @@ sub create_layout {
     my $depth = 0;
     my %layout_counts = (H => 0, V => 0, S => 0, T => 0);
 
+    my $node_layout_definition = 0;
+    my $node_layout_fill_order;
+
     foreach my $char (split('', $layout)) {
-        if ($char eq 'H') {
-            $r = $r . '{"layout": "splith",';
-            $r = $r . '"marks": ["H' . ++$layout_counts{H} . '"],';
-        } elsif ($char eq 'V') {
-            $r = $r . '{"layout": "splitv",';
-            $r = $r . '"marks": ["V' . ++$layout_counts{V} . '"],';
-        } elsif ($char eq 'S') {
-            $r = $r . '{"layout": "stacked",';
-            $r = $r . '"marks": ["S' . ++$layout_counts{S} . '"],';
-        } elsif ($char eq 'T') {
-            $r = $r . '{"layout": "tabbed",';
-            $r = $r . '"marks": ["T' . ++$layout_counts{T} . '"],';
+        if ($node_layout_definition) {
+            if ($char eq 'r') {
+                $node_layout_fill_order = 'reverse';
+            } elsif ($char eq '*') {
+                $focus = $windows[$#windows];
+            } elsif ($char eq '[') {
+                $node_layout_definition = 0;
+                $depth++;
+
+                $r = $r . '"layout_fill_order": "'.$node_layout_fill_order.'",';
+                $r = $r . '"nodes": [';
+            } else {
+                die "Could not understand '$char' in layout definition";
+            }
+        } elsif (any { $_ eq $char } ('H', 'V', 'S', 'T')) {
+            $node_layout_definition = 1;
+            $node_layout_fill_order = 'default';
+
+            if ($char eq 'H') {
+                $r = $r . '{"layout": "splith",';
+                $r = $r . '"marks": ["H' . ++$layout_counts{H} . '"],';
+            } elsif ($char eq 'V') {
+                $r = $r . '{"layout": "splitv",';
+                $r = $r . '"marks": ["V' . ++$layout_counts{V} . '"],';
+            } elsif ($char eq 'S') {
+                $r = $r . '{"layout": "stacked",';
+                $r = $r . '"marks": ["S' . ++$layout_counts{S} . '"],';
+            } elsif ($char eq 'T') {
+                $r = $r . '{"layout": "tabbed",';
+                $r = $r . '"marks": ["T' . ++$layout_counts{T} . '"],';
+            }
         } elsif ($char eq '[') {
-            $depth++;
-            $r = $r . '"nodes": [';
         } elsif ($char eq ']') {
             # End of nodes array: delete trailing comma.
             chop $r;
@@ -1261,32 +1283,50 @@ sub verify_layout {
     my $depth = 0;
     my $node;
 
+    my $node_layout;
+    my $node_layout_defined = 0;
+    my $node_layout_fill_order;
+    my $node_layout_definition = 0;
+    my $node_layout_container_focused = 0;
+
     foreach my $char (split('', $layout)) {
         my $node_name;
-        my $node_layout;
-        if ($char eq 'H') {
-            $node_layout = 'splith';
-        } elsif ($char eq 'V') {
-            $node_layout = 'splitv';
-        } elsif ($char eq 'S') {
-            $node_layout = 'stacked';
-        } elsif ($char eq 'T') {
-            $node_layout = 'tabbed';
-        } elsif ($char eq '[') {
-            $depth++;
-            delete $counters{$depth};
+        if ($node_layout_definition) {
+            if ($char eq 'r') {
+                $node_layout_fill_order = 'reverse';
+            } elsif ($char eq '*') {
+                $node_layout_container_focused = 1;
+            } elsif ($char eq '[') {
+                $node_layout_definition = 0;
+                $node_layout_defined = 1;
+            } else {
+                die "Could not understand '$char' in layout definition";
+            }
+        } elsif (any { $_ eq $char } ('H', 'V', 'S', 'T')) {
+            $node_layout_definition = 1;
+            $node_layout_fill_order = 'default';
+
+            if ($char eq 'H') {
+                $node_layout = 'splith';
+            } elsif ($char eq 'V') {
+                $node_layout = 'splitv';
+            } elsif ($char eq 'S') {
+                $node_layout = 'stacked';
+            } elsif ($char eq 'T') {
+                $node_layout = 'tabbed';
+            }
         } elsif ($char eq ']') {
             $depth--;
         } elsif ($char eq ' ') {
         } elsif ($char eq '*') {
-            $tester->is_eq($node->{focused}, 1, 'Correct node focused');
+            $tester->is_eq($node->{focused}, 1, "Correct node focused in depth $depth, node numer " . $counters{$depth});
         } elsif ($char =~ /[[:alnum:]]/) {
             $node_name = $char;
         } else {
             die "Could not understand $char";
         }
 
-        if ($node_layout || $node_name) {
+        if ($node_layout_defined || $node_name) {
             if (exists($counters{$depth})) {
                 $counters{$depth} = $counters{$depth} + 1;
             } else {
@@ -1298,8 +1338,19 @@ sub verify_layout {
                 $node = $node->{nodes}->[$counters{$i}];
             }
 
-            if ($node_layout) {
+            if ($node_layout_defined) {
+                if ($node_layout_container_focused) {
+                    $tester->is_eq($node->{focused}, 1, "Correct node focused in depth $depth, node numer " . $counters{$depth});
+                }
+
                 $tester->is_eq($node->{layout}, $node_layout, "Layouts match in depth $depth, node number " . $counters{$depth});
+                $tester->is_eq($node->{layout_fill_order}, $node_layout_fill_order, "Layout's fill order match in depth $depth, node number " . $counters{$depth});
+
+                $depth++;
+                delete $counters{$depth};
+
+                $node_layout_defined = 0;
+                $node_layout_container_focused = 0;
             } else {
                 $tester->is_eq($node->{name}, $node_name, "Names match in depth $depth, node number " . $counters{$depth});
             }

--- a/testcases/t/116-nestedcons.t
+++ b/testcases/t/116-nestedcons.t
@@ -62,6 +62,7 @@ my $expected = {
     swallows => $ignore,
     percent => undef,
     layout => 'splith',
+    layout_fill_order => 'default',
     floating => 'auto_off',
     last_split_layout => 'splith',
     scratchpad_state => 'none',

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -259,16 +259,24 @@ is(parser_calls($config),
 
 $config = <<'EOT';
 workspace_layout default
+workspace_layout default reverse
 workspace_layout stacked
+workspace_layout stacked reverse
 workspace_layout stacking
+workspace_layout stacking reverse
 workspace_layout tabbed
+workspace_layout tabbed reverse
 EOT
 
 $expected = <<'EOT';
-cfg_workspace_layout(default)
-cfg_workspace_layout(stacked)
-cfg_workspace_layout(stacking)
-cfg_workspace_layout(tabbed)
+cfg_workspace_layout(default, (null))
+cfg_workspace_layout(default, reverse)
+cfg_workspace_layout(stacked, (null))
+cfg_workspace_layout(stacked, reverse)
+cfg_workspace_layout(stacking, (null))
+cfg_workspace_layout(stacking, reverse)
+cfg_workspace_layout(tabbed, (null))
+cfg_workspace_layout(tabbed, reverse)
 EOT
 
 is(parser_calls($config),

--- a/testcases/t/509-workspace_layout.t
+++ b/testcases/t/509-workspace_layout.t
@@ -17,7 +17,13 @@
 # Tests whether workspace_layout is properly set after startup.
 #
 use List::Util qw(first);
-use i3test i3_config => <<EOT;
+use i3test i3_autostart => 0;
+
+################################################################################
+# Test that workspace_layout is properly set
+################################################################################
+
+my $config = <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -25,12 +31,56 @@ fake-outputs 1024x768+0+0
 workspace_layout tabbed
 EOT
 
-################################################################################
-# Test that workspace_layout is properly set
-################################################################################
+my $pid = launch_with_config($config);
 
 is(focused_ws, '1', 'starting on workspace 1');
 my $ws = get_ws(1);
 is($ws->{workspace_layout}, 'tabbed', 'workspace layout is "tabbed"');
+is($ws->{layout_fill_order}, 'default', 'unspecified workspace layout fill order reverts to "default"');
+
+exit_gracefully($pid);
+
+################################################################################
+# Test that workspace_layout fill order is properly set
+################################################################################
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+fake-outputs 1024x768+0+0
+workspace_layout stacked reverse
+EOT
+
+$pid = launch_with_config($config);
+
+my $tmp = fresh_workspace;
+$ws = get_ws($tmp);
+
+is($ws->{workspace_layout}, 'stacked', 'workspace layout is "stacked"');
+is($ws->{layout_fill_order}, 'reverse', 'workspace layout fill order is "reverse"');
+
+exit_gracefully($pid);
+
+################################################################################
+# Test that workspace_layout fill order falls back to default on unknown value
+################################################################################
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+fake-outputs 1024x768+0+0
+workspace_layout stacked foobar
+EOT
+
+$pid = launch_with_config($config);
+
+$tmp = fresh_workspace;
+$ws = get_ws($tmp);
+
+is($ws->{layout_fill_order}, 'default', 'unknown workspace layout fill order config is translated to "default"');
+
+exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/543-layout-reverse.t
+++ b/testcases/t/543-layout-reverse.t
@@ -166,4 +166,20 @@ cmd 'layout fill_order toggle';
 ($nodes, $focus) = get_ws_content($tmp);
 is($nodes->[1]->{layout_fill_order}, 'default', 'layout fill order was toggled to default');
 
+################################################################################
+# Make sure that command 'layout <layout> reverse' works as expected
+################################################################################
+
+$tmp = fresh_workspace;
+
+open_window;
+open_window;
+cmd 'split v';
+open_window;
+
+cmd 'layout stacked reverse';
+my $split = @{get_ws_content($tmp)}[1];
+is($split->{layout}, 'stacked', 'layout stacked');
+is($split->{layout_fill_order}, 'reverse', 'layout fill order is reverse');
+
 done_testing;

--- a/testcases/t/543-layout-reverse.t
+++ b/testcases/t/543-layout-reverse.t
@@ -1,0 +1,119 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests reverse layouts.
+use i3test;
+use File::Temp qw(tempfile);
+use IO::Handle;
+
+my $tmp = fresh_workspace;
+
+################################################################################
+# Make sure cmp_tree() knows what to do with reverse layouts
+################################################################################
+
+cmp_tree(
+    msg => "Reverse layout sanity check for cmp_tree()",
+    ws => $tmp,
+    layout_before => 'V[c d* Tr[e f g]]',
+    layout_after => 'V[c d Tr[e f g]]',
+    cb => sub {
+        cmd 'focus next sibling';
+    });
+
+my @content = @{get_ws_content($tmp)};
+is($content[0]->{nodes}[2]->{layout_fill_order}, 'reverse', 'manually check that layout created by cmp_tree has to correct fill order');
+
+################################################################################
+# Make sure fill_order is correctly restored.
+################################################################################
+
+ok(!workspace_exists('ws_reverse'), 'workspace "ws_reverse" does not exist yet');
+
+my ($fh, $filename) = tempfile(UNLINK => 1);
+print $fh <<'EOT';
+// vim:ts=4:sw=4:et
+{
+    "border": "pixel",
+    "floating": "auto_off",
+    "layout": "splith",
+    "type": "workspace",
+    "name": "ws_reverse",
+    "layout_fill_order": "reverse",
+    "nodes": [
+        {
+            "border": "pixel",
+            "floating": "auto_off",
+            "layout": "tabbed",
+            "type": "con",
+            "layout_fill_order": "default",
+            "nodes": [
+                {
+                    "border": "pixel",
+                    "floating": "auto_off",
+                    "layout": "splith",
+                    "type": "con",
+                    "layout_fill_order": "default",
+                    "nodes": [
+                        {
+                            "border": "pixel",
+                            "floating": "auto_off",
+                            "type": "con"
+                        },
+                        {
+                            "border": "pixel",
+                            "floating": "auto_off",
+                            "type": "con"
+                        }
+                    ]
+                },
+                {
+                    "border": "pixel",
+                    "floating": "auto_off",
+                    "type": "con"
+                }
+            ]
+        },
+        {
+            "border": "pixel",
+            "floating": "auto_off",
+            "layout": "splitv",
+            "type": "con",
+            "layout_fill_order": "reverse"
+        }
+    ]
+}
+EOT
+$fh->flush;
+cmd "append_layout $filename";
+
+ok(workspace_exists('ws_reverse'), 'workspace "ws_reverse" exists now');
+
+my $ws = get_ws('ws_reverse');
+is($ws->{layout_fill_order}, 'reverse', 'workspace fill order is reverse');
+
+@content = @{$ws->{nodes}};
+is(@content, 2, 'workspace has two nodes');
+is($content[0]->{layout_fill_order}, 'default', 'child node one has default fill order');
+is($content[1]->{layout_fill_order}, 'reverse', 'child node two has reverse fill order');
+
+################################################################################
+# Test that con_get_tree_representation returns the correct layout string
+################################################################################
+
+# TODO Unable to find a method to the i3-frame titles
+
+done_testing;

--- a/testcases/t/543-layout-reverse.t
+++ b/testcases/t/543-layout-reverse.t
@@ -15,9 +15,14 @@
 #   (unless you are already familiar with Perl)
 #
 # Tests reverse layouts.
-use i3test;
+
+# disable autostart here so that we can test using workspace_layout config
+# option later on.
+use i3test i3_autostart => 0;
 use File::Temp qw(tempfile);
 use IO::Handle;
+
+my $pid = launch_with_config("");
 
 my $tmp = fresh_workspace;
 
@@ -35,7 +40,7 @@ cmp_tree(
     });
 
 my @content = @{get_ws_content($tmp)};
-is($content[0]->{nodes}[2]->{layout_fill_order}, 'reverse', 'manually check that layout created by cmp_tree has to correct fill order');
+is($content[0]->{nodes}[2]->{layout_fill_order}, 'reverse', 'manually check that the layout created by cmp_tree has the correct fill order');
 
 ################################################################################
 # Make sure fill_order is correctly restored.
@@ -181,5 +186,203 @@ cmd 'layout stacked reverse';
 my $split = @{get_ws_content($tmp)}[1];
 is($split->{layout}, 'stacked', 'layout stacked');
 is($split->{layout_fill_order}, 'reverse', 'layout fill order is reverse');
+
+################################################################################
+# Test that the layout_fill_order affects how containers get inserted into a layout)
+################################################################################
+
+# splitv
+$tmp = fresh_workspace;
+
+open_window;
+open_window name => 'foo';
+cmd 'split v';
+open_window name => 'bar';
+
+cmd 'layout fill_order reverse';
+open_window name => 'baz';
+
+$split = @{get_ws_content($tmp)}[1];
+is($split->{nodes}[1]->{name}, 'baz', 'window baz was inserted before window bar (index 1)');
+is($split->{nodes}[2]->{name}, 'bar', 'window bar comes after window baz');
+
+open_window name => 'qux';
+$split = @{get_ws_content($tmp)}[1];
+is($split->{nodes}[1]->{name}, 'qux', 'window qux was inserted before window baz (index 0)');
+
+# splith
+$tmp = fresh_workspace;
+
+open_window;
+open_window name => 'foo';
+cmd 'split h';
+open_window name => 'bar';
+
+cmd 'layout fill_order reverse';
+open_window name => 'baz';
+
+$split = @{get_ws_content($tmp)}[1];
+is($split->{nodes}[1]->{name}, 'baz', 'window baz was inserted before window bar (index 1)');
+is($split->{nodes}[2]->{name}, 'bar', 'window bar comes after window baz');
+
+# tabbed
+$tmp = fresh_workspace;
+
+open_window;
+open_window name => 'foo';
+cmd 'split h';
+open_window name => 'bar';
+
+cmd 'layout tabbed';
+cmd 'layout fill_order reverse';
+open_window name => 'baz';
+
+$split = @{get_ws_content($tmp)}[1];
+is($split->{nodes}[1]->{name}, 'baz', 'window baz was inserted before window bar (index 1)');
+is($split->{nodes}[2]->{name}, 'bar', 'window bar comes after window baz');
+
+# stacking
+$tmp = fresh_workspace;
+
+open_window;
+open_window name => 'foo';
+cmd 'split h';
+open_window name => 'bar';
+
+cmd 'layout stacking';
+cmd 'layout fill_order reverse';
+open_window name => 'baz';
+
+$split = @{get_ws_content($tmp)}[1];
+is($split->{nodes}[1]->{name}, 'baz', 'window baz was inserted before window bar (index 1)');
+is($split->{nodes}[2]->{name}, 'bar', 'window bar comes after window baz');
+
+exit_gracefully($pid);
+
+################################################################################
+# Test that workspace_attach_to() sets the correct layout fill order for new splits
+################################################################################
+
+my $config = <<EOT;
+workspace_layout stacking reverse
+EOT
+
+$pid = launch_with_config($config);
+
+$tmp = fresh_workspace;
+
+open_window;
+open_window;
+
+@content = @{get_ws_content($tmp)};
+is($content[0]->{layout}, 'stacked', 'workspace child node has stacking layout');
+is($content[0]->{layout_fill_order}, 'reverse', 'workspace child node has reverse layout fill order');
+
+exit_gracefully($pid);
+
+################################################################################
+# Test that workspace_encapsulate() sets the correct layout fill order (via tree_split)
+################################################################################
+
+my $config = <<EOT;
+workspace_layout default reverse
+EOT
+
+$pid = launch_with_config($config);
+
+$tmp = fresh_workspace;
+
+open_window;
+open_window;
+cmd 'focus parent';
+cmd 'split v';
+open_window;
+
+@content = @{get_ws_content($tmp)};
+is($content[1]->{layout_fill_order}, 'reverse', 'workspace child node has reverse layout fill order');
+
+################################################################################
+# Make sure that floating cons get correctly inserted into reverse layout tiling cons
+################################################################################
+cmp_tree(
+    msg => 'moving con into reverse layout inserts it before the last focused con, part 1',
+    layout_before => 'H[Vr[a b*] c]',
+    layout_after => 'H[Vr[a c* b]]',
+    cb => sub {
+        cmd '[class=c] focus';
+        cmd 'move left';
+    });
+
+$tmp = fresh_workspace;
+cmd 'layout splitv'; # We explicitely set the workspace layout to splitv to
+                     # prevent tree_flatten() from removing the outer V[] and
+                     # Hr[] splits. See issues #3503 and #3003.
+cmp_tree(
+    msg => 'moving con into reverse layout inserts it before the last focused con, part 2',
+    layout_before => 'V[a Hr[b c* d]]',
+    layout_after => 'V[Hr[b a c d]]',
+    ws => $tmp,
+    cb => sub {
+        cmd '[class=a] focus';
+        cmd 'move down';
+    });
+
+cmp_tree(
+    msg => "command 'floating disable' inserts container before tiling focused container in reverse layouts, part 1",
+    layout_before => 'Hr[a b c d*]',
+    layout_after => 'Hr[a d* b c]',
+    cb => sub {
+        cmd 'floating enable';
+        cmd '[class=b] focus';
+        cmd 'focus floating';
+        cmd 'floating disable';
+    });
+
+cmp_tree(
+    msg => "command 'floating disable' inserts container before tiling focused container in reverse layouts, part 2",
+    layout_before => 'H[a Vr[b S[c d e]] f*]',
+    layout_after => 'H[a Vr[f* b S[c d e]]]',
+    cb => sub {
+        cmd 'floating enable';
+        cmd '[class=b] focus';
+        cmd 'focus floating';
+        cmd 'floating disable';
+    });
+
+################################################################################
+# Make sure calls to insert_con_into() take layout fill order into account
+################################################################################
+
+# There are three places insert_con_into() gets called which these three
+# cmp_tree() tests below supposed to invoke. Really, only the first two require
+# special fill order handling.
+
+cmp_tree(
+    msg => 'moving con into reverse layout inserts it before the last focused con',
+    layout_before => 'H[Vr[a b*] c]',
+    layout_after => 'H[Vr[a c* b]]',
+    cb => sub {
+        cmd '[class=c] focus';
+        cmd 'move left';
+    });
+
+cmp_tree(
+    msg => "move con into bordering branch of an adjacent container with reverse fill order",
+    layout_before => 'H[Vr[a* b] Vr[c d]]',
+    layout_after => 'H[Vr[c* a b] Vr[d]]',
+    cb => sub {
+        cmd '[class=c] focus';
+        cmd 'move left';
+    });
+
+cmp_tree(
+    msg => 'moving con into parent container with reverse fill order',
+    layout_before => 'Hr[V[a b* c]]',
+    layout_after => 'Hr[V[a c] b*]',
+    cb => sub {
+        cmd 'move right';
+    });
+
+exit_gracefully($pid);
 
 done_testing;

--- a/testcases/t/543-layout-reverse.t
+++ b/testcases/t/543-layout-reverse.t
@@ -116,4 +116,54 @@ is($content[1]->{layout_fill_order}, 'reverse', 'child node two has reverse fill
 
 # TODO Unable to find a method to the i3-frame titles
 
+################################################################################
+# Test that the layout fill_order command works on workspaces
+################################################################################
+
+$tmp = fresh_workspace;
+
+$ws = get_ws($tmp);
+is($ws->{layout_fill_order}, 'default', 'ensure the default layout fill order');
+
+cmd 'layout fill_order reverse';
+$ws = get_ws($tmp);
+is($ws->{layout_fill_order}, 'reverse', 'cmd "layout fill_order reverse" changes layout_fill_order to "reverse"');
+
+cmd 'layout fill_order default';
+$ws = get_ws($tmp);
+is($ws->{layout_fill_order}, 'default', 'cmd "layout fill_order default" changes layout_fill_order to "default"');
+
+cmd 'layout fill_order toggle';
+$ws = get_ws($tmp);
+is ($ws->{layout_fill_order}, 'reverse', 'cmd "layout fill_order toggle" changes layout_fill_order from "default" -> "reverse"');
+cmd 'layout fill_order toggle';
+$ws = get_ws($tmp);
+is ($ws->{layout_fill_order}, 'default', 'cmd "layout fill_order toggle" changes layout_fill_order from "reverse" -> "default"');
+
+cmd 'layout fill_order foobar';
+$ws = get_ws($tmp);
+is ($ws->{layout_fill_order}, 'default', 'nonsensical layout fill_order option leaves fill order at default');
+
+################################################################################
+# Test the layout fill_order command works on containers down the tree
+################################################################################
+
+$tmp = fresh_workspace;
+
+open_window;
+open_window;
+cmd 'split v';
+open_window;
+
+my ($nodes, $focus) = get_ws_content($tmp);
+is($nodes->[1]->{layout_fill_order}, 'default', 'layout fill order is default currently');
+
+cmd 'layout fill_order reverse';
+($nodes, $focus) = get_ws_content($tmp);
+is($nodes->[1]->{layout_fill_order}, 'reverse', 'layout fill order is reverse now');
+
+cmd 'layout fill_order toggle';
+($nodes, $focus) = get_ws_content($tmp);
+is($nodes->[1]->{layout_fill_order}, 'default', 'layout fill order was toggled to default');
+
 done_testing;


### PR DESCRIPTION
This is an implementation of #1767 (allow splitting to the left/top) and addresses the underlying desire to have layouts that are filled in from right to left and bottom to top.

I have dubbed this the "layout fill order" which has two values "default", and "reverse", where the former denotes the old behavior, where new windows get added on the right in horizontal layouts and on the bottom in vertical layouts. The latter reverses this order: windows get added to the left in horizontal layouts and to the top in vertical layouts.

I have had a tough time coming up with an actual name for this functionality, not sure if "layout fill order" is intuitive for everybody, so I'm open to suggestions.

Closes #1767.

### Implementation

The discussion in #1767 suggested adding additional layouts that are populated in reverse (by extending `layout_t`), but I think that begs a larger refactoring as in many places, the normal layout is equivalent with its reverse counterpart (let's say `L_SPLITH` and `L_SPLITH_REVERSE`), requiring layout checks to be doubled from `layout == L_SPLITH` to `layout == L_SPLITH || layout == L_SPLITH_REVERSE`.

To me, the way how a layout is populated with new windows is orthogonal to the layout itself. On a lower level, all the fill order does, is affect whether a new child node gets prepended or appended to the list of existing child nodes of a parent container, regardless of the actual layout itself. My solution is to store this in an additional property side-by-side with the layout. This let's me keep existing layout checks intact and only requires updating the few places that care about the fill order (mainly `con_attach()`).

### User-facing changes

- command `split` was extended to accept the arguments `left`, `right`, `up`, and `down`
  - `split right` and `split down` are aliases for `split h` and `split v` respectively
  - `split left` creates a horizontal split with reverse fill order so that the next window gets attached to the left
  - `split up` is similar, but creates a vertical reverse split
- command `workspace_layout <layout>` now accepts an additional argument `reverse` to set the default fill order for workspaces to reverse
- command `layout <default|stacked|stacking|tabbed|splitv|splith>` received an optional argument `reverse`
  - for example `layout splith reverse` changes the layout to splith with a reversed fill order (new window will get inserted before focused window instead of after).
- command `layout fill_order [default|reverse|toggle]` allows changing the fill order independent of the layout
- split indicators are drawn close to where a new window will appear
  - for a horizontal split with default fill order, the indicator will be drawn on the right border (as before)
  - for a horizontal split with reverse fill order, the indicator will be drawn on the left border
  - vice-versa for vertical splits
- the tree representation string format (mostly seen in container titles and the testsuite) uses the 'r' suffix to denote splits with reverse fill order, for example `Vr[]` for a vertical split with reverse fill order.

### TODO

Currently, documentation is missing completely as that makes only sense to add when the maintainers are happy with the implementation.