### PR TITLE
ipc: return signed int for container positions

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -34,3 +34,5 @@ strongly encouraged to upgrade.
   • i3bar: exit with 1 when a wrong command line argument is used
   • fix commented-out rofi call in default i3 config
   • clear pixmap before drawing to prevent visual garbage
+  • ipc: return proper signed int for container positions: negative values were
+    returned as large 32 bits integers

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -235,9 +235,9 @@ static void dump_rect(yajl_gen gen, const char *name, Rect r) {
     ystr(name);
     y(map_open);
     ystr("x");
-    y(integer, r.x);
+    y(integer, (int32_t)r.x);
     ystr("y");
-    y(integer, r.y);
+    y(integer, (int32_t)r.y);
     ystr("width");
     y(integer, r.width);
     ystr("height");


### PR DESCRIPTION
If we use json as a language-agnostic representation, it makes sense to use proper signed integers here.

Before (with a floating window):

```
  "rect": {
    "x": 4294966757,
    "y": 273,
    "width": 804,
    "height": 602
  },
```

After:

```
  "rect": {
    "x": -316,
    "y": 228,
    "width": 804,
    "height": 602
  },
```

Note that I was not sure if this was intended like this as the behavior seems quite old, but it does looks like a bug: for example, the popular i3ipc-python also returns these large integers.