### PR TITLE
Revert "Clear pixmap to black before starting to draw"

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -22,4 +22,3 @@ strongly encouraged to upgrade.
   • when initializing new outputs, avoid duplicating workspace numbers
   • fix workspaces not moving to assigned output after output becomes available
   • fix duplicate bindcode after i3-config-wizard
-  • clear pixmap before drawing to prevent visual grabage in clients using 'Shape'

--- a/src/x.c
+++ b/src/x.c
@@ -706,7 +706,6 @@ void x_draw_decoration(Con *con) {
 
     x_draw_decoration_after_title(con, p);
 copy_pixmaps:
-    draw_util_clear_surface(&(con->frame_buffer), (color_t){.red = 0.0, .green = 0.0, .blue = 0.0});
     draw_util_copy_surface(&(con->frame_buffer), &(con->frame), 0, 0, 0, 0, con->rect.width, con->rect.height);
 }
 


### PR DESCRIPTION
Reverts i3/i3#4280

Adds black bars in my configuration:

before
![2021-01-03-011031_1919x456_scrot](https://user-images.githubusercontent.com/5778622/103469101-c60ef400-4d60-11eb-80c8-2d2c43959213.png)


after
![2021-01-03-011116_1919x384_scrot](https://user-images.githubusercontent.com/5778622/103469104-ca3b1180-4d60-11eb-9410-d62d367e89f2.png)


Re-opened #3481

CC @tbgiles