### PR TITLE
Implement include config directive

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -35,6 +35,7 @@ option is enabled and only then sets a screenshot as background.
   • i3bar: use first bar config by default
   • i3-dump-log -f now uses UNIX sockets instead of pthreads. The UNIX socket approach
     should be more reliable and also more portable.
+  • Implement the include config directive
   • Allow for_window to match against WM_CLIENT_MACHINE
   • Add %machine placeholder (WM_CLIENT_MACHINE) to title_format
   • Allow multiple output names in 'move container|workspace to output'

--- a/docs/userguide
+++ b/docs/userguide
@@ -319,6 +319,90 @@ include the following line in your config file:
 # i3 config file (v4)
 ---------------------
 
+[[include]]
+=== Include directive
+
+Since i3 v4.20, it is possible to include other configuration files from your i3
+configuration.
+
+*Syntax*:
+-----------------
+include <pattern>
+-----------------
+
+i3 expands `pattern` using shell-like word expansion, specifically using the
+https://manpages.debian.org/wordexp.3[`wordexp(3)` C standard library function].
+
+*Examples*:
+--------------------------------------------------------------------------------
+# Tilde expands to the user’s home directory:
+include ~/.config/i3/assignments.conf
+
+# Environment variables are expanded:
+include $HOME/.config/i3/assignments.conf
+
+# Wildcards are expanded:
+include ~/.config/i3/config.d/*.conf
+
+# Command substitution:
+include ~/.config/i3/`hostname`.conf
+
+# i3 loads each path only once, so including the i3 config will not result
+# in an endless loop, but in an error:
+include ~/.config/i3/config
+
+# i3 changes the working directory while parsing a config file
+# so that relative paths are interpreted relative to the directory
+# of the config file that contains the path:
+include assignments.conf
+--------------------------------------------------------------------------------
+
+If a specified file cannot be read, for example because of a lack of file
+permissions, or because of a dangling symlink, i3 will report an error and
+continue processing your remaining configuration.
+
+To list all loaded configuration files, run `i3 --moreversion`:
+
+--------------------------------------------------------------------------------
+% i3 --moreversion
+Binary i3 version:  4.19.2-87-gfcae64f7+ © 2009 Michael Stapelberg and contributors
+Running i3 version: 4.19.2-87-gfcae64f7+ (pid 963940)
+Loaded i3 config:
+  /tmp/i3.cfg (main) (last modified: 2021-05-13T16:42:31 CEST, 463 seconds ago)
+  /tmp/included.cfg (included) (last modified: 2021-05-13T16:42:43 CEST, 451 seconds ago)
+  /tmp/another.cfg (included) (last modified: 2021-05-13T16:42:46 CEST, 448 seconds ago)
+--------------------------------------------------------------------------------
+
+Variables are shared between all config files, but beware of the following limitation:
+
+* You can define a variable and use it within an included file.
+* You cannot use (in the parent file) a variable that was defined within an included file.
+
+This is a technical limitation: variable expansion happens in a separate stage
+before parsing include directives.
+
+Conceptually, included files can only add to the configuration, not undo the
+effects of already-processed configuration. For example, you can only add new
+key bindings, not overwrite or remove existing key bindings. This means:
+
+* The `include` directive is suitable for organizing large configurations into
+  separate files, possibly selecting files based on conditionals.
+
+* The `include` directive is not suitable for expressing “use the default
+  configuration with the following changes”. For that case, we still recommend
+  copying and modifying the default config.
+
+[NOTE]
+====
+Implementation-wise, i3 does not currently construct one big configuration from
+all `include` directives. Instead, i3’s config file parser interprets all
+configuration directives in its `parse_file()` function. When processing an
+`include` configuration directive, the parser recursively calls `parse_file()`.
+
+This means the evaluation order of files forms a tree, or one could say i3 uses
+depth-first traversal.
+====
+
 === Comments
 
 It is possible and recommended to use comments in your configuration file to

--- a/generate-command-parser.pl
+++ b/generate-command-parser.pl
@@ -133,7 +133,7 @@ close($enumfh);
 open(my $callfh, '>', "GENERATED_${prefix}_call.h");
 my $resultname = uc(substr($prefix, 0, 1)) . substr($prefix, 1) . 'ResultIR';
 say $callfh '#pragma once';
-say $callfh "static void GENERATED_call(const int call_identifier, struct $resultname *result) {";
+say $callfh "static void GENERATED_call(Match *current_match, struct stack *stack, const int call_identifier, struct $resultname *result) {";
 say $callfh '    switch (call_identifier) {';
 my $call_id = 0;
 for my $state (@keys) {
@@ -150,8 +150,8 @@ for my $state (@keys) {
         # calls to get_string(). Also replaces state names (like FOR_WINDOW)
         # with their ID (useful for cfg_criteria_init(FOR_WINDOW) e.g.).
         $cmd =~ s/$_/$statenum{$_}/g for @keys;
-        $cmd =~ s/\$([a-z_]+)/get_string("$1")/g;
-        $cmd =~ s/\&([a-z_]+)/get_long("$1")/g;
+        $cmd =~ s/\$([a-z_]+)/get_string(stack, "$1")/g;
+        $cmd =~ s/\&([a-z_]+)/get_long(stack, "$1")/g;
         # For debugging/testing, we print the call using printf() and thus need
         # to generate a format string. The format uses %d for <number>s,
         # literal numbers or state IDs and %s for NULL, <string>s and literal
@@ -175,9 +175,9 @@ for my $state (@keys) {
         say $callfh '#ifndef TEST_PARSER';
         my $real_cmd = $cmd;
         if ($real_cmd =~ /\(\)/) {
-            $real_cmd =~ s/\(/(&current_match, result/;
+            $real_cmd =~ s/\(/(current_match, result/;
         } else {
-            $real_cmd =~ s/\(/(&current_match, result, /;
+            $real_cmd =~ s/\(/(current_match, result, /;
         }
         say $callfh "             $real_cmd;";
         say $callfh '#else';

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -39,6 +39,7 @@ CFGFUN(criteria_init, int _state);
 CFGFUN(criteria_add, const char *ctype, const char *cvalue);
 CFGFUN(criteria_pop_state);
 
+CFGFUN(include, const char *pattern);
 CFGFUN(font, const char *font);
 CFGFUN(exec, const char *exectype, const char *no_startup_id, const char *command);
 CFGFUN(for_window, const char *command);

--- a/include/config_parser.h
+++ b/include/config_parser.h
@@ -16,6 +16,50 @@
 SLIST_HEAD(variables_head, Variable);
 extern pid_t config_error_nagbar_pid;
 
+struct stack_entry {
+    /* Just a pointer, not dynamically allocated. */
+    const char *identifier;
+    enum {
+        STACK_STR = 0,
+        STACK_LONG = 1,
+    } type;
+    union {
+        char *str;
+        long num;
+    } val;
+};
+
+struct stack {
+    struct stack_entry stack[10];
+};
+
+struct parser_ctx {
+    bool use_nagbar;
+    bool assume_v4;
+
+    int state;
+    Match current_match;
+
+    /* A list which contains the states that lead to the current state, e.g.
+   * INITIAL, WORKSPACE_LAYOUT.
+   * When jumping back to INITIAL, statelist_idx will simply be set to 1
+   * (likewise for other states, e.g. MODE or BAR).
+   * This list is used to process the nearest error token. */
+    int statelist[10];
+    /* NB: statelist_idx points to where the next entry will be inserted */
+    int statelist_idx;
+
+    /*******************************************************************************
+   * The (small) stack where identified literals are stored during the parsing
+   * of a single config directive (like $workspace).
+   ******************************************************************************/
+    struct stack *stack;
+
+    struct variables_head variables;
+
+    bool has_errors;
+};
+
 /**
  * An intermediate reprsentation of the result of a parse_config call.
  * Currently unused, but the JSON output will be useful in the future when we
@@ -23,21 +67,33 @@ extern pid_t config_error_nagbar_pid;
  *
  */
 struct ConfigResultIR {
-    /* The JSON generator to append a reply to. */
-    yajl_gen json_gen;
+    struct parser_ctx *ctx;
 
     /* The next state to transition to. Passed to the function so that we can
      * determine the next state as a result of a function call, like
      * cfg_criteria_pop_state() does. */
     int next_state;
-};
 
