### PR TITLE
docs: fix broken link to Pango documentation

### DIFF
--- a/docs/i3bar-protocol
+++ b/docs/i3bar-protocol
@@ -191,7 +191,7 @@ separator_block_width::
 	is 9 pixels), since the separator line is drawn in the middle.
 markup::
 	A string that indicates how the text of the block should be parsed. Set to
-	+"pango"+ to use https://developer.gnome.org/pango/stable/pango-Markup.html[Pango markup].
+	+"pango"+ to use https://developer.gnome.org/pango/1.46/[Pango markup].
 	Set to +"none"+ to not use any markup (default). Pango markup only works
 	if you use a pango font.
 

--- a/docs/userguide
+++ b/docs/userguide
@@ -2279,9 +2279,8 @@ exhausting numbered ones and looks for numbered ones after exhausting named ones
 See <<move_to_outputs>> for how to move a container/workspace to a different
 RandR output.
 
-Workspace names are parsed as
-https://developer.gnome.org/pango/stable/pango-Markup.html[Pango markup]
-by i3bar.
+Workspace names are parsed as https://developer.gnome.org/pango/1.46/[Pango
+markup] by i3bar.
 
 [[back_and_forth]]
 To switch back to the previously focused workspace, use +workspace
@@ -2581,9 +2580,8 @@ unmark irssi
 
 By default, i3 will simply print the X11 window title. Using +title_format+,
 this can be customized by setting the format to the desired output. This
-directive supports
-https://developer.gnome.org/pango/stable/pango-Markup.html[Pango markup]
-and the following placeholders which will be replaced:
+directive supports https://developer.gnome.org/pango/1.46/[Pango markup] and the
+following placeholders which will be replaced:
 
 +%title+::
     For normal windows, this is the X11 window title (_NET_WM_NAME or WM_NAME


### PR DESCRIPTION
Looks like `/stable/` no longer automatically points to the latest version, so I linked to the "homepage" instead. :/