### PR TITLE
i3bar: Fix font rendering for Caveat font

### DIFF
--- a/libi3/font.c
+++ b/libi3/font.c
@@ -128,6 +128,7 @@ static int predict_text_width_pango(const char *text, size_t text_len, bool pang
     cairo_surface_t *surface = cairo_xcb_surface_create(conn, root_screen->root, root_visual_type, 1, 1);
     cairo_t *cr = cairo_create(surface);
     PangoLayout *layout = create_layout_with_dpi(cr);
+    PangoRectangle ink_extent, layout_extent;
 
     /* Get the font width */
     gint width;
@@ -139,7 +140,8 @@ static int predict_text_width_pango(const char *text, size_t text_len, bool pang
         pango_layout_set_text(layout, text, text_len);
 
     pango_cairo_update_layout(cr, layout);
-    pango_layout_get_pixel_size(layout, &width, NULL);
+    pango_layout_get_pixel_extents(layout, &ink_extent, &layout_extent);
+    width = layout_extent.width + ink_extent.x;
 
     /* Free resources */
     g_object_unref(layout);

--- a/libi3/font.c
+++ b/libi3/font.c
@@ -128,7 +128,7 @@ static int predict_text_width_pango(const char *text, size_t text_len, bool pang
     cairo_surface_t *surface = cairo_xcb_surface_create(conn, root_screen->root, root_visual_type, 1, 1);
     cairo_t *cr = cairo_create(surface);
     PangoLayout *layout = create_layout_with_dpi(cr);
-    PangoRectangle ink_extent, layout_extent;
+    PangoRectangle ink_extent, logical_extent;
 
     /* Get the font width */
     gint width;
@@ -140,8 +140,8 @@ static int predict_text_width_pango(const char *text, size_t text_len, bool pang
         pango_layout_set_text(layout, text, text_len);
 
     pango_cairo_update_layout(cr, layout);
-    pango_layout_get_pixel_extents(layout, &ink_extent, &layout_extent);
-    width = layout_extent.width + ink_extent.x;
+    pango_layout_get_pixel_extents(layout, &ink_extent, &logical_extent);
+    width = ((ink_extent.width + ink_extent.x) > logical_extent.width) ? (ink_extent.width + ink_extent.x) : logical_extent.width;
 
     /* Free resources */
     g_object_unref(layout);


### PR DESCRIPTION
Hi,

I noticed that font rendering for i3bar has some problems with certain fonts.
Using the google font [Caveat](https://fonts.google.com/specimen/Caveat?preview.text_type=custom) for instance, the text in the bar is always cut off at the right side. For the workspace buttons as well as for the text in the status bar.

I don't know if this is a regression, or not, since I just tried out the font today and noticed it.

I think this is because the [ink extent](https://developer.gnome.org/pango/stable/pango-Layout-Objects.html#pango-layout-get-extents) is not accounted for?

> Computes the logical and ink extents of layout.
> Logical extents are usually what you want for positioning things.
> Note that both extents may have non-zero x and y.
> You may want to use those to offset where you render the layout.
> Not doing that is a very typical bug that shows up as right-to-left layouts not being correctly positioned in a layout with a set width.

I tried to fix the issue, by adding the ink extent to the text width, when it is calculated. I first tried to adjust the rendering position of the text, but this resulted in text no longer being centered for certain other fonts. I tried the patch with different fonts I used before with i3bar and it seems to work. I am not so experienced with pango, so I am happy for any more insights.

I executed the test suite and it passes:

```
All tests successful.
Files=252, Tests=3712,  4 wallclock secs ( 0.75 usr +  0.15 sys =  0.90 CPU)
Result: PASS
```

Do you know of some fonts which gave you trouble in the past? I can do some more experiments to see if my solution is robust enough.

Any comments are welcome.