### PR TITLE
Batch updating the keyboard state / regrabbing keys

### DIFF
--- a/testcases/t/600-slow-keyboard-update.t
+++ b/testcases/t/600-slow-keyboard-update.t
@@ -1,0 +1,32 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Test that updating the keyboard state is fast.
+# Ticket: #3924
+# Bug still in: 4.19.2-70-g42c3dbe0
+use i3test;
+
+my $start = time();
+
+# The following causes an X11 event per line. Before the fix, running this took
+# about 13 seconds until i3 became responsive again.
+system(q@for x in $(seq 1 5000); do echo "keycode 107 = parenleft" ; done | xmodmap -@);
+sync_with_i3;
+
+my $delay = time() - $start;
+ok($delay <= 2, 'Test finishes quickly');
+
+done_testing;


### PR DESCRIPTION
This adds a test case that tests that i3 does something quickly. With current `next`, the test needs 13 seconds on my computer and fails. That's not quick. The following commits fix this by batching "the keyboard changed"-stuff: Instead of executing this code once per event we receive, this is now only done once per main loop iteration.

This might or might not fix #3924 (no idea - I only tested with my new test case), hence CC @sammko 

Also, I have no clue how to write test cases. I do not really know perl and I did not figure out the numbering scheme (thus went with 600). Perhaps this even has to handle the case "`xmodmap` is not installed" somehow? Dunno.

The test uses a time limit of two seconds because `time()` only provides second granularity. Limiting this to one second could cause failures where the current time is `x.99999` when the test starts and `(x+1).000001` when the test finishes. This would already look like a one second time difference. Allowing two seconds thus seemed the safest option to me.

Finally: IMO I am using way too many static variables for this, but let's see what you guys say about this.