### PR TITLE
Clear framebuffer for containers with visible windows

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -31,3 +31,4 @@ strongly encouraged to upgrade.
   • i3bar: properly restart status command after config change
   • i3bar: exit with 1 when a wrong command line argument is used
   • fix commented-out rofi call in default i3 config
+  • clear pixmap before drawing to prevent visual garbage

--- a/src/x.c
+++ b/src/x.c
@@ -537,6 +537,9 @@ void x_draw_decoration(Con *con) {
 
     /* 2: draw the client.background, but only for the parts around the window_rect */
     if (con->window != NULL) {
+        /* Clear visible windows before beginning to draw */
+        draw_util_clear_surface(&(con->frame_buffer), (color_t){.red = 0.0, .green = 0.0, .blue = 0.0});
+
         /* top area */
         draw_util_rectangle(&(con->frame_buffer), config.client.background,
                             0, 0, r->width, w->y);


### PR DESCRIPTION
From #4308, all containers were being cleared, rather than only on ones that will be showing a window. This meant that decorations in tabbed container were being cleared.

This PR clears the framebuffer on containers that contain visible windows (from the docs "meaning they represent an actual window instead of a split container").

Closes #3481