### PR TITLE
i3-sensible-terminal: prioritize terminals with good accessibility

### DIFF
--- a/i3-sensible-terminal
+++ b/i3-sensible-terminal
@@ -8,7 +8,13 @@
 # We welcome patches that add distribution-specific mechanisms to find the
 # preferred terminal emulator. On Debian, there is the x-terminal-emulator
 # symlink for example.
-for terminal in "$TERMINAL" x-terminal-emulator urxvt rxvt termit terminator Eterm aterm uxterm xterm gnome-terminal roxterm xfce4-terminal termite lxterminal mate-terminal terminology st qterminal lilyterm tilix terminix konsole kitty guake tilda alacritty hyper; do
+#
+# Invariants:
+# 1. $TERMINAL must come first
+# 2. Distribution-specific mechanisms come next, e.g. x-terminal-emulator
+# 3. The terminal emulator with best accessibility comes first.
+# 4. No order is guaranteed/desired for the remaining terminal emulators.
+for terminal in "$TERMINAL" x-terminal-emulator mate-terminal gnome-terminal terminator xfce4-terminal urxvt rxvt termit Eterm aterm uxterm xterm roxterm termite lxterminal terminology st qterminal lilyterm tilix terminix konsole kitty guake tilda alacritty hyper; do
     if command -v "$terminal" > /dev/null 2>&1; then
         exec "$terminal" "$@"
     fi

--- a/man/i3-sensible-terminal.man
+++ b/man/i3-sensible-terminal.man
@@ -23,20 +23,20 @@ It tries to start one of the following (in that order):
 
 * $TERMINAL (this is a non-standard variable)
 * x-terminal-emulator (only present on Debian and derivatives)
+* mate-terminal
+* gnome-terminal
+* terminator
+* xfce4-terminal
 * urxvt
 * rxvt
 * termit
-* terminator
 * Eterm
 * aterm
 * uxterm
 * xterm
-* gnome-terminal
 * roxterm
-* xfce4-terminal
 * termite
 * lxterminal
-* mate-terminal
 * terminology
 * st
 * qterminal


### PR DESCRIPTION
We never did (and still do not) guarantee any order in which terminal emulators
are tried. Quoting from the i3-sensible-terminal man page:

> Please don’t complain about the order: If the user has any preference, they
> will have $TERMINAL set or modified their i3 configuration file.

This commit moves mate-terminal to the beginning of the list, which is
considered the most accessible terminal emulator among blind users.

fixes https://github.com/i3/i3/issues/4256