### PR TITLE
Use docdir for all docs when building (Fixes #4268)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -643,7 +643,7 @@ if get_option('docs')
       '@OUTPUT@',
     ],
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'doc', 'i3'),
+    install_dir: docdir,
   )
 
   custom_target(
@@ -656,7 +656,7 @@ if get_option('docs')
       '@OUTPUT@',
     ],
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'doc', 'i3'),
+    install_dir: docdir,
   )
 endif
 


### PR DESCRIPTION
Trivial build fix to use docdir for doc installation instead of datadir/doc/i3 for lib-i3test.html and lib-i3test-test.html.