### PR TITLE
Add a new IPC message for requesting structured configuration

### DIFF
--- a/i3-msg/main.c
+++ b/i3-msg/main.c
@@ -195,6 +195,8 @@ int main(int argc, char *argv[]) {
                 message_type = I3_IPC_MESSAGE_TYPE_GET_VERSION;
             } else if (strcasecmp(optarg, "get_config") == 0) {
                 message_type = I3_IPC_MESSAGE_TYPE_GET_CONFIG;
+            } else if (strcasecmp(optarg, "get_config_json") == 0) {
+                message_type = I3_IPC_MESSAGE_TYPE_GET_CONFIG_JSON;
             } else if (strcasecmp(optarg, "send_tick") == 0) {
                 message_type = I3_IPC_MESSAGE_TYPE_SEND_TICK;
             } else if (strcasecmp(optarg, "subscribe") == 0) {

--- a/include/bindings.h
+++ b/include/bindings.h
@@ -114,3 +114,13 @@ bool load_keymap(void);
  * The list is terminated by a 0.
  */
 int *bindings_get_buttons_to_grab(void);
+
+/**
+ * Dumps an i3_event_state_mask_t into JSON (as an array)
+ */
+void dump_event_state_mask(yajl_gen gen, i3_event_state_mask_t mask);
+
+/**
+ * Dumps a binding into JSON
+ */
+void dump_binding(yajl_gen gen, Binding *bind);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -249,6 +249,14 @@ struct Config {
 
     /* The number of currently parsed barconfigs */
     int number_barconfigs;
+
+    /** A yajl_gen for generating the structured configuration */
+    yajl_gen json_gen;
+
+    /** The loaded configuration as JSON*/
+    unsigned char *json;
+    /** Length of the JSON */
+    size_t json_len;
 };
 
 /**

--- a/include/i3/ipc.h
+++ b/include/i3/ipc.h
@@ -69,6 +69,9 @@ typedef struct i3_ipc_header {
 /** Request the current binding state. */
 #define I3_IPC_MESSAGE_TYPE_GET_BINDING_STATE 12
 
+/** Request the loaded configuration as JSON */
+#define I3_IPC_MESSAGE_TYPE_GET_CONFIG_JSON 13
+
 /*
  * Messages from i3 to clients
  *
@@ -86,6 +89,7 @@ typedef struct i3_ipc_header {
 #define I3_IPC_REPLY_TYPE_TICK 10
 #define I3_IPC_REPLY_TYPE_SYNC 11
 #define I3_IPC_REPLY_TYPE_GET_BINDING_STATE 12
+#define I3_IPC_REPLY_TYPE_GET_CONFIG_JSON 13
 
 /*
  * Events from i3 to clients. Events have the first bit set high.

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -7,6 +7,7 @@
  * bindings.c: Functions for configuring, finding and, running bindings.
  */
 #include "all.h"
+#include "yajl_utils.h"
 
 #include <math.h>
 
@@ -1026,4 +1027,94 @@ int *bindings_get_buttons_to_grab(void) {
     memcpy(buttons, buffer, num * sizeof(int));
 
     return buttons;
+}
+
+void dump_event_state_mask(yajl_gen gen, i3_event_state_mask_t mask) {
+    y(array_open);
+    for (int i = 0; i < 20; i++) {
+        if (mask & (1 << i)) {
+            switch (1 << i) {
+                case XCB_KEY_BUT_MASK_SHIFT:
+                    ystr("shift");
+                    break;
+                case XCB_KEY_BUT_MASK_LOCK:
+                    ystr("lock");
+                    break;
+                case XCB_KEY_BUT_MASK_CONTROL:
+                    ystr("ctrl");
+                    break;
+                case XCB_KEY_BUT_MASK_MOD_1:
+                    ystr("Mod1");
+                    break;
+                case XCB_KEY_BUT_MASK_MOD_2:
+                    ystr("Mod2");
+                    break;
+                case XCB_KEY_BUT_MASK_MOD_3:
+                    ystr("Mod3");
+                    break;
+                case XCB_KEY_BUT_MASK_MOD_4:
+                    ystr("Mod4");
+                    break;
+                case XCB_KEY_BUT_MASK_MOD_5:
+                    ystr("Mod5");
+                    break;
+                case XCB_KEY_BUT_MASK_BUTTON_1:
+                    ystr("Button1");
+                    break;
+                case XCB_KEY_BUT_MASK_BUTTON_2:
+                    ystr("Button2");
+                    break;
+                case XCB_KEY_BUT_MASK_BUTTON_3:
+                    ystr("Button3");
+                    break;
+                case XCB_KEY_BUT_MASK_BUTTON_4:
+                    ystr("Button4");
+                    break;
+                case XCB_KEY_BUT_MASK_BUTTON_5:
+                    ystr("Button5");
+                    break;
+                case (I3_XKB_GROUP_MASK_1 << 16):
+                    ystr("Group1");
+                    break;
+                case (I3_XKB_GROUP_MASK_2 << 16):
+                    ystr("Group2");
+                    break;
+                case (I3_XKB_GROUP_MASK_3 << 16):
+                    ystr("Group3");
+                    break;
+                case (I3_XKB_GROUP_MASK_4 << 16):
+                    ystr("Group4");
+                    break;
+            }
+        }
+    }
+    y(array_close);
+}
+
+void dump_binding(yajl_gen gen, Binding *bind) {
+    y(map_open);
+    ystr("input_code");
+    y(integer, bind->keycode);
+
+    ystr("input_type");
+    ystr((const char *)(bind->input_type == B_KEYBOARD ? "keyboard" : "mouse"));
+
+    ystr("symbol");
+    if (bind->symbol == NULL)
+        y(null);
+    else
+        ystr(bind->symbol);
+
+    ystr("command");
+    ystr(bind->command);
+
+    // This key is only provided for compatibility, new programs should use
+    // event_state_mask instead.
+    ystr("mods");
+    dump_event_state_mask(gen, bind->event_state_mask);
+
+    ystr("event_state_mask");
+    dump_event_state_mask(gen, bind->event_state_mask);
+
+    y(map_close);
 }

--- a/src/config.c
+++ b/src/config.c
@@ -31,10 +31,10 @@ void ungrab_all_keys(xcb_connection_t *conn) {
 
 static void color_to_hex(color_t color, char *hex) {
     hex[0] = '#';
-    sprintf(hex+1, "%02x", (int) (color.red * 255));
-    sprintf(hex+3, "%02x", (int) (color.green * 255));
-    sprintf(hex+5, "%02x", (int) (color.blue * 255));
-    sprintf(hex+7, "%02x", (int) (color.alpha * 255));
+    sprintf(hex + 1, "%02x", (int)(color.red * 255));
+    sprintf(hex + 3, "%02x", (int)(color.green * 255));
+    sprintf(hex + 5, "%02x", (int)(color.blue * 255));
+    sprintf(hex + 7, "%02x", (int)(color.alpha * 255));
     hex[9] = '\0';
 }
 
@@ -42,8 +42,8 @@ static void dump_colortriple(yajl_gen gen, struct Colortriple triple) {
     char str[10];
 
     y(map_open);
-#define ADD(name) \
-    ystr(#name); \
+#define ADD(name)                   \
+    ystr(#name);                    \
     color_to_hex(triple.name, str); \
     ystr(str);
 
@@ -62,9 +62,17 @@ static void generate_structured_config(void) {
     y(map_open);
 
     /* Values from Config */
-#define CINT(name)  ystr(#name); y(integer, config.name)
-#define CBOOL(name) ystr(#name); y(bool, config.name)
-#define CSTR(name)  if (config.name != NULL) { ystr(#name); ystr(config.name); }
+#define CINT(name) \
+    ystr(#name);   \
+    y(integer, config.name)
+#define CBOOL(name) \
+    ystr(#name);    \
+    y(bool, config.name)
+#define CSTR(name)             \
+    if (config.name != NULL) { \
+        ystr(#name);           \
+        ystr(config.name);     \
+    }
     CSTR(ipc_socket_path);
     CSTR(restart_state_path);
     CINT(default_border_width);
@@ -235,7 +243,7 @@ static void generate_structured_config(void) {
 /* 'element' is the element of Config (client, bar) and 'class' is the color
  * class to be saved */
 #define ADD(element, class) \
-    ystr(#class); \
+    ystr(#class);           \
     dump_colortriple(gen, config.element.class);
 
     ystr("colors_client");
@@ -288,7 +296,7 @@ static void generate_structured_config(void) {
         ystr(autostart->command);
 
         ystr("no-startup-id");
-        y(bool, (int) autostart->no_startup_id);
+        y(bool, (int)autostart->no_startup_id);
 
         y(map_close);
     }
@@ -305,7 +313,7 @@ static void generate_structured_config(void) {
         ystr(autostart->command);
 
         ystr("no-startup-id");
-        y(bool, (int) autostart->no_startup_id);
+        y(bool, (int)autostart->no_startup_id);
 
         y(map_close);
     }
@@ -362,9 +370,9 @@ static void generate_structured_config(void) {
         /* The Match (criteria) */
         ystr("criteria");
         y(map_open);
-#define ADD(name) \
-    if (assignment->match.name != NULL) { \
-        ystr(#name); \
+#define ADD(name)                              \
+    if (assignment->match.name != NULL) {      \
+        ystr(#name);                           \
         ystr(assignment->match.name->pattern); \
     }
         ADD(title);
@@ -425,7 +433,7 @@ static void generate_structured_config(void) {
         if (assignment->match.window_mode != WM_ANY) {
             ystr("window_mode");
             switch (assignment->match.window_mode) {
-               case  WM_TILING_AUTO:
+                case WM_TILING_AUTO:
                     ystr("tiling_auto");
                     break;
                 case WM_TILING_USER:
@@ -450,7 +458,7 @@ static void generate_structured_config(void) {
 
         if (assignment->match.con_id != NULL) {
             ystr("con_id");
-            y(integer, (long) assignment->match.con_id);
+            y(integer, (long)assignment->match.con_id);
         }
 
         if (assignment->match.id != 0) {
@@ -689,7 +697,7 @@ bool load_configuration(const char *override_configpath, config_load_t load_type
     /* Generate the structured configuration information */
     config.json_gen = ygenalloc();
     generate_structured_config();
-    yajl_gen_get_buf(config.json_gen, (const unsigned char **) &(config.json), &(config.json_len));
+    yajl_gen_get_buf(config.json_gen, (const unsigned char **)&(config.json), &(config.json_len));
 
     return result;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -9,6 +9,7 @@
  *
  */
 #include "all.h"
+#include "yajl_utils.h"
 
 #include <xkbcommon/xkbcommon.h>
 
@@ -26,6 +27,442 @@ struct barconfig_head barconfigs = TAILQ_HEAD_INITIALIZER(barconfigs);
 void ungrab_all_keys(xcb_connection_t *conn) {
     DLOG("Ungrabbing all keys\n");
     xcb_ungrab_key(conn, XCB_GRAB_ANY, root, XCB_BUTTON_MASK_ANY);
+}
+
+static void color_to_hex(color_t color, char *hex) {
+    hex[0] = '#';
+    sprintf(hex+1, "%02x", (int) (color.red * 255));
+    sprintf(hex+3, "%02x", (int) (color.green * 255));
+    sprintf(hex+5, "%02x", (int) (color.blue * 255));
+    sprintf(hex+7, "%02x", (int) (color.alpha * 255));
+    hex[9] = '\0';
+}
+
+static void dump_colortriple(yajl_gen gen, struct Colortriple triple) {
+    char str[10];
+
+    y(map_open);
+#define ADD(name) \
+    ystr(#name); \
+    color_to_hex(triple.name, str); \
+    ystr(str);
+
+    ADD(border);
+    ADD(background);
+    ADD(text);
+    ADD(indicator);
+    ADD(child_border);
+#undef ADD
+    y(map_close);
+}
+
+static void generate_structured_config(void) {
+    yajl_gen gen = config.json_gen;
+
+    y(map_open);
+
+    /* Values from Config */
+#define CINT(name)  ystr(#name); y(integer, config.name)
+#define CBOOL(name) ystr(#name); y(bool, config.name)
+#define CSTR(name)  if (config.name != NULL) { ystr(#name); ystr(config.name); }
+    CSTR(ipc_socket_path);
+    CSTR(restart_state_path);
+    CINT(default_border_width);
+    CINT(default_floating_border_width);
+    CBOOL(disable_focus_follows_mouse);
+    CBOOL(force_xinerama);
+    CBOOL(disable_randr15);
+    CBOOL(workspace_auto_back_and_forth);
+    CBOOL(show_marks);
+    CINT(floating_maximum_width);
+    CINT(floating_maximum_height);
+    CINT(floating_minimum_width);
+    CINT(floating_minimum_height);
+    CSTR(fake_outputs);
+#undef CSTR
+#undef CINT
+#undef CBOOL
+
+    /* Enums and the like from Config */
+    if (config.font.pattern != NULL) {
+        ystr("font");
+        ystr(config.font.pattern);
+    }
+
+    ystr("floating_modifier");
+    dump_event_state_mask(gen, config.floating_modifier);
+
+    ystr("default_layout");
+    switch (config.default_layout) {
+        case L_DEFAULT:
+            ystr("default");
+            break;
+        case L_STACKED:
+            ystr("stacked");
+            break;
+        case L_TABBED:
+            ystr("tabbed");
+            break;
+        case L_DOCKAREA:
+            ystr("dockarea");
+            break;
+        case L_OUTPUT:
+            ystr("output");
+            break;
+        case L_SPLITV:
+            ystr("splitv");
+            break;
+        case L_SPLITH:
+            ystr("splith");
+            break;
+    }
+
+    ystr("default_orientation");
+    switch (config.default_orientation) {
+        case HORIZ:
+            ystr("horizontal");
+            break;
+        case VERT:
+            ystr("vertical");
+            break;
+        case NO_ORIENTATION:
+            ystr("none");
+            break;
+    }
+
+    ystr("mouse_warping");
+    switch (config.mouse_warping) {
+        case POINTER_WARPING_OUTPUT:
+            ystr("output");
+            break;
+        case POINTER_WARPING_NONE:
+            ystr("none");
+            break;
+    }
+
+    ystr("hide_edge_borders");
+    switch (config.hide_edge_borders) {
+        case HEBM_NONE:
+            ystr("none");
+            break;
+        case HEBM_VERTICAL:
+            ystr("vertical");
+            break;
+        case HEBM_HORIZONTAL:
+            ystr("horizontal");
+            break;
+        case HEBM_BOTH:
+            ystr("both");
+            break;
+        case HEBM_SMART:
+            ystr("smart");
+            break;
+    }
+
+    ystr("focus_wrapping");
+    switch (config.focus_wrapping) {
+        case FOCUS_WRAPPING_OFF:
+            ystr("off");
+            break;
+        case FOCUS_WRAPPING_ON:
+            ystr("on");
+            break;
+        case FOCUS_WRAPPING_FORCE:
+            ystr("force");
+            break;
+        case FOCUS_WRAPPING_WORKSPACE:
+            ystr("workspace");
+            break;
+    }
+
+    ystr("workspace_urgency_timer");
+    y(double, config.workspace_urgency_timer);
+
+    ystr("focus_on_window_activation");
+    switch (config.focus_on_window_activation) {
+        case FOWA_SMART:
+            ystr("smart");
+            break;
+        case FOWA_URGENT:
+            ystr("urgent");
+            break;
+        case FOWA_FOCUS:
+            ystr("focus");
+            break;
+        case FOWA_NONE:
+            ystr("none");
+            break;
+    }
+
+    ystr("title_align");
+    switch (config.title_align) {
+        case ALIGN_LEFT:
+            ystr("left");
+            break;
+        case ALIGN_CENTER:
+            ystr("center");
+            break;
+        case ALIGN_RIGHT:
+            ystr("right");
+            break;
+    }
+
+    ystr("default_border");
+    switch (config.default_border) {
+        case BS_NORMAL:
+            ystr("normal");
+            break;
+        case BS_NONE:
+            ystr("none");
+            break;
+        case BS_PIXEL:
+            ystr("pixel");
+            break;
+    }
+    ystr("default_floating_border");
+    switch (config.default_floating_border) {
+        case BS_NORMAL:
+            ystr("normal");
+            break;
+        case BS_NONE:
+            ystr("none");
+            break;
+        case BS_PIXEL:
+            ystr("pixel");
+            break;
+    }
+
+/* 'element' is the element of Config (client, bar) and 'class' is the color
+ * class to be saved */
+#define ADD(element, class) \
+    ystr(#class); \
+    dump_colortriple(gen, config.element.class);
+
+    ystr("colors_client");
+    y(map_open);
+
+    char client_bg[10];
+    color_to_hex(config.client.background, client_bg);
+    ystr("background");
+    ystr(client_bg);
+
+    ADD(client, focused);
+    ADD(client, focused_inactive);
+    ADD(client, unfocused);
+    ADD(client, urgent);
+    ADD(client, placeholder);
+
+    y(map_close); /* colors_client */
+
+    ystr("colors_bar");
+    y(map_open);
+
+    ADD(bar, focused);
+    ADD(bar, unfocused);
+    ADD(bar, urgent);
+
+    y(map_close);
+#undef ADD
+
+    ystr("popup_during_fullscreen");
+    switch (config.popup_during_fullscreen) {
+        case PDF_SMART:
+            ystr("smart");
+            break;
+        case PDF_LEAVE_FULLSCREEN:
+            ystr("leave_fullscreen");
+            break;
+        case PDF_IGNORE:
+            ystr("ignore");
+            break;
+    }
+    /* exec */
+    ystr("exec");
+    y(array_open);
+
+    struct Autostart *autostart;
+    TAILQ_FOREACH (autostart, &autostarts, autostarts) {
+        y(map_open);
+
+        ystr("command");
+        ystr(autostart->command);
+
+        ystr("no-startup-id");
+        y(bool, (int) autostart->no_startup_id);
+
+        y(map_close);
+    }
+    y(array_close);
+
+    /* exec_always */
+    ystr("exec_always");
+    y(array_open);
+
+    TAILQ_FOREACH (autostart, &autostarts_always, autostarts_always) {
+        y(map_open);
+
+        ystr("command");
+        ystr(autostart->command);
+
+        ystr("no-startup-id");
+        y(bool, (int) autostart->no_startup_id);
+
+        y(map_close);
+    }
+    y(array_close);
+
+    /* Assignments */
+    ystr("assignments");
+    y(array_open);
+
+    Assignment *assignment;
+    TAILQ_FOREACH (assignment, &assignments, assignments) {
+        y(map_open);
+        ystr("type");
+        switch (assignment->type) {
+            case A_COMMAND:
+                ystr("command");
+                break;
+            case A_TO_WORKSPACE:
+                ystr("workspace");
+                break;
+            case A_TO_WORKSPACE_NUMBER:
+                ystr("workspace_number");
+                break;
+            case A_TO_OUTPUT:
+                ystr("output");
+                break;
+            case A_NO_FOCUS:
+                ystr("no_focus");
+                break;
+            case A_ANY:
+                break;
+        }
+
+        if (assignment->type & (A_COMMAND | A_TO_WORKSPACE |
+                                A_TO_WORKSPACE_NUMBER | A_TO_OUTPUT)) {
+            ystr("value");
+            switch (assignment->type) {
+                case A_COMMAND:
+                    ystr(assignment->dest.command);
+                    break;
+                case A_TO_WORKSPACE:
+                case A_TO_WORKSPACE_NUMBER:
+                    ystr(assignment->dest.workspace);
+                    break;
+                case A_TO_OUTPUT:
+                    ystr(assignment->dest.output);
+                    break;
+                default:
+                    /* to make the compiler happy */
+                    break;
+            }
+        }
+
+        /* The Match (criteria) */
+        ystr("criteria");
+        y(map_open);
+#define ADD(name) \
+    if (assignment->match.name != NULL) { \
+        ystr(#name); \
+        ystr(assignment->match.name->pattern); \
+    }
+        ADD(title);
+        ADD(application);
+        ADD(class);
+        ADD(instance);
+        ADD(mark);
+        ADD(window_role);
+        ADD(workspace);
+        ADD(machine);
+#undef ADD
+
+        if (assignment->match.window_type != UINT32_MAX) {
+            ystr("window_type");
+            if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_NORMAL) {
+                ystr("normal");
+            } else if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_DOCK) {
+                ystr("dock");
+            } else if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_DIALOG) {
+                ystr("dialog");
+            } else if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_UTILITY) {
+                ystr("utility");
+            } else if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_TOOLBAR) {
+                ystr("toolbar");
+            } else if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_SPLASH) {
+                ystr("splash");
+            } else if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_MENU) {
+                ystr("menu");
+            } else if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_DROPDOWN_MENU) {
+                ystr("dropdown_menu");
+            } else if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_POPUP_MENU) {
+                ystr("popup_menu");
+            } else if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_TOOLTIP) {
+                ystr("tooltip");
+            } else if (assignment->match.window_type == A__NET_WM_WINDOW_TYPE_NOTIFICATION) {
+                ystr("notification");
+            } else {
+                ELOG("Illegal value of window type: %d. This is probably a bug in i3\n",
+                     assignment->match.window_type);
+                y(null);
+            }
+        }
+
+        if (assignment->match.urgent != U_DONTCHECK) {
+            ystr("urgent");
+            switch (assignment->match.urgent) {
+                case U_LATEST:
+                    ystr("latest");
+                    break;
+                case U_OLDEST:
+                    ystr("oldest");
+                    break;
+                case U_DONTCHECK:
+                    break;
+            }
+        }
+
+        if (assignment->match.window_mode != WM_ANY) {
+            ystr("window_mode");
+            switch (assignment->match.window_mode) {
+               case  WM_TILING_AUTO:
+                    ystr("tiling_auto");
+                    break;
+                case WM_TILING_USER:
+                    ystr("tiling_user");
+                    break;
+                case WM_TILING:
+                    ystr("tiling");
+                    break;
+                case WM_FLOATING_AUTO:
+                    ystr("floating_auto");
+                    break;
+                case WM_FLOATING_USER:
+                    ystr("floating_user");
+                    break;
+                case WM_FLOATING:
+                    ystr("floating");
+                    break;
+                case WM_ANY:
+                    break;
+            }
+        }
+
+        if (assignment->match.con_id != NULL) {
+            ystr("con_id");
+            y(integer, (long) assignment->match.con_id);
+        }
+
+        if (assignment->match.id != 0) {
+            ystr("id");
+            y(integer, assignment->match.id);
+        }
+
+        y(map_close); /* Match */
+        y(map_close); /* Assignment */
+    }
+    y(array_close); /* Assignments */
+    y(map_close);
 }
 
 static void free_configuration(void) {
@@ -146,6 +583,10 @@ static void free_configuration(void) {
     free(config.ipc_socket_path);
     free(config.restart_state_path);
     free(config.fake_outputs);
+
+    /* Free the structured config */
+    yajl_gen_free(config.json_gen);
+    config.json_len = 0;
 }
 
 /*
@@ -244,6 +685,11 @@ bool load_configuration(const char *override_configpath, config_load_t load_type
         x_deco_recurse(croot);
         xcb_flush(conn);
     }
+
+    /* Generate the structured configuration information */
+    config.json_gen = ygenalloc();
+    generate_structured_config();
+    yajl_gen_get_buf(config.json_gen, (const unsigned char **) &(config.json), &(config.json_len));
 
     return result;
 }

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -245,96 +245,6 @@ static void dump_rect(yajl_gen gen, const char *name, Rect r) {
     y(map_close);
 }
 
-static void dump_event_state_mask(yajl_gen gen, Binding *bind) {
-    y(array_open);
-    for (int i = 0; i < 20; i++) {
-        if (bind->event_state_mask & (1 << i)) {
-            switch (1 << i) {
-                case XCB_KEY_BUT_MASK_SHIFT:
-                    ystr("shift");
-                    break;
-                case XCB_KEY_BUT_MASK_LOCK:
-                    ystr("lock");
-                    break;
-                case XCB_KEY_BUT_MASK_CONTROL:
-                    ystr("ctrl");
-                    break;
-                case XCB_KEY_BUT_MASK_MOD_1:
-                    ystr("Mod1");
-                    break;
-                case XCB_KEY_BUT_MASK_MOD_2:
-                    ystr("Mod2");
-                    break;
-                case XCB_KEY_BUT_MASK_MOD_3:
-                    ystr("Mod3");
-                    break;
-                case XCB_KEY_BUT_MASK_MOD_4:
-                    ystr("Mod4");
-                    break;
-                case XCB_KEY_BUT_MASK_MOD_5:
-                    ystr("Mod5");
-                    break;
-                case XCB_KEY_BUT_MASK_BUTTON_1:
-                    ystr("Button1");
-                    break;
-                case XCB_KEY_BUT_MASK_BUTTON_2:
-                    ystr("Button2");
-                    break;
-                case XCB_KEY_BUT_MASK_BUTTON_3:
-                    ystr("Button3");
-                    break;
-                case XCB_KEY_BUT_MASK_BUTTON_4:
-                    ystr("Button4");
-                    break;
-                case XCB_KEY_BUT_MASK_BUTTON_5:
-                    ystr("Button5");
-                    break;
-                case (I3_XKB_GROUP_MASK_1 << 16):
-                    ystr("Group1");
-                    break;
-                case (I3_XKB_GROUP_MASK_2 << 16):
-                    ystr("Group2");
-                    break;
-                case (I3_XKB_GROUP_MASK_3 << 16):
-                    ystr("Group3");
-                    break;
-                case (I3_XKB_GROUP_MASK_4 << 16):
-                    ystr("Group4");
-                    break;
-            }
-        }
-    }
-    y(array_close);
-}
-
-static void dump_binding(yajl_gen gen, Binding *bind) {
-    y(map_open);
-    ystr("input_code");
-    y(integer, bind->keycode);
-
-    ystr("input_type");
-    ystr((const char *)(bind->input_type == B_KEYBOARD ? "keyboard" : "mouse"));
-
-    ystr("symbol");
-    if (bind->symbol == NULL)
-        y(null);
-    else
-        ystr(bind->symbol);
-
-    ystr("command");
-    ystr(bind->command);
-
-    // This key is only provided for compatibility, new programs should use
-    // event_state_mask instead.
-    ystr("mods");
-    dump_event_state_mask(gen, bind);
-
-    ystr("event_state_mask");
-    dump_event_state_mask(gen, bind);
-
-    y(map_close);
-}
-
 void dump_node(yajl_gen gen, struct Con *con, bool inplace_restart) {
     y(map_open);
     ystr("id");
@@ -1340,9 +1250,13 @@ IPC_HANDLER(get_binding_state) {
     y(free);
 }
 
+IPC_HANDLER(get_config_json) {
+    ipc_send_client_message(client, config.json_len, I3_IPC_REPLY_TYPE_GET_CONFIG_JSON, config.json);
+}
+
 /* The index of each callback function corresponds to the numeric
  * value of the message type (see include/i3/ipc.h) */
-handler_t handlers[13] = {
+handler_t handlers[] = {
     handle_run_command,
     handle_get_workspaces,
     handle_subscribe,
@@ -1356,6 +1270,7 @@ handler_t handlers[13] = {
     handle_send_tick,
     handle_sync,
     handle_get_binding_state,
+    handle_get_config_json,
 };
 
 /*


### PR DESCRIPTION
Adds a new IPC message for requesting the configuration in JSON, as discussed in #4293.

I wanted to generate the JSON somewhat automatically, but didn't find any acceptable way of doing it - if we generated the JSON at the same time we parsed the config file, the result wouldn't be very structured and would have duplicit values if some directives were set and then overridden.

TODO:
- [ ] parts of the configuration:
    - [ ] keybindings
    - [ ] workspaces
    - [ ] bar
- [ ] tests
- [ ] documentation