### PR TITLE
make vim keybindings actually be vim keybindings

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -37,10 +37,10 @@ bindsym XF86AudioMicMute exec --no-startup-id pactl set-source-mute @DEFAULT_SOU
 
 # use these keys for focus, movement, and resize directions when reaching for
 # the arrows is not convenient
-set $up l
-set $down k
-set $left j
-set $right semicolon
+set $up k
+set $down j
+set $left h
+set $right l
 
 # use Mouse+Mod1 to drag floating windows to their wanted position
 floating_modifier Mod1
@@ -84,7 +84,7 @@ bindsym Mod1+Shift+Up move up
 bindsym Mod1+Shift+Right move right
 
 # split in horizontal orientation
-bindsym Mod1+h split h
+bindsym Mod1+g split h
 
 # split in vertical orientation
 bindsym Mod1+v split v


### PR DESCRIPTION
Sadly, this means $mod+h can no longer mean split horizontally, but I moved that to $mod+g, since that is nearby. It should probably be changed to be more consistent.