### PR TITLE
Made state consistent with window in remanage_window

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -56,3 +56,4 @@ option is enabled and only then sets a screenshot as background.
   • clear pixmap before drawing to prevent visual garbage
   • ipc: return proper signed int for container positions: negative values were
     returned as large 32 bits integers
+  • fix some swallowed windows would appear to be clipped

--- a/include/x.h
+++ b/include/x.h
@@ -36,6 +36,15 @@ void x_move_win(Con *src, Con *dest);
 void x_reparent_child(Con *con, Con *old);
 
 /**
+ * Reparents child window from old con into new con. The reparenting happens in
+ * the next call of x_push_changes(). Unlike x_reparent_child & x_move_win, this
+ * function assumes that the old con is about to be destroyed and preserves
+ * window_rect and child_mapped.
+ *
+ */
+void x_reparent_child2(Con *new, Con *old);
+
+/**
  * Re-initializes the associated X window state for this container. You have
  * to call this when you assign a client to an empty container to ensure that
  * its state gets updated correctly.

--- a/include/x.h
+++ b/include/x.h
@@ -42,7 +42,7 @@ void x_reparent_child(Con *con, Con *old);
  * window_rect and child_mapped.
  *
  */
-void x_reparent_child2(Con *new, Con *old);
+void x_reparent_child_deep(Con *new, Con *old);
 
 /**
  * Re-initializes the associated X window state for this container. You have

--- a/src/manage.c
+++ b/src/manage.c
@@ -733,7 +733,7 @@ Con *remanage_window(Con *con) {
 
     xcb_window_t old_frame = _match_depth(con->window, nc);
 
-    x_reparent_child2(nc, con);
+    x_reparent_child_deep(nc, con);
 
     bool moved_workpaces = (con_get_workspace(nc) != con_get_workspace(con));
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -733,7 +733,7 @@ Con *remanage_window(Con *con) {
 
     xcb_window_t old_frame = _match_depth(con->window, nc);
 
-    x_reparent_child(nc, con);
+    x_reparent_child2(nc, con);
 
     bool moved_workpaces = (con_get_workspace(nc) != con_get_workspace(con));
 

--- a/src/x.c
+++ b/src/x.c
@@ -251,6 +251,34 @@ void x_move_win(Con *src, Con *dest) {
     }
 }
 
+/*
+ * Reparents child window from old con into new con. The reparenting happens in
+ * the next call of x_push_changes(). Unlike x_reparent_child & x_move_win, this
+ * function assumes that the old con is about to be destroyed and preserves
+ * window_rect and child_mapped.
+ *
+ */
+void x_reparent_child2(Con *new, Con *old) {
+    struct con_state *new_state, *old_state;
+
+    if ((new_state = state_for_frame(new->frame.id)) == NULL) {
+        ELOG("window state for new con not found\n");
+        return;
+    }
+
+    if ((old_state = state_for_frame(old->frame.id)) == NULL) {
+        ELOG("window state for old con not found\n");
+        return;
+    }
+
+    new_state->need_reparent = true;
+    new_state->old_frame = old->frame.id;
+
+    new_state->child_mapped = old_state->child_mapped;
+
+    memcpy(&(new_state->window_rect), &(old_state->window_rect), sizeof(Rect));
+}
+
 static void _x_con_kill(Con *con) {
     con_state *state;
 

--- a/src/x.c
+++ b/src/x.c
@@ -258,7 +258,7 @@ void x_move_win(Con *src, Con *dest) {
  * window_rect and child_mapped.
  *
  */
-void x_reparent_child2(Con *new, Con *old) {
+void x_reparent_child_deep(Con *new, Con *old) {
     struct con_state *new_state, *old_state;
 
     if ((new_state = state_for_frame(new->frame.id)) == NULL) {


### PR DESCRIPTION
Fixes #4075.

i3 believes everything is fine because the con_state window_rect says it is the right size. This commit updates window_rect to the actual state as well as child_mapped.

Does this need a test? I have no idea how to make a test for a bug like this.