-struct ConfigResultIR *parse_config(const char *input, struct context *context);
+    /* Whether any error happened while processing this config directive. */
+    bool has_errors;
+};
 
 /**
  * launch nagbar to indicate errors in the configuration file.
  */
 void start_config_error_nagbar(const char *configpath, bool has_errors);
+
+/**
+ * Releases the memory of all variables in ctx.
+ *
+ */
+void free_variables(struct parser_ctx *ctx);
+
+typedef enum {
+    PARSE_FILE_FAILED = -1,
+    PARSE_FILE_SUCCESS = 0,
+    PARSE_FILE_CONFIG_ERRORS = 1,
+} parse_file_result_t;
 
 /**
  * Parses the given file by first replacing the variables, then calling
@@ -47,4 +103,4 @@ void start_config_error_nagbar(const char *configpath, bool has_errors);
  * parsing.
  *
  */
-bool parse_file(const char *f, bool use_nagbar);
+parse_file_result_t parse_file(struct parser_ctx *ctx, const char *f);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -15,6 +15,7 @@
 #include "queue.h"
 #include "i3.h"
 
+typedef struct IncludedFile IncludedFile;
 typedef struct Config Config;
 typedef struct Barconfig Barconfig;
 extern char *current_configpath;
@@ -22,6 +23,7 @@ extern char *current_config;
 extern Config config;
 extern SLIST_HEAD(modes_head, Mode) modes;
 extern TAILQ_HEAD(barconfig_head, Barconfig) barconfigs;
