### PR TITLE
Fails to build with "'GENERATED_command_enums.h' file not found"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -514,6 +514,7 @@ executable(
     'i3-config-wizard/i3-config-wizard-atoms.xmacro.h',
     'i3-config-wizard/main.c',
     'i3-config-wizard/xcb.h',
+    config_parser,
   ],
   install: true,
   include_directories: include_directories('include', 'i3-config-wizard'),
@@ -669,7 +670,10 @@ executable(
 
 executable(
   'test.commands_parser',
-  'src/commands_parser.c',
+  [
+    'src/commands_parser.c',
+    command_parser,
+  ],
   include_directories: inc,
   c_args: '-DTEST_PARSER',
   dependencies: common_deps,
@@ -678,7 +682,10 @@ executable(
 
 executable(
   'test.config_parser',
-  'src/config_parser.c',
+  [
+    'src/config_parser.c',
+    config_parser,
+  ],
   include_directories: inc,
   c_args: '-DTEST_PARSER',
   dependencies: common_deps,


### PR DESCRIPTION
I maintain i3-gaps port on FreeBSD and it intermittently fails to build with the following error:
```
[1/135] sh -c 'cp -r /wrkdirs/usr/ports/x11-wm/i3-gaps/work/i3-4.19/AnyEvent-I3 . && cd AnyEvent-I3 && perl Makefile.PL && make && touch ../AnyEvent-I3.stamp'
Warning: prerequisite AnyEvent 0 not found.
Warning: prerequisite AnyEvent::Handle 0 not found.
Warning: prerequisite AnyEvent::Socket 0 not found.
Warning: prerequisite JSON::XS 0 not found.
Checking if your kit is complete...
Looks good
Generating a Unix-style Makefile
Writing Makefile for AnyEvent::I3
Writing MYMETA.yml and MYMETA.json
cp lib/AnyEvent/I3.pm blib/lib/AnyEvent/I3.pm
Manifying 1 pod document
[2/135] /usr/local/bin/meson --internal vcstagger config.h.in config.h '4.19 (2020-11-15)' /wrkdirs/usr/ports/x11-wm/i3-gaps/work/i3-4.19 @VCS_TAG@ '(.*)' ' '
[3/135] cc -Itest.commands_parser.p -I. -I.. -I../include -I/usr/local/include/startup-notification-1.0 -I/usr/local/include -I/usr/local/include/cairo -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/include -I/usr/local/include/pixman-1 -I/usr/local/include/freetype2 -I/usr/local/include/libdrm -I/usr/local/include/libpng16 -I/usr/local/include/pango-1.0 -I/usr/local/include/fribidi -I/usr/local/include/harfbuzz -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c11 -O3 -Wunused-value -D_GNU_SOURCE -O2 -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing -DLIBICONV_PLUG -isystem /usr/local/include -pthread -D_THREAD_SAFE -DTEST_PARSER -MD -MQ test.commands_parser.p/src_commands_parser.c.o -MF test.commands_parser.p/src_commands_parser.c.o.d -o test.commands_parser.p/src_commands_parser.c.o -c ../src/commands_parser.c
FAILED: test.commands_parser.p/src_commands_parser.c.o
cc -Itest.commands_parser.p -I. -I.. -I../include -I/usr/local/include/startup-notification-1.0 -I/usr/local/include -I/usr/local/include/cairo -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/include -I/usr/local/include/pixman-1 -I/usr/local/include/freetype2 -I/usr/local/include/libdrm -I/usr/local/include/libpng16 -I/usr/local/include/pango-1.0 -I/usr/local/include/fribidi -I/usr/local/include/harfbuzz -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c11 -O3 -Wunused-value -D_GNU_SOURCE -O2 -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing -DLIBICONV_PLUG -isystem /usr/local/include -pthread -D_THREAD_SAFE -DTEST_PARSER -MD -MQ test.commands_parser.p/src_commands_parser.c.o -MF test.commands_parser.p/src_commands_parser.c.o.d -o test.commands_parser.p/src_commands_parser.c.o -c ../src/commands_parser.c
../src/commands_parser.c:40:10: fatal error: 'GENERATED_command_enums.h' file not found
#include "GENERATED_command_enums.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```

I'm not very familiar with meson, but it seems that `command_parser` and `config_parser` need to be declared as dependencies instead of sources to make sure generated sources are ready before i3 build starts.

This PR seems to fix these build errors.