### PR TITLE
Clear framebuffer before drawing borders

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -22,3 +22,4 @@ strongly encouraged to upgrade.
   • when initializing new outputs, avoid duplicating workspace numbers
   • fix workspaces not moving to assigned output after output becomes available
   • fix duplicate bindcode after i3-config-wizard
+  • clear pixmap before drawing to prevent visual grabage in clients using 'Shape'

--- a/src/x.c
+++ b/src/x.c
@@ -486,7 +486,6 @@ void x_draw_decoration(Con *con) {
     if (leaf && con->frame_buffer.id == XCB_NONE)
         return;
 
-
     /* 1: build deco_params and compare with cache */
     struct deco_render_params *p = scalloc(1, sizeof(struct deco_render_params));
 

--- a/src/x.c
+++ b/src/x.c
@@ -706,6 +706,7 @@ void x_draw_decoration(Con *con) {
 
     x_draw_decoration_after_title(con, p);
 copy_pixmaps:
+    draw_util_clear_surface(&(con->frame_buffer), (color_t){.red = 0.0, .green = 0.0, .blue = 0.0});
     draw_util_copy_surface(&(con->frame_buffer), &(con->frame), 0, 0, 0, 0, con->rect.width, con->rect.height);
 }
 

--- a/src/x.c
+++ b/src/x.c
@@ -535,7 +535,6 @@ void x_draw_decoration(Con *con) {
     con->pixmap_recreated = false;
     con->mark_changed = false;
 
-
     /* Clear background before drawing. Clearing here makes sure we are in a 
      * state where we are expected to redraw the borders */
     draw_util_clear_surface(&(con->frame_buffer), (color_t){.red = 0.0, .green = 0.0, .blue = 0.0});

--- a/src/x.c
+++ b/src/x.c
@@ -468,7 +468,6 @@ void x_draw_decoration(Con *con) {
      *  • direct children of outputs or dockareas
      *  • floating containers (they don’t have a decoration)
      */
-
     if ((!leaf &&
          parent->layout != L_STACKED &&
          parent->layout != L_TABBED) ||
@@ -741,7 +740,6 @@ void x_deco_recurse(Con *con) {
             draw_util_copy_surface(&(con->frame_buffer), &(con->frame), 0, 0, 0, 0, con->rect.width, con->rect.height);
         }
     }
-
 
     if ((con->type != CT_ROOT && con->type != CT_OUTPUT) &&
         (!leaf || con->mapped))

--- a/src/x.c
+++ b/src/x.c
@@ -468,6 +468,7 @@ void x_draw_decoration(Con *con) {
      *  • direct children of outputs or dockareas
      *  • floating containers (they don’t have a decoration)
      */
+
     if ((!leaf &&
          parent->layout != L_STACKED &&
          parent->layout != L_TABBED) ||
@@ -485,6 +486,7 @@ void x_draw_decoration(Con *con) {
      * x_push_node() was not yet called) */
     if (leaf && con->frame_buffer.id == XCB_NONE)
         return;
+
 
     /* 1: build deco_params and compare with cache */
     struct deco_render_params *p = scalloc(1, sizeof(struct deco_render_params));
@@ -534,6 +536,11 @@ void x_draw_decoration(Con *con) {
     parent->pixmap_recreated = false;
     con->pixmap_recreated = false;
     con->mark_changed = false;
+
+
+    /* Clear background before drawing. Clearing here makes sure we are in a 
+     * state where we are expected to redraw the borders */
+    draw_util_clear_surface(&(con->frame_buffer), (color_t){.red = 0.0, .green = 0.0, .blue = 0.0});
 
     /* 2: draw the client.background, but only for the parts around the window_rect */
     if (con->window != NULL) {
@@ -706,7 +713,6 @@ void x_draw_decoration(Con *con) {
 
     x_draw_decoration_after_title(con, p);
 copy_pixmaps:
-    draw_util_clear_surface(&(con->frame_buffer), (color_t){.red = 0.0, .green = 0.0, .blue = 0.0});
     draw_util_copy_surface(&(con->frame_buffer), &(con->frame), 0, 0, 0, 0, con->rect.width, con->rect.height);
 }
 
@@ -735,6 +741,7 @@ void x_deco_recurse(Con *con) {
             draw_util_copy_surface(&(con->frame_buffer), &(con->frame), 0, 0, 0, 0, con->rect.width, con->rect.height);
         }
     }
+
 
     if ((con->type != CT_ROOT && con->type != CT_OUTPUT) &&
         (!leaf || con->mapped))


### PR DESCRIPTION
The framebuffer clear was done too late, causing window borders to be cleared too.

This PR fixes this by clearing the framebuffer before the call to draw the borders, instead of every time a pixmap copy happens.

Should mean that PR #4307 is no longer required.

Closes #3481 

CC: @orestisfl 