+extern TAILQ_HEAD(includedfiles_head, IncludedFile) included_files;
 
 /**
  * Used during the config file lexing/parsing to keep the state of the lexer
@@ -67,6 +69,16 @@ struct Variable {
     char *next_match;
 
     SLIST_ENTRY(Variable) variables;
+};
+
+/**
+ * List entry struct for an included file.
+ *
+ */
+struct IncludedFile {
+    char *path;
+
+    TAILQ_ENTRY(IncludedFile) files;
 };
 
 /**

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -20,6 +20,7 @@ state INITIAL:
   'set '                                   -> IGNORE_LINE
   'set	'                                  -> IGNORE_LINE
   'set_from_resource'                      -> IGNORE_LINE
+  'include'                                -> INCLUDE
   bindtype = 'bindsym', 'bindcode', 'bind' -> BINDING
   'bar'                                    -> BARBRACE
   'font'                                   -> FONT
@@ -62,6 +63,11 @@ state INITIAL:
 state IGNORE_LINE:
   line
       -> INITIAL
+
+# include <pattern>
+state INCLUDE:
+  pattern = string
+      -> call cfg_include($pattern)
 
 # floating_minimum_size <width> x <height>
 state FLOATING_MINIMUM_SIZE_WIDTH:
@@ -393,6 +399,8 @@ state BINDCOMMAND:
   exclude_titlebar = '--exclude-titlebar'
       ->
   command = string
+      -> call cfg_binding($bindtype, $modifiers, $key, $release, $border, $whole_window, $exclude_titlebar, $command)
+  end
       -> call cfg_binding($bindtype, $modifiers, $key, $release, $border, $whole_window, $exclude_titlebar, $command)
 
 ################################################################################

--- a/src/commands_parser.c
+++ b/src/commands_parser.c
@@ -56,40 +56,19 @@ typedef struct tokenptr {
 
 #include "GENERATED_command_tokens.h"
 
-/*******************************************************************************
- * The (small) stack where identified literals are stored during the parsing
- * of a single command (like $workspace).
- ******************************************************************************/
-
-struct stack_entry {
-    /* Just a pointer, not dynamically allocated. */
-    const char *identifier;
-    enum {
-        STACK_STR = 0,
-        STACK_LONG = 1,
-    } type;
-    union {
-        char *str;
-        long num;
-    } val;
-};
-
-/* 10 entries should be enough for everybody. */
-static struct stack_entry stack[10];
-
 /*
  * Pushes a string (identified by 'identifier') on the stack. We simply use a
  * single array, since the number of entries we have to store is very small.
  *
  */
