### PR TITLE
fix crash with “layout default”: ipc.c won’t dump L_DEFAULT layout

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -1855,9 +1855,9 @@ void con_set_layout(Con *con, layout_t layout) {
             con_attach(new, con, false);
 
             tree_flatten(croot);
+            con_force_split_parents_redraw(con);
+            return;
         }
-        con_force_split_parents_redraw(con);
-        return;
     }
 
     if (layout == L_DEFAULT) {

--- a/testcases/t/312-regress-layout-default.t
+++ b/testcases/t/312-regress-layout-default.t
@@ -1,0 +1,25 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Verifies i3 does not crash when using layout default.
+# Ticket: #4408
+# Bug still in: 4.19.2-83-gc8158875
+use i3test;
+
+cmd 'layout default';
+fresh_workspace;
+
+done_testing;


### PR DESCRIPTION
fixes #4408