### PR TITLE
Use separate pixmaps for each edge of a container

### DIFF
--- a/include/all.h
+++ b/include/all.h
@@ -76,3 +76,4 @@
 #include "restore_layout.h"
 #include "sync.h"
 #include "main.h"
+#include "multi_draw.h"

--- a/include/data.h
+++ b/include/data.h
@@ -17,6 +17,7 @@
 #include <sys/time.h>
 
 #include "queue.h"
+#include "multi_draw.h"
 
 /*
  * To get the big concept: There are helper structures like struct
@@ -621,7 +622,7 @@ struct Con {
 
     /* The surface used for the frame window. */
     surface_t frame;
-    surface_t frame_buffer;
+    multi_surface_t frame_buffer;
     bool pixmap_recreated;
 
     enum {

--- a/include/multi_draw.h
+++ b/include/multi_draw.h
@@ -37,6 +37,12 @@ void multi_draw_init(xcb_connection_t *conn, multi_surface_t *surface, xcb_visua
 void multi_surface_free(multi_surface_t *surface);
 
 /**
+ * Destroys the multi surface and calls xcb_free_pixmap() on each drawable.
+ *
+ */
+void multi_surface_free_pixmap(multi_surface_t *surface);
+
+/**
  * Draw the given text using libi3.
  *
  */

--- a/include/multi_draw.h
+++ b/include/multi_draw.h
@@ -1,0 +1,63 @@
+/*
+ * vim:ts=4:sw=4:expandtab
+ *
+ * i3 - an improved dynamic tiling window manager
+ * © 2021 Uli Schlachter and contributors (see also: LICENSE)
+ *
+ * Support for "drawing with holes": Think of a window with a frame around it.
+ * There is some drawing on each side and in the middle a big hole where the
+ * inner window is.
+ *
+ */
+#pragma once
+
+#include <config.h>
+#include "libi3.h"
+
+/* A wrapper around multiple surface_t arranged in a big, virtual layout. */
+typedef struct multi_surface_t {
+    struct {
+        surface_t surface;
+        int x;
+        int y;
+    } surfaces[4];
+} multi_surface_t;
+
+/**
+ * Initialize the multi surface to draw to the given drawables.
+ *
+ */
+void multi_draw_init(xcb_connection_t *conn, multi_surface_t *surface, xcb_visualtype_t *visual,
+                     int num_drawables, xcb_drawable_t *drawables, int *xs, int *ys, int *widths, int *heights);
+
+/**
+ * Destroys the multi surface.
+ *
+ */
+void multi_surface_free(multi_surface_t *surface);
+
+/**
+ * Draw the given text using libi3.
+ *
+ */
+void multi_surface_text(i3String *text, multi_surface_t *surface, color_t fg_color, color_t bg_color, int x, int y, int max_width);
+
+/**
+ * Draws a filled rectangle.
+ *
+ */
+void multi_surface_rectangle(multi_surface_t *surface, color_t color, double x, double y, double w, double h);
+
+/**
+ * Clears a surface with the given color.
+ *
+ */
+void multi_surface_clear(multi_surface_t *surface, color_t color);
+
+/**
+ * Copies a multi surface onto a "normal" surface. Areas not covered by the
+ * multi surface are filled with fill_color.
+ *
+ */
+void multi_surface_copy_surface(multi_surface_t *src, surface_t *dest, int src_x, int src_y,
+                                int dest_x, int dest_y, unsigned int width, unsigned int height, color_t fill_color);

--- a/meson.build
+++ b/meson.build
@@ -393,6 +393,7 @@ i3srcs = [
   'src/manage.c',
   'src/match.c',
   'src/move.c',
+  'src/multi_draw.c',
   'src/output.c',
   'src/randr.c',
   'src/regex.c',

--- a/src/con.c
+++ b/src/con.c
@@ -1712,6 +1712,10 @@ adjacent_t con_adjacent_borders(Con *con) {
         return result;
 
     Con *workspace = con_get_workspace(con);
+    if (workspace == NULL) {
+        ELOG("FIXME: Workspace was NULL\n");
+        return result;
+    }
     if (con->rect.x == workspace->rect.x)
         result |= ADJ_LEFT_SCREEN_EDGE;
     if (con->rect.x + con->rect.width == workspace->rect.x + workspace->rect.width)

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -625,8 +625,9 @@ static void handle_expose_event(xcb_expose_event_t *event) {
 
     /* Since we render to our surface on every change anyways, expose events
      * only tell us that the X server lost (parts of) the window contents. */
-    draw_util_copy_surface(&(parent->frame_buffer), &(parent->frame),
-                           0, 0, 0, 0, parent->rect.width, parent->rect.height);
+    multi_surface_copy_surface(&(parent->frame_buffer), &(parent->frame),
+                               0, 0, 0, 0, parent->rect.width, parent->rect.height,
+                               (color_t){.red = 0.0, .green = 0.0, .blue = 0.0});
     xcb_flush(conn);
 }
 

--- a/src/multi_draw.c
+++ b/src/multi_draw.c
@@ -1,0 +1,119 @@
+/*
+ * vim:ts=4:sw=4:expandtab
+ *
+ * i3 - an improved dynamic tiling window manager
+ * © 2021 Uli Schlachter and contributors (see also: LICENSE)
+ *
+ * Support for "drawing with holes": Think of a window with a frame around it.
+ * There is some drawing on each side and in the middle a big hole where the
+ * inner window is.
+ *
+ */
+#include "all.h"
+
+#define FOR_EACH_SURFACE(multi_surface, index, surf, offset_x, offset_y) \
+    for ((index) = 0, (surf) = &((multi_surface)->surfaces[0].surface), (offset_x) = (multi_surface)->surfaces[0].x, (offset_y) = (multi_surface)->surfaces[0].y; \
+            (index) < 4 && (multi_surface)->surfaces[index].surface.surface != NULL; \
+            (index)++, (surf) = &((multi_surface)->surfaces[(index)].surface), (offset_x) = (multi_surface)->surfaces[(index)].x, (offset_y) = (multi_surface)->surfaces[(index)].y)
+
+/**
+ * Initialize the multi surface to draw to the given drawables.
+ *
+ */
+void multi_draw_init(xcb_connection_t *conn, multi_surface_t *surface, xcb_visualtype_t *visual,
+                     int num_drawables, xcb_drawable_t *drawables, int *xs, int *ys, int *widths, int *heights) {
+    assert(num_drawables <= sizeof(surface->surfaces) / sizeof(surface->surfaces[0]));
+
+    /* Set everything to NULL; this is used to indicate not-present surfaces */
+    memset(surface, 0, sizeof(*surface));
+
+    for (int i = 0; i < num_drawables; i++) {
+        surface->surfaces[i].x = xs[i];
+        surface->surfaces[i].y = ys[i];
+        draw_util_surface_init(conn, &(surface->surfaces[i].surface), drawables[i], visual, widths[i], heights[i]);
+    }
+}
+
+/**
+ * Destroys the multi surface.
+ *
+ */
+void multi_surface_free(multi_surface_t *surface) {
+    surface_t *s;
+    int index, offset_x, offset_y;
+    xcb_connection_t *conn = cairo_xcb_device_get_connection(cairo_surface_get_device(surface->surfaces[0].surface.surface));
+    FOR_EACH_SURFACE(surface, index, s, offset_x, offset_y) {
+        draw_util_surface_free(conn, s);
+        (void) offset_x;
+        (void) offset_y;
+    }
+}
+
+/**
+ * Draw the given text using libi3.
+ *
+ */
+void multi_surface_text(i3String *text, multi_surface_t *surface, color_t fg_color, color_t bg_color, int x, int y, int max_width) {
+    surface_t *s;
+    int index, offset_x, offset_y;
+    FOR_EACH_SURFACE(surface, index, s, offset_x, offset_y) {
+        draw_util_text(text, s, fg_color, bg_color, x - offset_x, y - offset_y, max_width);
+    }
+}
+
+/**
+ * Draws a filled rectangle.
+ *
+ */
+void multi_surface_rectangle(multi_surface_t *surface, color_t color, double x, double y, double w, double h) {
+    surface_t *s;
+    int index, offset_x, offset_y;
+    FOR_EACH_SURFACE(surface, index, s, offset_x, offset_y) {
+        draw_util_rectangle(s, color, x - offset_x, y - offset_y, w, h);
+    }
+}
+
+/**
+ * Clears a surface with the given color.
+ *
+ */
+void multi_surface_clear(multi_surface_t *surface, color_t color) {
+    surface_t *s;
+    int index, offset_x, offset_y;
+    FOR_EACH_SURFACE(surface, index, s, offset_x, offset_y) {
+        draw_util_clear_surface(s, color);
+        (void) offset_x;
+        (void) offset_y;
+    }
+}
+
+/**
+ * Copies a multi surface onto a "normal" surface. Areas not covered by the
+ * multi surface are filled with fill_color.
+ *
+ */
+void multi_surface_copy_surface(multi_surface_t *src, surface_t *dest, int src_x, int src_y,
+                                int dest_x, int dest_y, unsigned int width, unsigned int height, color_t fill_color) {
+    surface_t *s;
+    int index, offset_x, offset_y;
+
+    /* Figure out which area is not covered by any of the sub-surface */
+    cairo_region_t *region = cairo_region_create_rectangle(&(cairo_rectangle_int_t){dest_x, dest_y, width, height});
+    FOR_EACH_SURFACE(src, index, s, offset_x, offset_y) {
+        cairo_region_subtract_rectangle(region, &(cairo_rectangle_int_t){offset_x, offset_y, s->width, s->height});
+    }
+
+    /* Fill the uncovered rectangles */
+    for (int i = 0; i < cairo_region_num_rectangles(region); i++) {
+        cairo_rectangle_int_t rect;
+        cairo_region_get_rectangle(region, i, &rect);
+        draw_util_rectangle(dest, fill_color, rect.x, rect.y, rect.width, rect.height);
+    }
+
+    /* Copy everything else */
+    FOR_EACH_SURFACE(src, index, s, offset_x, offset_y) {
+        draw_util_copy_surface(s, dest, src_x - offset_x, src_y - offset_y, dest_x, dest_y, width, height);
+    }
+
+    cairo_region_destroy(region);
+}

--- a/src/multi_draw.c
+++ b/src/multi_draw.c
@@ -47,6 +47,29 @@ void multi_surface_free(multi_surface_t *surface) {
         (void) offset_x;
         (void) offset_y;
     }
+
+    /* Set everything to NULL; this is used to indicate not-present surfaces */
+    memset(surface, 0, sizeof(*surface));
+}
+
+/**
+ * Destroys the multi surface and calls xcb_free_pixmap() on each drawable.
+ *
+ */
+void multi_surface_free_pixmap(multi_surface_t *surface) {
+    xcb_pixmap_t pixmaps[4];
+    xcb_connection_t *conn = cairo_xcb_device_get_connection(cairo_surface_get_device(surface->surfaces[0].surface.surface));
+
+    /* Check that we got the array size correct */
+    assert(sizeof(pixmaps) / sizeof(pixmaps[0]) == sizeof(surface->surfaces) / sizeof(surface->surfaces[0]));
+    for (int i = 0; i < sizeof(pixmaps) / sizeof(pixmaps[0]); i++)
+        pixmaps[i] = surface->surfaces[i].surface.id;
+
+    multi_surface_free(surface);
+    for (int i = 0; i < sizeof(pixmaps) / sizeof(pixmaps[0]); i++) {
+        if (pixmaps[i] != XCB_NONE)
+            xcb_free_pixmap(conn, pixmaps[i]);
+    }
 }
 
 /**

--- a/src/x.c
+++ b/src/x.c
@@ -935,10 +935,10 @@ void x_push_node(Con *con) {
         /* Make sure unused rectangles are all zero */
         memset(&rectangles, 0, sizeof(rectangles));
         size_t num_rectangles = x_get_border_rectangles(con, rectangles);
-            for (int i = 0; i < num_rectangles; i++) {
-                printf("Rectangle %d: (%d,%d) with size (%d,%d)\n", i,
-                        rectangles[i].x, rectangles[i].y, rectangles[i].width, rectangles[i].height);
-            }
+        for (int i = 0; i < num_rectangles; i++) {
+            printf("Rectangle %d: (%d,%d) with size (%d,%d)\n", i,
+                    rectangles[i].x, rectangles[i].y, rectangles[i].width, rectangles[i].height);
+        }
 
         /* We first create the new pixmap, then render to it, set it as the
          * background and only afterwards change the window size. This reduces


### PR DESCRIPTION
Here is my current attempt at fixing #3479.

It does not work. `x_get_border_rectangles()` calls `con_adjacent_borders()` which follows a `NULL` pointer and crashes. I "fixed" that with a NULL pointer check, but now this function is giving me all empty rectangles for the borders:
```
11.03.2021 13:49:31 - ERROR: FIXME: Workspace was NULL
Rectangle 0: (0,0) with size (0,0)
Rectangle 1: (640,0) with size (0,0)
Rectangle 2: (0,0) with size (640,0)
Segmentation fault
```
(No, I did not yet look at where that segfault comes from; yes, I can open a window, but it ends up with all-black frames)

So, this (draft) PR is just to document my current state and to ask:

### How do I get the necessary size of the border pixmaps?

It seems like `con->window_rect` is the geometry of the "inner window" and `con->rect` is the geometry of the outer window  (so I get width and height from this). Is this correct? Is there some existing helper that allows me to turn this into up to four rectangles describing the "area not covered by the inner window"? Is `x_get_border_rectanges()` meant for something else?