### PR TITLE
Remove unnecessary calls to xcb_flush()

### DIFF
--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -926,7 +926,6 @@ int main(int argc, char *argv[]) {
     draw_util_surface_init(conn, &surface, win, get_visualtype(root_screen), WIN_WIDTH, WIN_HEIGHT);
 
     /* Grab the keyboard to get all input */
-    xcb_flush(conn);
 
     /* Try (repeatedly, if necessary) to grab the keyboard. We might not
      * get the keyboard at the first attempt because of the keybinding

--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -535,8 +535,6 @@ static int handle_expose(void) {
         txt(5, 10, "<ESC>", red, black);
     }
 
-    xcb_flush(conn);
-
     return 1;
 }
 
@@ -565,7 +563,6 @@ static int handle_key_press(void *ignored, xcb_connection_t *conn, xcb_key_press
                                 8,
                                 strlen("i3: generate config"),
                                 "i3: generate config");
-            xcb_flush(conn);
         } else
             finish();
     }
@@ -986,6 +983,7 @@ int main(int argc, char *argv[]) {
         }
 
         free(event);
+        xcb_flush(conn);
     }
 
     /* Dismiss drawable surface */

--- a/i3-input/main.c
+++ b/i3-input/main.c
@@ -138,8 +138,6 @@ static int handle_expose(void *data, xcb_connection_t *conn, xcb_expose_event_t 
         i3string_free(input);
     }
 
-    xcb_flush(conn);
-
     return 1;
 }
 
@@ -532,6 +530,7 @@ int main(int argc, char *argv[]) {
         }
 
         free(event);
+        xcb_flush(conn);
     }
 
     draw_util_surface_free(conn, &surface);

--- a/i3-input/main.c
+++ b/i3-input/main.c
@@ -480,7 +480,6 @@ int main(int argc, char *argv[]) {
     draw_util_surface_init(conn, &surface, win, get_visualtype(root_screen), win_pos.width, win_pos.height);
 
     /* Grab the keyboard to get all input */
-    xcb_flush(conn);
 
     /* Try (repeatedly, if necessary) to grab the keyboard. We might not
      * get the keyboard at the first attempt because of the keybinding

--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -261,7 +261,6 @@ static int handle_expose(xcb_connection_t *conn, xcb_expose_event_t *event) {
     /* border line at the bottom */
     draw_util_rectangle(&bar, color_border_bottom, 0, bar.height - BAR_BORDER, bar.width, BAR_BORDER);
 
-    xcb_flush(conn);
     return 1;
 }
 
@@ -654,6 +653,7 @@ int main(int argc, char *argv[]) {
         }
 
         free(event);
+        xcb_flush(conn);
     }
 
     free(pattern);

--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -616,7 +616,6 @@ int main(int argc, char *argv[]) {
         sn_launchee_context_unref(sncontext);
     }
 
