### PR TITLE
Add a script to list keybindings

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -22,6 +22,7 @@ strongly encouraged to upgrade.
   • Add %machine placeholder (WM_CLIENT_MACHINE) to title_format
   • Allow multiple output names in 'move container|workspace to output'
   • Add 'move container|workspace to output next'
+  • Add a script for listing all keybindings and a keybinding for running it
 
  ┌────────────────────────────┐
  │ Bugfixes                   │

--- a/etc/config.keycodes
+++ b/etc/config.keycodes
@@ -57,6 +57,9 @@ bindcode $mod+40 exec --no-startup-id dmenu_run
 # .desktop file. It is a wrapper around dmenu, so you need that installed.
 # bindcode $mod+40 exec --no-startup-id i3-dmenu-desktop
 
+# show list of keybindings
+bindcode $mod+56 exec i3-sensible-terminal -e "i3-list-bindings -s"
+
 # change focus
 bindcode $mod+44 focus left
 bindcode $mod+45 focus down

--- a/i3-list-bindings
+++ b/i3-list-bindings
@@ -1,0 +1,91 @@
+#!/usr/bin/env perl
+# vim:ts=4:sw=4:expandtab
+use strict;
+use warnings;
+use v5.10;
+
+# gets the loaded configuration file and parses it
+# the keybindings are grouped into blocks with an optional comment on top
+sub slurp {
+    # get the loaded config and add a few newlines at the end to make sure the last
+    # keybinding block is saved properly
+    my $config = `i3-msg -t get_config` . "\n\n";
+
+    my $last_comment = "";
+    my @blocks = ();
+    my @current_block = (); 
+    my $in_mode = 0;
+
+    foreach my $line (split("\n", $config)) {
+        chomp $line;
+
+        if ($line =~ /^\s*}.*$/) {
+            # end of a mode definition
+            $in_mode = 0;
+        } elsif ($in_mode) {
+            # don't record any keybindings for modes other than "default"
+            next;
+        } elsif ($line =~ /^\s*mode\s.*$/) {
+            # start of a mode definition
+            $in_mode = 1;
+        } elsif ($line =~ /^\s*bindsym\s+(?:--\S*\s+)*(\S*)\s(.*?)\s*(?:#\s*(.*))?$/) {
+            # a keybinding
+            my %keybinding = (binding => $1, action => $2, comment => $3 ? $3 : "");
+            push(@current_block, \%keybinding);
+        } elsif ($line =~ /^\s*#\s*(.*)\s*$/) {
+            # a comment
+            $last_comment = $1;
+        } else {
+            # a command or a blank line - end of a block
+            if (@current_block && scalar @current_block != 1) {
+                # save the current block to the array of blocks
+                push(@blocks, {bindings => [@current_block], comment => $last_comment});
+            } elsif (scalar @current_block == 1) {
+                # if the current block is a single stray keybinding, we should group it together with
+                # other such keybindings.
+
+                # save the comment
+                $current_block[0]->{comment} = $last_comment;
+
+                if ($blocks[-1] && $blocks[-1]->{_stray}) {
+                    push(@{$blocks[-1]->{bindings}}, $current_block[0]);
+                } else {
+                    # if there is no block with stray keybindings, create one
+                    push(@blocks, {bindings => [@current_block], comment => "", _stray => 1});
+                }
+            }
+
+            @current_block = ();
+            $last_comment = "";
+        }
+    }
+
+    return @blocks;
+}
+
+# text formatting subroutines
+sub block_header { return "\e[7m" . shift . "\e[0m"; }
+sub keybinding { return "\e[94m" . shift . "\e[0m"; }
+sub comment { return "\e[32m" . shift . "\e[0m"; }
+
+foreach my $block (slurp()) {
+    print block_header "$block->{comment}\n" if $block->{comment};
+
+    foreach my $binding (@{$block->{bindings}}) {
+        print keybinding($binding->{binding}) . "\t$binding->{action}\t" . comment("$binding->{comment}\n");
+    }
+
+    print "\n";
+}
+
+# optionally wait for user input
+my $param = @ARGV ? $ARGV[0] : 0;
+if ($param eq "-s") {
+    `i3-msg floating enable`;
+
+    print "Press RETURN to exit\n";
+    <STDIN>;
+} elsif ($param) {
+    print "Illegal parameter $param\n";
+    exit 1;
+}

--- a/man/i3-list-bindings.man
+++ b/man/i3-list-bindings.man
@@ -1,0 +1,31 @@
+i3-list-bindings(1)
+===================
+j-jzk <me@j-jzk.cz>
+v1.0, April 2021
+
+== NAME
+
+i3-list-bindings - lists keybindings in the currently loaded i3 configuration
+
+== SYNOPSIS
+
+i3-list-bindings [-s]
+
+== OPTIONS
+
+-s::
+"Standalone" mode - opens itself as a floating window and doesn't exit immediately,
+but waits for a Return key.
+
+== DESCRIPTION
+
+i3-list-bindings gets the currently loaded i3 configuration and prints all of the
+keybindings in a synoptical way.
+
+== SEE ALSO
+
+i3(1)
+
+== AUTHOR
+
+j-jzk and contributors

--- a/meson.build
+++ b/meson.build
@@ -206,6 +206,7 @@ if get_option('mans')
     'man/i3-sensible-pager.man',
     'man/i3-sensible-terminal.man',
     'man/i3-dump-log.man',
+    'man/i3-list-bindings.man',
   ]
 
   foreach m : man_inputs
@@ -282,6 +283,7 @@ else
 	'man/i3-dump-log.1',
 	'man/i3-dmenu-desktop.1',
 	'man/i3-save-tree.1',
+    'man/i3-list-bindings.1',
       ],
       install_dir: man1,
     )
@@ -577,6 +579,7 @@ install_data(
     'i3-sensible-editor',
     'i3-sensible-pager',
     'i3-sensible-terminal',
+    'i3-list-bindings',
   ],
   install_dir: 'bin',
 )


### PR DESCRIPTION
Adds a script for listing all keybindings, as described in issue #4293.

I've used the system command `i3-msg` instead of `AnyEvent::I3` to not include any new runtime dependencies. I don't see any issues with `i3-msg ...`, but changing it shouldn't be a problem.

Also, the way the script makes its window floating is a little clumsy, but I couldn't find a better way. Is there one?