### PR TITLE
Revert "Clear framebuffer before drawing borders (#4308)"

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -25,7 +25,6 @@ strongly encouraged to upgrade.
   • when initializing new outputs, avoid duplicating workspace numbers
   • fix workspaces not moving to assigned output after output becomes available
   • fix duplicate bindcode after i3-config-wizard
-  • clear pixmap before drawing to prevent visual grabage in clients using 'Shape'
   • i3bar: properly close file descriptors
   • i3bar: properly restart status command after config change
   • i3bar: exit with 1 when a wrong command line argument is used

--- a/src/x.c
+++ b/src/x.c
@@ -535,10 +535,6 @@ void x_draw_decoration(Con *con) {
     con->pixmap_recreated = false;
     con->mark_changed = false;
 
-    /* Clear background before drawing. Clearing here makes sure we are in a 
-     * state where we are expected to redraw the borders */
-    draw_util_clear_surface(&(con->frame_buffer), (color_t){.red = 0.0, .green = 0.0, .blue = 0.0});
-
     /* 2: draw the client.background, but only for the parts around the window_rect */
     if (con->window != NULL) {
         /* top area */


### PR DESCRIPTION
This reverts commit 057a63527969598ad2301a1df5f5589c8e63cce5.

As discussed in #4308