### PR TITLE
Some follow-up to 

### DIFF
--- a/include/libi3.h
+++ b/include/libi3.h
@@ -566,8 +566,6 @@ typedef struct surface_t {
     /* A classic XCB graphics context. */
     xcb_gcontext_t gc;
 
-    xcb_visualtype_t *visual_type;
-
     int width;
     int height;
 

--- a/libi3/draw_util.c
+++ b/libi3/draw_util.c
@@ -35,9 +35,11 @@ static void draw_util_set_source_color(surface_t *surface, color_t color);
 void draw_util_surface_init(xcb_connection_t *conn, surface_t *surface, xcb_drawable_t drawable,
                             xcb_visualtype_t *visual, int width, int height) {
     surface->id = drawable;
-    surface->visual_type = ((visual == NULL) ? visual_type : visual);
     surface->width = width;
     surface->height = height;
+
+    if (visual == NULL)
+        visual = visual_type;
 
     surface->gc = xcb_generate_id(conn);
     xcb_void_cookie_t gc_cookie = xcb_create_gc_checked(conn, surface->gc, surface->id, 0, NULL);
@@ -47,7 +49,7 @@ void draw_util_surface_init(xcb_connection_t *conn, surface_t *surface, xcb_draw
         ELOG("Could not create graphical context. Error code: %d. Please report this bug.\n", error->error_code);
     }
 
-    surface->surface = cairo_xcb_surface_create(conn, surface->id, surface->visual_type, width, height);
+    surface->surface = cairo_xcb_surface_create(conn, surface->id, visual, width, height);
     surface->cr = cairo_create(surface->surface);
 }
 


### PR DESCRIPTION
This is some follow-up to #4361 (and includes the two commits from that PR, hence the draft status).

I'm not really sure if the "stuff" around the calls to `cairo_surface_flush()` are really worth it. Missing a call to `cairo_surface_flush()` can lead to weird bugs that no one normally sees, but then someone has a weird X11 server that does not support the RENDER extension (or only an old version of it) and things break. One can test stuff with `CAIRO_DEBUG="xrender-version=-1.-1"`, but meh... I don't know.

If deemed too risky, I can get rid of the commits around `cairo_surface_flush()`. This part seemed like a better idea when I started it...