-static void push_string(const char *identifier, char *str) {
+static void push_string(struct stack *stack, const char *identifier, char *str) {
     for (int c = 0; c < 10; c++) {
-        if (stack[c].identifier != NULL)
+        if (stack->stack[c].identifier != NULL)
             continue;
         /* Found a free slot, let’s store it here. */
-        stack[c].identifier = identifier;
-        stack[c].val.str = str;
-        stack[c].type = STACK_STR;
+        stack->stack[c].identifier = identifier;
+        stack->stack[c].val.str = str;
+        stack->stack[c].type = STACK_STR;
         return;
     }
 
@@ -103,15 +82,15 @@ static void push_string(const char *identifier, char *str) {
 }
 
 // TODO move to a common util
-static void push_long(const char *identifier, long num) {
+static void push_long(struct stack *stack, const char *identifier, long num) {
     for (int c = 0; c < 10; c++) {
-        if (stack[c].identifier != NULL) {
+        if (stack->stack[c].identifier != NULL) {
             continue;
         }
 
-        stack[c].identifier = identifier;
-        stack[c].val.num = num;
-        stack[c].type = STACK_LONG;
+        stack->stack[c].identifier = identifier;
+        stack->stack[c].val.num = num;
+        stack->stack[c].type = STACK_LONG;
         return;
     }
 
@@ -125,36 +104,36 @@ static void push_long(const char *identifier, long num) {
 }
 
 // TODO move to a common util
-static const char *get_string(const char *identifier) {
+static const char *get_string(struct stack *stack, const char *identifier) {
     for (int c = 0; c < 10; c++) {
-        if (stack[c].identifier == NULL)
+        if (stack->stack[c].identifier == NULL)
             break;
-        if (strcmp(identifier, stack[c].identifier) == 0)
-            return stack[c].val.str;
+        if (strcmp(identifier, stack->stack[c].identifier) == 0)
+            return stack->stack[c].val.str;
     }
     return NULL;
 }
 
 // TODO move to a common util
-static long get_long(const char *identifier) {
+static long get_long(struct stack *stack, const char *identifier) {
     for (int c = 0; c < 10; c++) {
-        if (stack[c].identifier == NULL)
+        if (stack->stack[c].identifier == NULL)
             break;
-        if (strcmp(identifier, stack[c].identifier) == 0)
-            return stack[c].val.num;
+        if (strcmp(identifier, stack->stack[c].identifier) == 0)
+            return stack->stack[c].val.num;
     }
 
     return 0;
 }
 
 // TODO move to a common util
-static void clear_stack(void) {
+static void clear_stack(struct stack *stack) {
     for (int c = 0; c < 10; c++) {
-        if (stack[c].type == STACK_STR)
-            free(stack[c].val.str);
-        stack[c].identifier = NULL;
-        stack[c].val.str = NULL;
-        stack[c].val.num = 0;
+        if (stack->stack[c].type == STACK_STR)
+            free(stack->stack[c].val.str);
+        stack->stack[c].identifier = NULL;
+        stack->stack[c].val.str = NULL;
+        stack->stack[c].val.num = 0;
     }
 }
 
@@ -163,9 +142,12 @@ static void clear_stack(void) {
  ******************************************************************************/
 
 static cmdp_state state;
-#ifndef TEST_PARSER
 static Match current_match;
-#endif
+/*******************************************************************************
+ * The (small) stack where identified literals are stored during the parsing
+ * of a single command (like $workspace).
+ ******************************************************************************/
+static struct stack stack;
 static struct CommandResultIR subcommand_output;
 static struct CommandResultIR command_output;
 
@@ -176,19 +158,19 @@ static void next_state(const cmdp_token *token) {
         subcommand_output.json_gen = command_output.json_gen;
         subcommand_output.client = command_output.client;
         subcommand_output.needs_tree_render = false;
-        GENERATED_call(token->extra.call_identifier, &subcommand_output);
+        GENERATED_call(&current_match, &stack, token->extra.call_identifier, &subcommand_output);
         state = subcommand_output.next_state;
         /* If any subcommand requires a tree_render(), we need to make the
          * whole parser result request a tree_render(). */
         if (subcommand_output.needs_tree_render)
             command_output.needs_tree_render = true;
-        clear_stack();
+        clear_stack(&stack);
         return;
     }
 
     state = token->next_state;
     if (state == INITIAL) {
-        clear_stack();
+        clear_stack(&stack);
     }
 }
 
@@ -296,8 +278,9 @@ CommandResult *parse_command(const char *input, yajl_gen gen, ipc_client *client
             /* A literal. */
             if (token->name[0] == '\'') {
                 if (strncasecmp(walk, token->name + 1, strlen(token->name) - 1) == 0) {
-                    if (token->identifier != NULL)
-                        push_string(token->identifier, sstrdup(token->name + 1));
+                    if (token->identifier != NULL) {
+                        push_string(&stack, token->identifier, sstrdup(token->name + 1));
+                    }
                     walk += strlen(token->name) - 1;
                     next_state(token);
                     token_handled = true;
@@ -319,8 +302,9 @@ CommandResult *parse_command(const char *input, yajl_gen gen, ipc_client *client
                 if (end == walk)
                     continue;
 
-                if (token->identifier != NULL)
-                    push_long(token->identifier, num);
+                if (token->identifier != NULL) {
+                    push_long(&stack, token->identifier, num);
+                }
 
                 /* Set walk to the first non-number character */
                 walk = end;
@@ -333,8 +317,9 @@ CommandResult *parse_command(const char *input, yajl_gen gen, ipc_client *client
                 strcmp(token->name, "word") == 0) {
                 char *str = parse_string(&walk, (token->name[0] != 's'));
                 if (str != NULL) {
-                    if (token->identifier)
-                        push_string(token->identifier, str);
+                    if (token->identifier) {
+                        push_string(&stack, token->identifier, str);
+                    }
                     /* If we are at the end of a quoted string, skip the ending
                      * double quote. */
                     if (*walk == '"')
@@ -436,7 +421,7 @@ CommandResult *parse_command(const char *input, yajl_gen gen, ipc_client *client
             y(map_close);
 
             free(position);
-            clear_stack();
+            clear_stack(&stack);
             break;
         }
     }

--- a/src/config.c
+++ b/src/config.c
@@ -10,6 +10,9 @@
  */
 #include "all.h"
 
+#include <libgen.h>
+#include <unistd.h>
+
 #include <xkbcommon/xkbcommon.h>
 
 char *current_configpath = NULL;
@@ -17,6 +20,7 @@ char *current_config = NULL;
 Config config;
 struct modes_head modes;
 struct barconfig_head barconfigs = TAILQ_HEAD_INITIALIZER(barconfigs);
+struct includedfiles_head included_files = TAILQ_HEAD_INITIALIZER(included_files);
 
 /*
  * Ungrabs all keys, to be called before re-grabbing the keys because of a
@@ -225,8 +229,42 @@ bool load_configuration(const char *override_configpath, config_load_t load_type
             "$XDG_CONFIG_HOME/i3/config, ~/.i3/config, $XDG_CONFIG_DIRS/i3/config "
             "and " SYSCONFDIR "/i3/config)");
     }
-    LOG("Parsing configfile %s\n", current_configpath);
-    const bool result = parse_file(current_configpath, load_type != C_VALIDATE);
+
+    IncludedFile *file;
+    while (!TAILQ_EMPTY(&included_files)) {
+        file = TAILQ_FIRST(&included_files);
+        FREE(file->path);
+        TAILQ_REMOVE(&included_files, file, files);
+        FREE(file);
+    }
+
+    char resolved_path[PATH_MAX] = {'\0'};
+    if (realpath(current_configpath, resolved_path) == NULL) {
+        die("realpath(%s): %s", current_configpath, strerror(errno));
+    }
+
+    file = scalloc(1, sizeof(IncludedFile));
+    file->path = sstrdup(resolved_path);
+    TAILQ_INSERT_TAIL(&included_files, file, files);
+
+    LOG("Parsing configfile %s\n", resolved_path);
+    struct stack stack;
+    memset(&stack, '\0', sizeof(struct stack));
+    struct parser_ctx ctx = {
+        .use_nagbar = (load_type != C_VALIDATE),
+        .assume_v4 = false,
+        .stack = &stack,
+    };
+    SLIST_INIT(&(ctx.variables));
+    FREE(current_config);
+    const int result = parse_file(&ctx, resolved_path);
+    free_variables(&ctx);
+    if (result == -1) {
+        die("Could not open configuration file: %s\n", strerror(errno));
+    }
+
+    extract_workspace_names_from_bindings();
+    reorder_bindings();
 
     if (config.font.type == FONT_TYPE_NONE && load_type != C_VALIDATE) {
         ELOG("You did not specify required configuration option \"font\"\n");
@@ -245,5 +283,5 @@ bool load_configuration(const char *override_configpath, config_load_t load_type
         xcb_flush(conn);
     }
 
-    return result;
+    return result == 0;
 }

--- a/src/display_version.c
+++ b/src/display_version.c
@@ -14,22 +14,34 @@
 #include <time.h>
 #include <unistd.h>
 
-static bool human_readable_key, loaded_config_file_name_key;
-static char *human_readable_version, *loaded_config_file_name;
+static bool human_readable_key;
+static bool loaded_config_file_name_key;
+static bool included_config_file_names;
+
+static char *human_readable_version;
+static char *loaded_config_file_name;
 
 static int version_string(void *ctx, const unsigned char *val, size_t len) {
-    if (human_readable_key)
+    if (human_readable_key) {
         sasprintf(&human_readable_version, "%.*s", (int)len, val);
-    if (loaded_config_file_name_key)
+    }
+    if (loaded_config_file_name_key) {
         sasprintf(&loaded_config_file_name, "%.*s", (int)len, val);
+    }
+    if (included_config_file_names) {
+        IncludedFile *file = scalloc(1, sizeof(IncludedFile));
+        sasprintf(&(file->path), "%.*s", (int)len, val);
+        TAILQ_INSERT_TAIL(&included_files, file, files);
+    }
     return 1;
 }
 
 static int version_map_key(void *ctx, const unsigned char *stringval, size_t stringlen) {
-    human_readable_key = (stringlen == strlen("human_readable") &&
-                          strncmp((const char *)stringval, "human_readable", strlen("human_readable")) == 0);
-    loaded_config_file_name_key = (stringlen == strlen("loaded_config_file_name") &&
-                                   strncmp((const char *)stringval, "loaded_config_file_name", strlen("loaded_config_file_name")) == 0);
+#define KEY_MATCHES(x) (stringlen == strlen(x) && strncmp((const char *)stringval, x, strlen(x)) == 0)
+    human_readable_key = KEY_MATCHES("human_readable");
+    loaded_config_file_name_key = KEY_MATCHES("loaded_config_file_name");
+    included_config_file_names = KEY_MATCHES("included_config_file_names");
+#undef KEY_MATCHES
     return 1;
 }
 
@@ -37,6 +49,22 @@ static yajl_callbacks version_callbacks = {
     .yajl_string = version_string,
     .yajl_map_key = version_map_key,
 };
+
+static void print_config_path(const char *path, const char *role) {
+    struct stat sb;
+    time_t now;
+    char mtime[64];
+
+    printf("  %s (%s)", path, role);
+    if (stat(path, &sb) == -1) {
+        printf("\n");
+        ELOG("Cannot stat config file \"%s\"\n", path);
+    } else {
+        strftime(mtime, sizeof(mtime), "%c", localtime(&(sb.st_mtime)));
+        time(&now);
+        printf(" (last modified: %s, %.f seconds ago)\n", mtime, difftime(now, sb.st_mtime));
+    }
+}
 
 /*
  * Connects to i3 to find out the currently running version. Useful since it
@@ -98,17 +126,11 @@ void display_running_version(void) {
     printf("Running i3 version: %s (pid %s)\n", human_readable_version, pid_from_atom);
 
     if (loaded_config_file_name) {
-        struct stat sb;
-        time_t now;
-        char mtime[64];
-        printf("Loaded i3 config: %s", loaded_config_file_name);
-        if (stat(loaded_config_file_name, &sb) == -1) {
-            printf("\n");
-            ELOG("Cannot stat config file \"%s\"\n", loaded_config_file_name);
-        } else {
-            strftime(mtime, sizeof(mtime), "%c", localtime(&(sb.st_mtime)));
-            time(&now);
-            printf(" (Last modified: %s, %.f seconds ago)\n", mtime, difftime(now, sb.st_mtime));
+        printf("Loaded i3 config:\n");
+        print_config_path(loaded_config_file_name, "main");
+        IncludedFile *file;
+        TAILQ_FOREACH (file, &included_files, files) {
+            print_config_path(file->path, "included");
         }
     }
 

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1040,6 +1040,17 @@ IPC_HANDLER(get_version) {
     ystr("loaded_config_file_name");
     ystr(current_configpath);
 
+    ystr("included_config_file_names");
+    y(array_open);
+    IncludedFile *file;
+    TAILQ_FOREACH (file, &included_files, files) {
+        if (file == TAILQ_FIRST(&included_files)) {
+            /* Skip the first file, which is current_configpath. */
+            continue;
+        }
+        ystr(file->path);
+    }
+    y(array_close);
     y(map_close);
 
     const unsigned char *payload;

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -506,6 +506,7 @@ EOT
 
 my $expected_all_tokens = "ERROR: CONFIG: Expected one of these tokens: <end>, '#', '" . join("', '", 'set ', 'set	', qw(
         set_from_resource
+        include
         bindsym
         bindcode
         bind

--- a/testcases/t/313-include.t
+++ b/testcases/t/313-include.t
@@ -1,0 +1,338 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Verifies the include directive.
+
+use File::Temp qw(tempfile tempdir);
+use File::Basename qw(basename);
+use i3test i3_autostart => 0;
+
+# starts i3 with the given config, opens a window, returns its border style
+sub launch_get_border {
+    my ($config) = @_;
+
+    my $pid = launch_with_config($config);
+
+    my $i3 = i3(get_socket_path(0));
+    my $tmp = fresh_workspace;
+
+    my $window = open_window(name => 'special title');
+
+    my @content = @{get_ws_content($tmp)};
+    cmp_ok(@content, '==', 1, 'one node on this workspace now');
+    my $border = $content[0]->{border};
+
+    exit_gracefully($pid);
+
+    return $border;
+}
+
+#####################################################################
+# test thet windows get the default border
+#####################################################################
+
+my $config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+EOT
+
+is(launch_get_border($config), 'normal', 'normal border');
+
+#####################################################################
+# now use a variable and for_window
+#####################################################################
+
+my ($fh, $filename) = tempfile(UNLINK => 1);
+print $fh <<'EOT';
+set $vartest special title
+for_window [title="$vartest"] border none
+EOT
+$fh->flush;
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+include $filename
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
+################################################################################
+# nested includes
+################################################################################
+
+my ($indirectfh, $indirectfilename) = tempfile(UNLINK => 1);
+print $indirectfh <<EOT;
+include $filename
+EOT
+$indirectfh->flush;
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+include $indirectfilename
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
+################################################################################
+# nested includes with relative paths
+################################################################################
+
+my $relative = basename($filename);
+my ($indirectfh2, $indirectfilename2) = tempfile(UNLINK => 1);
+print $indirectfh2 <<EOT;
+include $relative
+EOT
+$indirectfh2->flush;
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+include $indirectfilename2
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
+################################################################################
+# command substitution
+################################################################################
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+include `echo $filename`
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
+################################################################################
+# failing command substitution
+################################################################################
+
+$config = <<'EOT';
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+include i3-`false`.conf
+
+set $vartest special title
+for_window [title="$vartest"] border none
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
+################################################################################
+# permission denied
+################################################################################
+
+my ($permissiondeniedfh, $permissiondenied) = tempfile(UNLINK => 1);
+$permissiondeniedfh->flush;
+my $mode = 0055;
+chmod($mode, $permissiondenied);
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+include $permissiondenied
+include $filename
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
+################################################################################
+# dangling symlink
+################################################################################
+
+my ($danglingfh, $dangling) = tempfile(UNLINK => 1);
+unlink($dangling);
+symlink("/dangling", $dangling);
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+include $dangling
+set \$vartest special title
+for_window [title="\$vartest"] border none
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
+################################################################################
+# variables defined in the main file and used in the included file
+################################################################################
+
+my ($varfh, $var) = tempfile(UNLINK => 1);
+print $varfh <<'EOT';
+for_window [title="$vartest"] border none
+
+EOT
+$varfh->flush;
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+set \$vartest special title
+include $var
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
+SKIP: {
+    skip "not implemented";
+
+################################################################################
+# variables defined in the included file and used in the main file
+################################################################################
+
+($varfh, $var) = tempfile(UNLINK => 1);
+print $varfh <<'EOT';
+set $vartest special title
+EOT
+$varfh->flush;
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+include $var
+for_window [title="\$vartest"] border none
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+}
+
+################################################################################
+# workspace names are loaded in the correct order (before reorder_bindings)
+################################################################################
+
+# The included config can be empty, the issue lies with calling parse_file
+# multiple times.
+my ($wsfh, $ws) = tempfile(UNLINK => 1);
+$wsfh->flush;
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+bindsym 1 workspace 1: eggs
+bindsym Mod4+Shift+1 workspace 11: tomatoes
+
+include $var
+EOT
+
+# starts i3 with the given config, opens a window, returns its border style
+sub launch_get_workspace_name {
+    my ($config) = @_;
+
+    my $pid = launch_with_config($config);
+
+    my $i3 = i3(get_socket_path(0));
+    my $name = $i3->get_workspaces->recv->[0]->{name};
+
+    exit_gracefully($pid);
+
+    return $name;
+}
+
+is(launch_get_workspace_name($config), '1: eggs', 'workspace name');
+
+################################################################################
+# loop prevention
+################################################################################
+
+my ($loopfh1, $loopname1) = tempfile(UNLINK => 1);
+my ($loopfh2, $loopname2) = tempfile(UNLINK => 1);
+
+print $loopfh1 <<EOT;
+include $loopname2
+EOT
+$loopfh1->flush;
+
+print $loopfh2 <<EOT;
+include $loopname1
+EOT
+$loopfh2->flush;
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+# loop
+include $loopname1
+
+set \$vartest special title
+for_window [title="\$vartest"] border none
+EOT
+
+is(launch_get_border($config), 'none', 'no border');
+
+################################################################################
+# Verify the GET_VERSION IPC reply contains all included files
+################################################################################
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+include $indirectfilename2
+EOT
+
+my $pid = launch_with_config($config);
+
+my $i3 = i3(get_socket_path(0));
+my $version = $i3->get_version()->recv;
+my $included = $version->{included_config_file_names};
+
+is_deeply($included, [ $indirectfilename2, $filename ], 'included config file names correct');
+
+exit_gracefully($pid);
+
+################################################################################
+# Verify the GET_CONFIG IPC reply returns the top-level config
+################################################################################
+
+my $tmpdir = tempdir(CLEANUP => 1);
+my $socketpath = $tmpdir . "/config.sock";
+ok(! -e $socketpath, "$socketpath does not exist yet");
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+include $indirectfilename2
+
+ipc-socket $socketpath
+EOT
+
+my $pid = launch_with_config($config, dont_add_socket_path => 1, dont_create_temp_dir => 1);
+
+my $i3 = i3(get_socket_path(0));
+my $config_reply = $i3->get_config()->recv;
+
+is($config_reply->{config}, $config, 'GET_CONFIG returns the top-level config file');
+
+exit_gracefully($pid);
+
+
+done_testing;


### PR DESCRIPTION
The implementation [uses wordexp(3) just like sway](https://github.com/i3/i3/issues/1197#issuecomment-226844106).

Thanks to jajm [for their implementation](https://github.com/jajm/i3/commit/bb55709d0aa0731f7b3c641871731a992ababb1a).

This required refactoring the config parser to be re-entrant
(no more global state) and to return an error instead of dying.

In case a file cannot be opened, i3 reports an error but proceeds with the
remaining configuration.

All files that were successfully included are displayed in `i3 --moreversion`.

One caveat is i3 config file variable expansion, see the note in the userguide.

fixes #4192