### PR TITLE
Drop xcb_flush() before xcb_aux_sync()

### DIFF
--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -1532,7 +1532,6 @@ void clean_xcb(void) {
     free_font();
 
     xcb_free_cursor(xcb_connection, cursor);
-    xcb_flush(xcb_connection);
     xcb_aux_sync(xcb_connection);
     xcb_disconnect(xcb_connection);
 

--- a/src/restore_layout.c
+++ b/src/restore_layout.c
@@ -134,7 +134,6 @@ static void update_placeholder_contents(placeholder_state *state) {
     draw_util_clear_surface(&(state->surface), background);
 
     // TODO: make i3font functions per-connection, at least these two for now…?
-    xcb_flush(restore_conn);
     xcb_aux_sync(restore_conn);
 
     Match *swallows;
@@ -180,7 +179,6 @@ static void update_placeholder_contents(placeholder_state *state) {
     int y = (state->rect.height / 2) - (config.font.height / 2);
     draw_util_text(line, &(state->surface), foreground, background, x, y, text_width);
     i3string_free(line);
-    xcb_flush(restore_conn);
     xcb_aux_sync(restore_conn);
 }
 


### PR DESCRIPTION
xcb_flush() flushes xcb's output buffer. Thus, after this call, all
previous requests are surely written to the connection with the X11
server.

xcb_aux_sync() synchronises with the X11 server. It makes sure all
previous requests were sent to the X11 server and already processed. It
does this via free(xcb_get_input_focus_reply(xcb_get_input_focus())): It
sends a request and waits for its reply. It is guaranteed that the X11
server processes requests in-order.

This means that the sequence xcb_flush(); xcb_aux_sync() first writes
whatever is in the output buffer and then does another write for the
four bytes of the GetInputFocus request from xcb_aux_sync().

Put differently: xcb_flush(); xcb_aux_sync() doesn't do anything more
than just xcb_aux_sync(). In fact, it has slightly more overhead for the
same result.

Thus, this commit drops all calls to xcb_flush() immediately after
xcb_aux_sync().

Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

I did not learn from #4360, so here is another PR removing `xcb_flush()` calls. At least, this time I have a long reasoning of why they are definitely unnecessary. (Sorry for being pedantic about these calls...)