### PR TITLE
draw_util_surface_free(): Remove unnecessary argument

### DIFF
--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -989,7 +989,7 @@ int main(int argc, char *argv[]) {
     }
 
     /* Dismiss drawable surface */
-    draw_util_surface_free(conn, &surface);
+    draw_util_surface_free(&surface);
 
     return 0;
 }

--- a/i3-input/main.c
+++ b/i3-input/main.c
@@ -534,6 +534,6 @@ int main(int argc, char *argv[]) {
         free(event);
     }
 
-    draw_util_surface_free(conn, &surface);
+    draw_util_surface_free(&surface);
     return EXIT_OK;
 }

--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -658,7 +658,7 @@ int main(int argc, char *argv[]) {
     }
 
     free(pattern);
-    draw_util_surface_free(conn, &bar);
+    draw_util_surface_free(&bar);
 
     return 0;
 }

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -1620,9 +1620,9 @@ void destroy_window(i3_output *output) {
 
     kick_tray_clients(output);
 
-    draw_util_surface_free(xcb_connection, &(output->bar));
-    draw_util_surface_free(xcb_connection, &(output->buffer));
-    draw_util_surface_free(xcb_connection, &(output->statusline_buffer));
+    draw_util_surface_free(&(output->bar));
+    draw_util_surface_free(&(output->buffer));
+    draw_util_surface_free(&(output->statusline_buffer));
     xcb_destroy_window(xcb_connection, output->bar.id);
     xcb_free_pixmap(xcb_connection, output->buffer.id);
     xcb_free_pixmap(xcb_connection, output->statusline_buffer.id);
@@ -1914,9 +1914,9 @@ void reconfig_windows(bool redraw_bars) {
                                                                       walk->rect.w,
                                                                       bar_height);
 
-            draw_util_surface_free(xcb_connection, &(walk->bar));
-            draw_util_surface_free(xcb_connection, &(walk->buffer));
-            draw_util_surface_free(xcb_connection, &(walk->statusline_buffer));
+            draw_util_surface_free(&(walk->bar));
+            draw_util_surface_free(&(walk->buffer));
+            draw_util_surface_free(&(walk->statusline_buffer));
             draw_util_surface_init(xcb_connection, &(walk->bar), walk->bar.id, NULL, walk->rect.w, bar_height);
             draw_util_surface_init(xcb_connection, &(walk->buffer), walk->buffer.id, NULL, walk->rect.w, bar_height);
             draw_util_surface_init(xcb_connection, &(walk->statusline_buffer), walk->statusline_buffer.id, NULL, walk->rect.w, bar_height);

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -594,7 +594,7 @@ void draw_util_surface_set_size(surface_t *surface, int width, int height);
  * Destroys the surface.
  *
  */
-void draw_util_surface_free(xcb_connection_t *conn, surface_t *surface);
+void draw_util_surface_free(surface_t *surface);
 
 /**
  * Parses the given color in hex format to an internal color representation.

--- a/libi3/draw_util.c
+++ b/libi3/draw_util.c
@@ -57,7 +57,8 @@ void draw_util_surface_init(xcb_connection_t *conn, surface_t *surface, xcb_draw
  * Destroys the surface.
  *
  */
-void draw_util_surface_free(xcb_connection_t *conn, surface_t *surface) {
+void draw_util_surface_free(surface_t *surface) {
+    xcb_connection_t *conn = cairo_xcb_device_get_connection(cairo_surface_get_device(surface->surface));
     xcb_free_gc(conn, surface->gc);
     cairo_surface_destroy(surface->surface);
     cairo_destroy(surface->cr);

--- a/src/restore_layout.c
+++ b/src/restore_layout.c
@@ -273,7 +273,7 @@ bool restore_kill_placeholder(xcb_window_t placeholder) {
             continue;
 
         xcb_destroy_window(restore_conn, state->window);
-        draw_util_surface_free(restore_conn, &(state->surface));
+        draw_util_surface_free(&(state->surface));
         TAILQ_REMOVE(&state_head, state, state);
         free(state);
         DLOG("placeholder window 0x%08x destroyed.\n", placeholder);

--- a/src/sighandler.c
+++ b/src/sighandler.c
@@ -211,7 +211,7 @@ static void sighandler_destroy_dialogs(void) {
         dialog_t *dialog = TAILQ_FIRST(&dialogs);
 
         xcb_free_colormap(conn, dialog->colormap);
-        draw_util_surface_free(conn, &(dialog->surface));
+        draw_util_surface_free(&(dialog->surface));
         xcb_destroy_window(conn, dialog->id);
 
         TAILQ_REMOVE(&dialogs, dialog, dialogs);

--- a/src/x.c
+++ b/src/x.c
@@ -258,8 +258,8 @@ static void _x_con_kill(Con *con) {
         xcb_free_colormap(conn, con->colormap);
     }
 
-    draw_util_surface_free(conn, &(con->frame));
-    draw_util_surface_free(conn, &(con->frame_buffer));
+    draw_util_surface_free(&(con->frame));
+    draw_util_surface_free(&(con->frame_buffer));
     xcb_free_pixmap(conn, con->frame_buffer.id);
     con->frame_buffer.id = XCB_NONE;
     state = state_for_frame(con->frame.id);
@@ -939,7 +939,7 @@ void x_push_node(Con *con) {
         /* Check if the container has an unneeded pixmap left over from
          * previously having a border or titlebar. */
         if (!is_pixmap_needed && con->frame_buffer.id != XCB_NONE) {
-            draw_util_surface_free(conn, &(con->frame_buffer));
+            draw_util_surface_free(&(con->frame_buffer));
             xcb_free_pixmap(conn, con->frame_buffer.id);
             con->frame_buffer.id = XCB_NONE;
         }
@@ -948,7 +948,7 @@ void x_push_node(Con *con) {
             if (con->frame_buffer.id == XCB_NONE) {
                 con->frame_buffer.id = xcb_generate_id(conn);
             } else {
-                draw_util_surface_free(conn, &(con->frame_buffer));
+                draw_util_surface_free(&(con->frame_buffer));
                 xcb_free_pixmap(conn, con->frame_buffer.id);
             }
 


### PR DESCRIPTION
Cairo allows querying the underlying xcb_connection_t* of a cairo
surface and thus this function does not really need the caller to pass
this in.

No idea if this change is really worth it. I am mostly doing this
because I can / because it seemed sensible (this means the caller cannot
pass different xcb_connection_t* to init and free, but that's likely a
very low risk).

Signed-off-by: Uli Schlachter <psychon@znc.in>