### PR TITLE
Prefetch some information through xcb

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -577,11 +577,14 @@ int main(int argc, char *argv[]) {
 
     /* Prefetch X11 extensions that we are interested in. */
     xcb_prefetch_extension_data(conn, &xcb_xkb_id);
-    xcb_prefetch_extension_data(conn, &xcb_xinerama_id);
-    xcb_prefetch_extension_data(conn, &xcb_randr_id);
     xcb_prefetch_extension_data(conn, &xcb_shape_id);
     /* BIG-REQUESTS is used by libxcb internally. */
     xcb_prefetch_extension_data(conn, &xcb_big_requests_id);
+    if (force_xinerama) {
+        xcb_prefetch_extension_data(conn, &xcb_xinerama_id);
+    } else {
+        xcb_prefetch_extension_data(conn, &xcb_randr_id);
+    }
 
     /* Place requests for the atoms we need as soon as possible */
 #define xmacro(atom) \

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,8 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <xcb/xinerama.h>
+#include <xcb/bigreq.h>
 
 #ifdef I3_ASAN_ENABLED
 #include <sanitizer/lsan_interface.h>
@@ -573,6 +575,14 @@ int main(int argc, char *argv[]) {
     root_screen = xcb_aux_get_screen(conn, conn_screen);
     root = root_screen->root;
 
+    /* Prefetch X11 extensions that we are interested in. */
+    xcb_prefetch_extension_data(conn, &xcb_xkb_id);
+    xcb_prefetch_extension_data(conn, &xcb_xinerama_id);
+    xcb_prefetch_extension_data(conn, &xcb_randr_id);
+    xcb_prefetch_extension_data(conn, &xcb_shape_id);
+    /* BIG-REQUESTS is used by libxcb internally. */
+    xcb_prefetch_extension_data(conn, &xcb_big_requests_id);
+
     /* Place requests for the atoms we need as soon as possible */
 #define xmacro(atom) \
     xcb_intern_atom_cookie_t atom##_cookie = xcb_intern_atom(conn, 0, strlen(#atom), #atom);
@@ -601,6 +611,8 @@ int main(int argc, char *argv[]) {
     } else {
         visual_type = get_visualtype(root_screen);
     }
+
+    xcb_prefetch_maximum_request_length(conn);
 
     init_dpi();
 
@@ -666,9 +678,6 @@ int main(int argc, char *argv[]) {
     xcursor_set_root_cursor(XCURSOR_CURSOR_POINTER);
 
     const xcb_query_extension_reply_t *extreply;
-    xcb_prefetch_extension_data(conn, &xcb_xkb_id);
-    xcb_prefetch_extension_data(conn, &xcb_shape_id);
-
     extreply = xcb_get_extension_data(conn, &xcb_xkb_id);
     xkb_supported = extreply->present;
     if (!extreply->present) {


### PR DESCRIPTION
This commit makes libxcb prefetch some information that will be needed
later anyway. This avoids some round-trips to the X11 server since the
information is already present when needed.

Signed-off-by: Uli Schlachter <psychon@znc.in>

------

I took a look at some xtrace output and found some simple improvements. It would also be nice to prefetch render and shm, but that would require new build dependencies just for this prefetch:
```
$ grep :\ QueryExtens /tmp/t | grep 000:
000:<:0005: 20: Request(98): QueryExtension name='XKEYBOARD'
000:<:0006: 16: Request(98): QueryExtension name='XINERAMA'
000:<:0007: 16: Request(98): QueryExtension name='RANDR'
000:<:0008: 16: Request(98): QueryExtension name='SHAPE'
000:<:0009: 20: Request(98): QueryExtension name='BIG-REQUESTS'
000:<:0048: 16: Request(98): QueryExtension name='RENDER'
000:<:0049: 16: Request(98): QueryExtension name='MIT-SHM'
```
How did I decide where to place this? Before this commit, there were two round-trips to get the maximum request size. Thus, I just placed this to avoid these two round trips. Seems like cairo causes the request to the maximum request size while loading the config:
```
(gdb) bt
#0  xcb_get_maximum_request_length (c=0x5555555f62c0) at ../../src/xcb_out.c:160
#1  0x00007ffff788470a in  () at /usr/lib/x86_64-linux-gnu/libcairo.so.2
#2  0x00007ffff7886626 in  () at /usr/lib/x86_64-linux-gnu/libcairo.so.2
#3  0x00007ffff788904f in cairo_xcb_surface_create () at /usr/lib/x86_64-linux-gnu/libcairo.so.2
#4  0x00005555555bad39 in load_pango_font (font=0x7fffffffa850, desc=0x5555555f5396 "DejaVu Sans Mono 8")
    at ../libi3/font.c:60
#5  0x00005555555bb192 in load_font (pattern=0x5555555f5390 "pango:DejaVu Sans Mono 8", fallback=true) at ../libi3/font.c:175
#6  0x0000555555582be6 in cfg_font
    (current_match=0x5555555e28a0 <current_match>, result=0x5555555e2930 <subcommand_output>, font=0x5555555f5390 "pango:DejaVu Sans Mono 8") at ../src/config_directives.c:98
#7  0x00005555555874b2 in GENERATED_call (call_identifier=115, result=0x5555555e2930 <subcommand_output>)
    at ./GENERATED_config_call.h:937
#8  0x0000555555587562 in next_state (token=0x5555555e0bb0 <tokens_FONT>) at ../src/config_parser.c:210
#9  0x0000555555587bfd in parse_config
    (input=0x555555606be0 "# i3 config file (v4)\n#\n# Please see https://i3wm.org/docs/userguide.html for a complete reference!\n\n# Font for window titles. Will also be used by the bar unless a different font\n# is used in the bar"..., context=0x555555602000) at ../src/config_parser.c:392
#10 0x0000555555589a12 in parse_file (f=0x5555555f53c0 "/home/psychon/.config/i3/config", use_nagbar=true)
    at ../src/config_parser.c:1096
#11 0x00005555555827f7 in load_configuration (override_configpath=0x0, load_type=C_LOAD) at ../src/config.c:229
#12 0x000055555559d801 in main (argc=1, argv=0x7fffffffe8a8) at ../src/main.c:642
```