### PR TITLE
Add missing SYNC Reply type in IPC docs

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -132,6 +132,8 @@ GET_CONFIG (9)::
 	Reply to the GET_CONFIG message.
 TICK (10)::
 	Reply to the SEND_TICK message.
+SYNC (11)::
+	Reply to the SYNC message.
 GET_BINDING_STATE (12)::
 	Reply to the GET_BINDING_STATE message.
 


### PR DESCRIPTION
[Reply format in IPC](https://i3wm.org/docs/ipc.html#_receiving_replies_from_i3) page doesn't list SYNC reply.

Fixes https://github.com/i3/i3.github.io/issues/65
Original PR https://github.com/i3/i3.github.io/pull/66/