### PR TITLE
Add title_height and bar { height } config parameters

### DIFF
--- a/i3bar/include/configuration.h
+++ b/i3bar/include/configuration.h
@@ -55,6 +55,7 @@ typedef struct config_t {
     char *fontname;
     i3String *separator_symbol;
     TAILQ_HEAD(tray_outputs_head, tray_output_t) tray_outputs;
+    int height;
     int tray_padding;
     int num_outputs;
     char **outputs;

--- a/i3bar/include/workspaces.h
+++ b/i3bar/include/workspaces.h
@@ -35,6 +35,7 @@ struct i3_ws {
     char *canonical_name;     /* The true name of the ws according to the ipc */
     i3String *name;           /* The name of the ws that is displayed on the bar */
     int name_width;           /* The rendered width of the name */
+    int button_width;         /* The rendered width of the button */
     bool visible;             /* If the ws is currently visible on an output */
     bool focused;             /* If the ws is currently focused */
     bool urgent;              /* If the urgent hint of the ws is set */

--- a/i3bar/include/xcb.h
+++ b/i3bar/include/xcb.h
@@ -133,6 +133,18 @@ void reconfig_windows(bool redraw_bars);
 void draw_bars(bool force_unhide);
 
 /*
+ * Returns the width of a workspace's button
+ *
+ */
+int workspace_button_width(i3_ws *ws);
+
+/*
+ * Returns the width of a biding button
+ *
+ */
+int binding_button_width(mode binding);
+
+/*
  * Redraw the bars, i.e. simply copy the buffer to the barwindow
  *
  */

--- a/i3bar/src/config.c
+++ b/i3bar/src/config.c
@@ -337,6 +337,12 @@ static int config_integer_cb(void *params_, long long val) {
         return 1;
     }
 
+    if (!strcmp(cur_key, "height")) {
+        DLOG("height = %lld\n", val);
+        config.height = val;
+        return 1;
+    }
+
     if (!strcmp(cur_key, "modifier")) {
         DLOG("modifier = %lld\n", val);
         config.modifier = (uint32_t)val;

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -62,6 +62,12 @@ xcb_colormap_t colormap;
 /* Overall height of the bar (based on font size) */
 int bar_height;
 
+/* Horizontal padding of the bar */
+int bar_padding_h;
+
+/* Vertical padding of the bar */
+int bar_padding_v;
+
 /* These are only relevant for XKB, which we only need for grabbing modifiers */
 int xkb_base;
 bool mod_pressed = 0;
@@ -180,7 +186,7 @@ static void draw_separator(i3_output *output, uint32_t x, struct status_block *b
         /* Draw a custom separator. */
         uint32_t separator_x = MAX(x - block->sep_block_width, center_x - separator_symbol_width / 2);
         draw_util_text(config.separator_symbol, &output->statusline_buffer, sep_fg, bar_bg,
-                       separator_x, logical_px(ws_voff_px), x - separator_x);
+                       separator_x, bar_padding_v, x - separator_x);
     }
 }
 
@@ -306,7 +312,7 @@ static void draw_statusline(i3_output *output, uint32_t clip_left, bool use_focu
 
         draw_util_text(text, &output->statusline_buffer, fg_color, bg_color,
                        x + render->x_offset + has_border * logical_px(block->border_left),
-                       bar_height / 2 - font.height / 2,
+                       bar_padding_v,
                        render->width - has_border * logical_px(block->border_left + block->border_right));
         x += full_render_width;
 
@@ -1355,7 +1361,12 @@ void init_xcb_late(char *fontname) {
     font = load_font(fontname, true);
     set_font(&font);
     DLOG("Calculated font height: %d\n", font.height);
-    bar_height = font.height + 2 * logical_px(ws_voff_px);
+    bar_height = logical_px(config.height);
+    if (bar_height == 0) {
+        bar_height = font.height + 2 * logical_px(ws_voff_px);
+    }
+    bar_padding_v = (bar_height - font.height) / 2;
+    bar_padding_h = (bar_height - font.size) / 2;
     icon_size = bar_height - 2 * logical_px(config.tray_padding);
 
     if (config.separator_symbol)
@@ -1968,23 +1979,43 @@ void reconfig_windows(bool redraw_bars) {
     }
 }
 
+int workspace_button_width(i3_ws *ws) {
+    int width = ws->name_width + 2 * logical_px(ws_hoff_px) + 2 * logical_px(1);
+    if (width < bar_height) {
+        width = bar_height;
+    }
+    return width;
+}
+
+int binding_button_width(mode binding) {
+    int width = binding.name_width + 2 * logical_px(ws_hoff_px) + 2 * logical_px(1);
+    if (width < bar_height) {
+        width = bar_height;
+    }
+    return width;
+}
+
 /*
  * Draw the button for a workspace or the current binding mode indicator.
  *
  */
 static void draw_button(surface_t *surface, color_t fg_color, color_t bg_color, color_t border_color,
-                        int x, int width, int text_width, i3String *text) {
-    int height = font.height + 2 * logical_px(ws_voff_px) - 2 * logical_px(1);
-
+                        int x, int width, int text_width, int height, i3String *text) {
     /* Draw the border of the button. */
-    draw_util_rectangle(surface, border_color, x, logical_px(1), width, height);
+    draw_util_rectangle(surface, border_color, width, logical_px(1), width,
+                        height - 2 * logical_px(1));
 
     /* Draw the inside of the button. */
-    draw_util_rectangle(surface, bg_color, x + logical_px(1), 2 * logical_px(1),
-                        width - 2 * logical_px(1), height - 2 * logical_px(1));
+    draw_util_rectangle(surface, bg_color,
+                        width + logical_px(1),
+                        2 * logical_px(1),
+                        width - 2 * logical_px(1),
+                        height - 4 * logical_px(1));
 
-    draw_util_text(text, surface, fg_color, bg_color, x + (width - text_width) / 2,
-                   logical_px(ws_voff_px), text_width);
+    draw_util_text(text, surface, fg_color, bg_color,
+                    width + (width - text_width) / 2,
+                    bar_padding_v,
+                    text_width);
 }
 
 /*
@@ -2044,7 +2075,7 @@ void draw_bars(bool unhide) {
 
                 int w = predict_button_width(ws_walk->name_width);
                 draw_button(&(outputs_walk->buffer), fg_color, bg_color, border_color,
-                            workspace_width, w, ws_walk->name_width, ws_walk->name);
+                            workspace_width, w, ws_walk->name_width, bar_height, ws_walk->name);
 
                 workspace_width += w;
                 if (TAILQ_NEXT(ws_walk, tailq) != NULL)
@@ -2057,7 +2088,7 @@ void draw_bars(bool unhide) {
 
             int w = predict_button_width(binding.name_width);
             draw_button(&(outputs_walk->buffer), colors.binding_mode_fg, colors.binding_mode_bg,
-                        colors.binding_mode_border, workspace_width, w, binding.name_width, binding.name);
+                        colors.binding_mode_border, workspace_width, w, binding.name_width, bar_height, binding.name);
 
             unhide = true;
             workspace_width += w;
@@ -2083,6 +2114,7 @@ void draw_bars(bool unhide) {
 
             int16_t visible_statusline_width = MIN(statusline_width, max_statusline_width);
             int x_dest = outputs_walk->rect.w - tray_width - logical_px((tray_width > 0) * sb_hoff_px) - visible_statusline_width;
+            x_dest -= tray_width == 0 ? bar_padding_h : logical_px(2);
 
             draw_statusline(outputs_walk, clip_left, use_focus_colors, use_short_text);
             draw_util_copy_surface(&outputs_walk->statusline_buffer, &outputs_walk->buffer, 0, 0,

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -94,6 +94,7 @@ CFGFUN(bar_color, const char *colorclass, const char *border, const char *backgr
 CFGFUN(bar_socket_path, const char *socket_path);
 CFGFUN(bar_tray_output, const char *output);
 CFGFUN(bar_tray_padding, const long spacing_px);
+CFGFUN(bar_height, const long height_px);
 CFGFUN(bar_color_single, const char *colorclass, const char *color);
 CFGFUN(bar_status_command, const char *command);
 CFGFUN(bar_binding_mode_indicator, const char *value);

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -57,6 +57,7 @@ CFGFUN(fake_outputs, const char *outputs);
 CFGFUN(force_display_urgency_hint, const long duration_ms);
 CFGFUN(focus_on_window_activation, const char *mode);
 CFGFUN(title_align, const char *alignment);
+CFGFUN(title_height, const long height);
 CFGFUN(show_marks, const char *value);
 CFGFUN(hide_edge_borders, const char *borders);
 CFGFUN(assign_output, const char *output);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -278,6 +278,9 @@ struct Barconfig {
     /* Padding around the tray icons. */
     int tray_padding;
 
+    /* Bar height. */
+    int height;
+
     /** Path to the i3 IPC socket. This option is discouraged since programs
      * can find out the path by looking for the I3_SOCKET_PATH property on the
      * root window! */

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -203,6 +203,9 @@ struct Config {
         ALIGN_RIGHT
     } title_align;
 
+    /** Title height */
+    int title_height;
+
     /** The default border style for new windows. */
     border_style_t default_border;
 

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -66,6 +66,9 @@ struct Font {
     /** The height of the font, built from font_ascent + font_descent */
     int height;
 
+    /** Font size as described in config */
+    int size;
+
     /** The pattern/name used to load the font. */
     char *pattern;
 

--- a/libi3/font.c
+++ b/libi3/font.c
@@ -47,9 +47,11 @@ static bool load_pango_font(i3Font *font, const char *desc) {
         return false;
     }
 
+    int font_size = pango_font_description_get_size(font->specific.pango_desc) / PANGO_SCALE;
+
     LOG("Using Pango font %s, size %d\n",
         pango_font_description_get_family(font->specific.pango_desc),
-        pango_font_description_get_size(font->specific.pango_desc) / PANGO_SCALE);
+        font_size);
 
     /* We cache root_visual_type here, since you must call
      * load_pango_font before any other pango function
@@ -74,6 +76,7 @@ static bool load_pango_font(i3Font *font, const char *desc) {
 
     /* Set the font type and return successfully */
     font->type = FONT_TYPE_PANGO;
+    font->size = font_size;
     return true;
 }
 

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -487,6 +487,7 @@ state BAR:
   'output'                 -> BAR_OUTPUT
   'tray_output'            -> BAR_TRAY_OUTPUT
   'tray_padding'           -> BAR_TRAY_PADDING
+  'height'                 -> BAR_HEIGHT
   'font'                   -> BAR_FONT
   'separator_symbol'       -> BAR_SEPARATOR_SYMBOL
   'binding_mode_indicator' -> BAR_BINDING_MODE_INDICATOR
@@ -579,6 +580,16 @@ state BAR_TRAY_PADDING_PX:
       ->
   end
       -> call cfg_bar_tray_padding(&padding_px); BAR
+
+state BAR_HEIGHT:
+  height_px = number
+      -> BAR_HEIGHT_PX
+
+state BAR_HEIGHT_PX:
+  'px'
+      ->
+  end
+      -> call cfg_bar_height(&height_px); BAR
 
 state BAR_FONT:
   font = string

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -46,6 +46,7 @@ state INITIAL:
   'force_display_urgency_hint'             -> FORCE_DISPLAY_URGENCY_HINT
   'focus_on_window_activation'             -> FOCUS_ON_WINDOW_ACTIVATION
   'title_align'                            -> TITLE_ALIGN
+  'title_height'                           -> TITLE_HEIGHT
   'show_marks'                             -> SHOW_MARKS
   'workspace'                              -> WORKSPACE
   'ipc_socket', 'ipc-socket'               -> IPC_SOCKET
@@ -271,6 +272,10 @@ state FORCE_DISPLAY_URGENCY_HINT:
 state TITLE_ALIGN:
   alignment = 'left', 'center', 'right'
       -> call cfg_title_align($alignment)
+
+state TITLE_HEIGHT:
+  height = number
+      -> call cfg_title_height(&height)
 
 # show_marks
 state SHOW_MARKS:

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -621,6 +621,10 @@ CFGFUN(bar_tray_padding, const long padding_px) {
     current_bar->tray_padding = padding_px;
 }
 
+CFGFUN(bar_height, const long height) {
+    current_bar->height = height;
+}
+
 CFGFUN(bar_color_single, const char *colorclass, const char *color) {
     if (strcmp(colorclass, "background") == 0)
         current_bar->colors.background = sstrdup(color);

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -329,6 +329,10 @@ CFGFUN(title_align, const char *alignment) {
     }
 }
 
+CFGFUN(title_height, long height) {
+    config.title_height = height;
+}
+
 CFGFUN(show_marks, const char *value) {
     config.show_marks = eval_boolstr(value);
 }

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -767,6 +767,9 @@ static void dump_bar_config(yajl_gen gen, Barconfig *config) {
     ystr("tray_padding");
     y(integer, config->tray_padding);
 
+    ystr("height");
+    y(integer, config->height);
+
     YSTR_IF_SET(socket_path);
 
     ystr("mode");

--- a/src/render.c
+++ b/src/render.c
@@ -25,7 +25,10 @@ static void render_con_dockarea(Con *con, Con *child, render_params *p);
  * Returns the height for the decorations
  */
 int render_deco_height(void) {
-    int deco_height = config.font.height + 4;
+    int deco_height = config.title_height;
+    if (deco_height == 0) {
+        deco_height = config.font.height + 4 + logical_px(2);
+    }
     if (config.font.height & 0x01)
         ++deco_height;
     return deco_height;

--- a/src/x.c
+++ b/src/x.c
@@ -610,9 +610,9 @@ void x_draw_decoration(Con *con) {
     x_draw_title_border(con, p);
 
     /* 6: draw the title */
-    int text_offset_y = (con->deco_rect.height - config.font.height) / 2;
+    int deco_padding_h = (con->deco_rect.height - config.font.size) / 2;
+    int deco_padding_v = (con->deco_rect.height - config.font.height) / 2;
 
-    const int title_padding = logical_px(2);
     const int deco_width = (int)con->deco_rect.width;
     int mark_width = 0;
     if (config.show_marks && !TAILQ_EMPTY(&(con->marks_head))) {
@@ -636,16 +636,16 @@ void x_draw_decoration(Con *con) {
             mark_width = predict_text_width(mark);
 
             int mark_offset_x = (config.title_align == ALIGN_RIGHT)
-                                    ? title_padding
-                                    : deco_width - mark_width - title_padding;
+                                    ? deco_padding_h
+                                    : deco_width - mark_width - deco_padding_h;
 
             draw_util_text(mark, &(parent->frame_buffer),
                            p->color->text, p->color->background,
                            con->deco_rect.x + mark_offset_x,
-                           con->deco_rect.y + text_offset_y, mark_width);
+                           con->deco_rect.y + deco_padding_v, mark_width);
             I3STRING_FREE(mark);
 
-            mark_width += title_padding;
+            mark_width += deco_padding_h;
         }
 
         FREE(formatted_mark);
@@ -676,7 +676,7 @@ void x_draw_decoration(Con *con) {
     switch (config.title_align) {
         case ALIGN_LEFT:
             /* (pad)[text    ](pad)[mark + its pad) */
-            title_offset_x = title_padding;
+            title_offset_x = deco_padding_h;
             break;
         case ALIGN_CENTER:
             /* (pad)[  text  ](pad)[mark + its pad)
@@ -686,19 +686,19 @@ void x_draw_decoration(Con *con) {
              * where surface_width = deco_width - 2 * pad - mark_width
              * so, offset = pad + (surface_width - predict_text_width) / 2 =
              * = … = (deco_width - mark_width - predict_text_width) / 2 */
-            title_offset_x = max(title_padding, (deco_width - mark_width - predict_text_width(title)) / 2);
+            title_offset_x = max(deco_padding_h, (deco_width - mark_width - predict_text_width(title)) / 2);
             break;
         case ALIGN_RIGHT:
             /* [mark + its pad](pad)[    text](pad) */
-            title_offset_x = max(title_padding + mark_width, deco_width - title_padding - predict_text_width(title));
+            title_offset_x = max(deco_padding_h + mark_width, deco_width - deco_padding_h - predict_text_width(title));
             break;
     }
 
     draw_util_text(title, &(parent->frame_buffer),
                    p->color->text, p->color->background,
                    con->deco_rect.x + title_offset_x,
-                   con->deco_rect.y + text_offset_y,
-                   deco_width - mark_width - 2 * title_padding);
+                   con->deco_rect.y + deco_padding_v,
+                   deco_width - mark_width - 2 * deco_padding_h);
 
     if (win == NULL || con->title_format != NULL) {
         I3STRING_FREE(title);

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -539,6 +539,7 @@ my $expected_all_tokens = "ERROR: CONFIG: Expected one of these tokens: <end>, '
         force_display_urgency_hint
         focus_on_window_activation
         title_align
+        title_height
         show_marks
         workspace
         ipc_socket
@@ -626,10 +627,10 @@ EOT
 my $expected_tail = <<'EOT';
 ERROR: CONFIG: (in file <stdin>)
 ERROR: CONFIG: Line   3: font foobar
-ERROR: CONFIG: Line   4: 
+ERROR: CONFIG: Line   4:
 ERROR: CONFIG: Line   5: unknown qux
 ERROR: CONFIG:           ^^^^^^^^^^^
-ERROR: CONFIG: Line   6: 
+ERROR: CONFIG: Line   6:
 ERROR: CONFIG: Line   7: # yay
 EOT
 


### PR DESCRIPTION
This adds config options to set the height of the title window decoration and/or i3bar height.
With this users can add a bit more padding around the bar/title text, which can look better, depending on taste.

The defaults are of course kept as-is, so the default appearance won't change unless these parameters are specified.

Example of how I use `title_height`:
![image](https://user-images.githubusercontent.com/1712219/102712482-f5822300-42c1-11eb-9417-163087825c1e.png)
_(note: the border on top comes from another change on my fork, ignore it)_