-    /* Grab the keyboard to get all input */
     xcb_flush(conn);
 
     xcb_generic_event_t *event;

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -428,7 +428,6 @@ void init_colors(const struct xcb_color_strings_t *new_colors) {
 #undef PARSE_COLOR_FALLBACK
 
     init_tray_colors();
-    xcb_flush(xcb_connection);
 }
 
 static bool execute_custom_command(xcb_keycode_t input_code, bool event_is_release) {
@@ -1361,8 +1360,6 @@ void init_xcb_late(char *fontname) {
     if (config.separator_symbol)
         separator_symbol_width = predict_text_width(config.separator_symbol);
 
-    xcb_flush(xcb_connection);
-
     if (config.hide_on_modifier == M_HIDE)
         register_xkb_keyevents();
 }
@@ -2118,7 +2115,6 @@ void redraw_bars(void) {
 
         draw_util_copy_surface(&(outputs_walk->buffer), &(outputs_walk->bar), 0, 0,
                                0, 0, outputs_walk->rect.w, outputs_walk->rect.h);
-        xcb_flush(xcb_connection);
     }
 }
 

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -1529,7 +1529,6 @@ void clean_xcb(void) {
     free_font();
 
     xcb_free_cursor(xcb_connection, cursor);
-    xcb_flush(xcb_connection);
     xcb_aux_sync(xcb_connection);
     xcb_disconnect(xcb_connection);
 

--- a/libi3/fake_configure_notify.c
+++ b/libi3/fake_configure_notify.c
@@ -39,7 +39,6 @@ void fake_configure_notify(xcb_connection_t *conn, xcb_rectangle_t r, xcb_window
     generated_event->override_redirect = false;
 
     xcb_send_event(conn, false, window, XCB_EVENT_MASK_STRUCTURE_NOTIFY, (char *)generated_event);
-    xcb_flush(conn);
 
     free(event);
 }

--- a/libi3/get_mod_mask.c
+++ b/libi3/get_mod_mask.c
@@ -25,8 +25,6 @@ uint32_t aio_get_mod_mask_for(uint32_t keysym, xcb_key_symbols_t *symbols) {
     xcb_get_modifier_mapping_cookie_t cookie;
     xcb_get_modifier_mapping_reply_t *modmap_r;
 
-    xcb_flush(conn);
-
     /* Get the current modifier mapping (this is blocking!) */
     cookie = xcb_get_modifier_mapping(conn);
     if (!(modmap_r = xcb_get_modifier_mapping_reply(conn, cookie, NULL)))

--- a/src/click.c
+++ b/src/click.c
@@ -165,7 +165,6 @@ static void route_click(Con *con, xcb_button_press_event_t *event, const bool mo
 
         /* ASYNC_POINTER eats the event */
         xcb_allow_events(conn, XCB_ALLOW_ASYNC_POINTER, event->time);
-        xcb_flush(conn);
 
         command_result_free(result);
         return;
@@ -290,7 +289,6 @@ static void route_click(Con *con, xcb_button_press_event_t *event, const bool mo
         /* Avoid propagating events to clients, since the user expects
          * $mod+click to be handled by i3. */
         xcb_allow_events(conn, XCB_ALLOW_ASYNC_POINTER, event->time);
-        xcb_flush(conn);
         return;
     }
     /* 8: otherwise, check for border/decoration clicks and resize */
@@ -302,7 +300,6 @@ static void route_click(Con *con, xcb_button_press_event_t *event, const bool mo
 
 done:
     xcb_allow_events(conn, XCB_ALLOW_REPLAY_POINTER, event->time);
-    xcb_flush(conn);
     tree_render();
 }
 
@@ -364,7 +361,6 @@ void handle_button_press(xcb_button_press_event_t *event) {
 
         ELOG("Clicked into unknown window?!\n");
         xcb_allow_events(conn, XCB_ALLOW_REPLAY_POINTER, event->time);
-        xcb_flush(conn);
         return;
     }
 

--- a/src/config.c
+++ b/src/config.c
@@ -242,7 +242,6 @@ bool load_configuration(const char *override_configpath, config_load_t load_type
         /* Redraw the currently visible decorations on reload, so that the
          * possibly new drawing parameters changed. */
         x_deco_recurse(croot);
-        xcb_flush(conn);
     }
 
     return result;

--- a/src/floating.c
+++ b/src/floating.c
@@ -57,8 +57,6 @@ static void floating_set_hint_atom(Con *con, bool floating) {
     } else {
         xcb_delete_property(conn, con->window->id, A_I3_FLOATING_WINDOW);
     }
-
-    xcb_flush(conn);
 }
 
 /*
@@ -581,7 +579,6 @@ DRAGGING_CB(drag_window_callback) {
 
     render_con(con);
     x_push_node(con);
-    xcb_flush(conn);
 
     /* Check if we cross workspace boundaries while moving */
     if (!floating_maybe_reassign_ws(con))

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -305,7 +305,6 @@ static void handle_configure_request(xcb_configure_request_event_t *event) {
         COPY_MASK_MEMBER(XCB_CONFIG_WINDOW_STACK_MODE, stack_mode);
 
         xcb_configure_window(conn, event->window, mask, values);
-        xcb_flush(conn);
 
         return;
     }
@@ -627,7 +626,6 @@ static void handle_expose_event(xcb_expose_event_t *event) {
      * only tell us that the X server lost (parts of) the window contents. */
     draw_util_copy_surface(&(parent->frame_buffer), &(parent->frame),
                            0, 0, 0, 0, parent->rect.width, parent->rect.height);
-    xcb_flush(conn);
 }
 
 #define _NET_WM_MOVERESIZE_SIZE_TOPLEFT 0
@@ -797,7 +795,6 @@ static void handle_client_message(xcb_client_message_event_t *event) {
             A__NET_FRAME_EXTENTS,
             XCB_ATOM_CARDINAL, 32, 4,
             &r);
-        xcb_flush(conn);
     } else if (event->type == A_WM_CHANGE_STATE) {
         /* http://tronche.com/gui/x/icccm/sec-4.html#s-4.1.4 */
         if (event->data.data32[0] == XCB_ICCCM_WM_STATE_ICONIC) {

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -219,6 +219,14 @@ IPC_HANDLER(run_command) {
     if (result->needs_tree_render)
         tree_render();
 
+    /* Apparently the test suite expects that the X11 server already handled a
+     * command by the time the IPC reply comes in. This was previously done via
+     * xcb_flush(), but that is not enough to prevent races. Only a sync ensures
+     * that the X11 server actually handled things already.
+     */
+    /* XXX: Why? Did I get this right? */
+    xcb_aux_sync(conn);
+
     command_result_free(result);
 
     const unsigned char *reply;

--- a/src/main.c
+++ b/src/main.c
@@ -924,8 +924,6 @@ int main(int argc, char *argv[]) {
     ev_prepare_init(xcb_prepare, xcb_prepare_cb);
     ev_prepare_start(main_loop, xcb_prepare);
 
-    xcb_flush(conn);
-
     /* What follows is a fugly consequence of X11 protocol race conditions like
      * the following: In an i3 in-place restart, i3 will reparent all windows
      * to the root window, then exec() itself. In the new process, it calls
@@ -980,7 +978,6 @@ int main(int argc, char *argv[]) {
 
         xcb_copy_area(conn, root->root, pixmap, gc, 0, 0, 0, 0, width, height);
         xcb_change_window_attributes(conn, root->root, XCB_CW_BACK_PIXMAP, (uint32_t[]){pixmap});
-        xcb_flush(conn);
         xcb_free_gc(conn, gc);
         xcb_free_pixmap(conn, pixmap);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -147,7 +147,7 @@ static void xcb_prepare_cb(EV_P_ ev_prepare *w, int revents) {
         free(event);
     }
 
-    /* Flush all queued events to X11. */
+    /* Flush all queued requests to X11. */
     xcb_flush(conn);
 }
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -562,7 +562,6 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
 
     values[0] = CHILD_EVENT_MASK & ~XCB_EVENT_MASK_ENTER_WINDOW;
     xcb_change_window_attributes(conn, window, XCB_CW_EVENT_MASK, values);
-    xcb_flush(conn);
 
     /* Put the client inside the save set. Upon termination (whether killed or
      * normal exit does not matter) of the window manager, these clients will

--- a/src/randr.c
+++ b/src/randr.c
@@ -1100,6 +1100,4 @@ void randr_init(int *event_base, const bool disable_randr15) {
                                XCB_RANDR_NOTIFY_MASK_OUTPUT_CHANGE |
                                XCB_RANDR_NOTIFY_MASK_CRTC_CHANGE |
                                XCB_RANDR_NOTIFY_MASK_OUTPUT_PROPERTY);
-
-    xcb_flush(conn);
 }

--- a/src/resize.c
+++ b/src/resize.c
@@ -63,8 +63,6 @@ DRAGGING_CB(resize_callback) {
         *(params->new_position) = new_y;
         xcb_configure_window(conn, params->helpwin, XCB_CONFIG_WINDOW_Y, params->new_position);
     }
-
-    xcb_flush(conn);
 }
 
 bool resize_find_tiling_participants(Con **current, Con **other, direction_t direction, bool both_sides) {
@@ -175,7 +173,6 @@ void resize_graphical_handler(Con *first, Con *second, orientation_t orientation
     DLOG("x = %d, width = %d\n", output->rect.x, output->rect.width);
 
     x_mask_event_mask(~XCB_EVENT_MASK_ENTER_WINDOW);
-    xcb_flush(conn);
 
     uint32_t mask = 0;
     uint32_t values[2];
@@ -229,8 +226,6 @@ void resize_graphical_handler(Con *first, Con *second, orientation_t orientation
 
     xcb_circulate_window(conn, XCB_CIRCULATE_RAISE_LOWEST, helpwin);
 
-    xcb_flush(conn);
-
     /* `new_position' will be updated by the `resize_callback'. */
     new_position = initial_position;
 
@@ -247,7 +242,6 @@ void resize_graphical_handler(Con *first, Con *second, orientation_t orientation
 
     xcb_destroy_window(conn, helpwin);
     xcb_destroy_window(conn, grabwin);
-    xcb_flush(conn);
 
     /* User cancelled the drag so no action should be taken. */
     if (drag_result == DRAG_REVERT) {

--- a/src/restore_layout.c
+++ b/src/restore_layout.c
@@ -134,7 +134,6 @@ static void update_placeholder_contents(placeholder_state *state) {
     draw_util_clear_surface(&(state->surface), background);
 
     // TODO: make i3font functions per-connection, at least these two for now…?
-    xcb_flush(restore_conn);
     xcb_aux_sync(restore_conn);
 
     Match *swallows;
@@ -180,7 +179,6 @@ static void update_placeholder_contents(placeholder_state *state) {
     int y = (state->rect.height / 2) - (config.font.height / 2);
     draw_util_text(line, &(state->surface), foreground, background, x, y, text_width);
     i3string_free(line);
-    xcb_flush(restore_conn);
     xcb_aux_sync(restore_conn);
 }
 
@@ -257,8 +255,6 @@ void restore_open_placeholder_windows(Con *parent) {
     TAILQ_FOREACH (child, &(parent->floating_head), floating_windows) {
         open_placeholder_window(child);
     }
-
-    xcb_flush(restore_conn);
 }
 
 /*

--- a/src/sighandler.c
+++ b/src/sighandler.c
@@ -203,7 +203,6 @@ static void sighandler_create_dialogs(void) {
     }
 
     sighandler_handle_expose();
-    xcb_flush(conn);
 }
 
 static void sighandler_destroy_dialogs(void) {
@@ -217,8 +216,6 @@ static void sighandler_destroy_dialogs(void) {
         TAILQ_REMOVE(&dialogs, dialog, dialogs);
         free(dialog);
     }
-
-    xcb_flush(conn);
 }
 
 static void sighandler_handle_expose(void) {
@@ -226,8 +223,6 @@ static void sighandler_handle_expose(void) {
     TAILQ_FOREACH (current, &dialogs, dialogs) {
         sighandler_draw_dialog(current);
     }
-
-    xcb_flush(conn);
 }
 
 static void sighandler_draw_dialog(dialog_t *dialog) {
@@ -323,6 +318,7 @@ static void handle_signal(int sig, siginfo_t *info, void *data) {
         }
 
         free(event);
+        xcb_flush(conn);
     }
 }
 

--- a/src/sync.c
+++ b/src/sync.c
@@ -23,6 +23,5 @@ void sync_respond(xcb_window_t window, uint32_t rnd) {
     ev->data.data32[1] = rnd;
 
     xcb_send_event(conn, false, window, XCB_EVENT_MASK_NO_EVENT, (char *)ev);
-    xcb_flush(conn);
     free(reply);
 }

--- a/src/x.c
+++ b/src/x.c
@@ -351,7 +351,6 @@ void x_window_kill(xcb_window_t window, kill_window_t kill_window) {
 
     LOG("Sending WM_DELETE to the client\n");
     xcb_send_event(conn, false, window, XCB_EVENT_MASK_NO_EVENT, (char *)ev);
-    xcb_flush(conn);
     free(event);
 }
 
@@ -1052,7 +1051,6 @@ void x_push_node(Con *con) {
         if (con->frame_buffer.id != XCB_NONE) {
             draw_util_copy_surface(&(con->frame_buffer), &(con->frame), 0, 0, 0, 0, con->rect.width, con->rect.height);
         }
-        xcb_flush(conn);
 
         DLOG("mapping container %08x (serial %d)\n", con->frame.id, cookie.sequence);
         state->mapped = con->mapped;
@@ -1331,7 +1329,6 @@ void x_push_changes(Con *con) {
         last_focused = XCB_NONE;
     }
 
-    xcb_flush(conn);
     DLOG("ENDING CHANGES\n");
 
     /* Disable EnterWindow events for windows which will be unmapped in
@@ -1359,8 +1356,6 @@ void x_push_changes(Con *con) {
     //CIRCLEQ_FOREACH(state, &old_state_head, old_state) {
     //    DLOG("old stack: 0x%08x\n", state->id);
     //}
-
-    xcb_flush(conn);
 }
 
 /*
@@ -1481,7 +1476,5 @@ void x_set_shape(Con *con, xcb_shape_sk_t kind, bool enable) {
         } else {
             x_unshape_frame(con, kind);
         }
-
-        xcb_flush(conn);
     }
 }


### PR DESCRIPTION
I did a little exorcism and removed some calls to `xcb_flush()`:
```
 18 files changed, 5 insertions(+), 58 deletions(-)
```

My general strategy is:
- Before blocking (e.g. explicitly via `xcb_wait_for_event()` or implicitly by returning to the event loop), pending requests should be sent / `xcb_flush()` should always be called. The code was mostly already doing this.
- Since the above ensures that requests will be flushed, all other calls to `xcb_flush()` are redundant and can be removed.

I started with many small commits but then got lazy when I reached the "main code base".

TODO:
- [ ] ] I saw the small paragraph in `docs/hacking-howto` about calling `xcb_flush()`, but I am not sure what to do with it.
- [ ] I am not sure I got the IPC stuff right. I *think* your code is racy, but I am not entirely sure:
    - I had a test suite failure where the `_NET_CURRENT_DESKTOP` property was outdated. What I think happened: Previously, the code first `xcb_flush()`d and then replied to the ipc request from the test. However, this is racy. Nothing guarantees that the X11 server already handled i3's `ChangeProperty` request before the test suite managed to query the property. However, I guess it is very, very unlikely for i3 to loose this race.
    - To paper over this bug, I added a call to `xcb_aux_sync()` and left a TODO comment. Someone who knows this IPC code better than me should try to explain why the race I described above is not possible.
    - It does not help that I failed to find any documentation for the `sync` IPC command not do I really understand the test suite's `sync_with_i3`. Either I really managed to miss a required `xcb_flush()` or the syncing here is somehow broken...
- [ ] I did not dare to touch the sequence `xcb_ungrab_server(conn); xcb_flush(conn);`. I think that flush is not necessary, but I do not dare to actually remove it. Feel free to just leave them there. (The same for `xcb_ungrab_pointer()` and `xcb_ungrab_keyboard()` followed by a flush.)
- [x] I did not touch `testcases/` (nor do I understand the code in there)
- [ ] Some calls to `xcb_flush()` look fishy to me, but a comment claims that they are there for a reason. I doubt that comment, but okay... https://github.com/i3/i3/blob/7da136dca494073a5de9a38df9eb1ee220cf6006/src/x.c#L992-L1001