### PR TITLE
Clear pixmap to black before starting to draw

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -22,3 +22,4 @@ strongly encouraged to upgrade.
   • when initializing new outputs, avoid duplicating workspace numbers
   • fix workspaces not moving to assigned output after output becomes available
   • fix duplicate bindcode after i3-config-wizard
+  • clear pixmap before drawing to prevent visual grabage in clients using 'Shape'

--- a/src/x.c
+++ b/src/x.c
@@ -706,6 +706,7 @@ void x_draw_decoration(Con *con) {
 
     x_draw_decoration_after_title(con, p);
 copy_pixmaps:
+    draw_util_clear_surface(&(con->frame_buffer), (color_t){.red = 0.0, .green = 0.0, .blue = 0.0});
     draw_util_copy_surface(&(con->frame_buffer), &(con->frame), 0, 0, 0, 0, con->rect.width, con->rect.height);
 }
 


### PR DESCRIPTION
This bug appears to still be kicking around, so here's a stab at it.

Added a call to clear the framebuffer before writing to it. In addition to running the test suite, also tested with `xeyes`, and background was black as expected.

I've updated the release notes to mention this bugfix.

fixes #3481 