### PR TITLE
No temporary cairo surface for font drawing

### DIFF
--- a/include/libi3.h
+++ b/include/libi3.h
@@ -452,13 +452,6 @@ void draw_text(i3String *text, xcb_drawable_t drawable, xcb_gcontext_t gc,
                xcb_visualtype_t *visual, int x, int y, int max_width);
 
 /**
- * ASCII version of draw_text to print static strings.
- *
- */
-void draw_text_ascii(const char *text, xcb_drawable_t drawable,
-                     xcb_gcontext_t gc, int x, int y, int max_width);
-
-/**
  * Predict the text width in pixels for the given text. Text must be
  * specified as an i3String.
  *

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -445,11 +445,13 @@ bool font_is_pango(void);
  * specified coordinates (from the top left corner of the leftmost, uppermost
  * glyph) and using the provided gc.
  *
+ * The given cairo surface must refer to the specified X drawable.
+ *
  * Text must be specified as an i3String.
  *
  */
 void draw_text(i3String *text, xcb_drawable_t drawable, xcb_gcontext_t gc,
-               xcb_visualtype_t *visual, int x, int y, int max_width);
+               cairo_surface_t *surface, int x, int y, int max_width);
 
 /**
  * Predict the text width in pixels for the given text. Text must be

--- a/libi3/draw_util.c
+++ b/libi3/draw_util.c
@@ -133,7 +133,7 @@ void draw_util_text(i3String *text, surface_t *surface, color_t fg_color, color_
     CAIRO_SURFACE_FLUSH(surface->surface);
 
     set_font_colors(surface->gc, fg_color, bg_color);
-    draw_text(text, surface->id, surface->gc, surface->visual_type, x, y, max_width);
+    draw_text(text, surface->id, surface->gc, surface->surface, x, y, max_width);
 
     /* Notify cairo that we (possibly) used another way to draw on the surface. */
     cairo_surface_mark_dirty(surface->surface);

--- a/libi3/font.c
+++ b/libi3/font.c
@@ -380,41 +380,6 @@ void draw_text(i3String *text, xcb_drawable_t drawable, xcb_gcontext_t gc,
     }
 }
 
-/*
- * ASCII version of draw_text to print static strings.
- *
- */
-void draw_text_ascii(const char *text, xcb_drawable_t drawable,
-                     xcb_gcontext_t gc, int x, int y, int max_width) {
-    assert(savedFont != NULL);
-
-    switch (savedFont->type) {
-        case FONT_TYPE_NONE:
-            /* Nothing to do */
-            return;
-        case FONT_TYPE_XCB: {
-            size_t text_len = strlen(text);
-            if (text_len > 255) {
-                /* The text is too long to draw it directly to X */
-                i3String *str = i3string_from_utf8(text);
-                draw_text(str, drawable, gc, NULL, x, y, max_width);
-                i3string_free(str);
-            } else {
-                /* X11 coordinates for fonts start at the baseline */
-                int pos_y = y + savedFont->specific.xcb.info->font_ascent;
-
-                xcb_image_text_8(conn, text_len, drawable, gc, x, pos_y, text);
-            }
-            break;
-        }
-        case FONT_TYPE_PANGO:
-            /* Render the text using Pango */
-            draw_text_pango(text, strlen(text),
-                            drawable, root_visual_type, x, y, max_width, false);
-            return;
-    }
-}
-
 static int xcb_query_text_width(const xcb_char2b_t *text, size_t text_len) {
     /* Make the user know we’re using the slow path, but only once. */
     static bool first_invocation = true;

--- a/libi3/font.c
+++ b/libi3/font.c
@@ -82,12 +82,10 @@ static bool load_pango_font(i3Font *font, const char *desc) {
  *
  */
 static void draw_text_pango(const char *text, size_t text_len,
-                            xcb_drawable_t drawable, xcb_visualtype_t *visual, int x, int y,
-                            int max_width, bool pango_markup) {
+                            xcb_drawable_t drawable, cairo_surface_t *surface,
+                            int x, int y, int max_width, bool pango_markup) {
     /* Create the Pango layout */
     /* root_visual_type is cached in load_pango_font */
-    cairo_surface_t *surface = cairo_xcb_surface_create(conn, drawable,
-                                                        visual, x + max_width, y + savedFont->height);
     cairo_t *cr = cairo_create(surface);
     PangoLayout *layout = create_layout_with_dpi(cr);
     gint height;
@@ -115,7 +113,6 @@ static void draw_text_pango(const char *text, size_t text_len,
     /* Free resources */
     g_object_unref(layout);
     cairo_destroy(cr);
-    cairo_surface_destroy(surface);
 }
 
 /*
@@ -358,11 +355,8 @@ static void draw_text_xcb(const xcb_char2b_t *text, size_t text_len, xcb_drawabl
  *
  */
 void draw_text(i3String *text, xcb_drawable_t drawable, xcb_gcontext_t gc,
-               xcb_visualtype_t *visual, int x, int y, int max_width) {
+               cairo_surface_t *surface, int x, int y, int max_width) {
     assert(savedFont != NULL);
-    if (visual == NULL) {
-        visual = root_visual_type;
-    }
 
     switch (savedFont->type) {
         case FONT_TYPE_NONE:
@@ -375,7 +369,7 @@ void draw_text(i3String *text, xcb_drawable_t drawable, xcb_gcontext_t gc,
         case FONT_TYPE_PANGO:
             /* Render the text using Pango */
             draw_text_pango(i3string_as_utf8(text), i3string_get_num_bytes(text),
-                            drawable, visual, x, y, max_width, i3string_is_markup(text));
+                            drawable, surface, x, y, max_width, i3string_is_markup(text));
             return;
     }
 }


### PR DESCRIPTION
Instead of creating a temporary cairo surface in `draw_text()`, this now requires a cairo surface from the caller. That seems more sane to me than what the code currently does.

-------

CC @mychris I did not try reproducing your problem, but if I understood it correctly, then this might fix it. The idea here is that cairo now actually knows the "real" size of the drawable and is not lied to with a smaller size.

(Regardless of whether this fixes the issue from #4357 I think this is worth merging)