### PR TITLE
When moving to next or prev workspace, don't skip colliding number

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -56,3 +56,5 @@ option is enabled and only then sets a screenshot as background.
   • clear pixmap before drawing to prevent visual garbage
   • ipc: return proper signed int for container positions: negative values were
     returned as large 32 bits integers
+  • Workspaces with colliding numbers are no longer skipped when moving to
+    next, prev, next_on_output, or prev_on_output workspaces

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -702,6 +702,7 @@ Con *workspace_next_on_output(void) {
     Con *current = con_get_workspace(focused);
     Con *next = NULL;
     Con *output = con_get_output(focused);
+    bool found_current = false;
 
     if (current->num == -1) {
         /* If currently a named workspace, find next named workspace. */
@@ -713,6 +714,12 @@ Con *workspace_next_on_output(void) {
                 continue;
             if (child->num == -1)
                 break;
+            if (child == current) {
+                found_current = true;
+            } else if (child->num == current->num && found_current) {
+                next = child;
+                goto workspace_next_on_output_end;
+            }
             /* Need to check child against current and next because we are
              * traversing multiple lists and thus are not guaranteed the
              * relative order between the list of workspaces. */
@@ -723,7 +730,6 @@ Con *workspace_next_on_output(void) {
 
     /* Find next named workspace. */
     if (!next) {
-        bool found_current = false;
         NODES_FOREACH (output_get_content(output)) {
             if (child->type != CT_WORKSPACE)
                 continue;
@@ -757,6 +763,7 @@ Con *workspace_prev_on_output(void) {
     Con *current = con_get_workspace(focused);
     Con *prev = NULL;
     Con *output = con_get_output(focused);
+    bool found_current = false;
     DLOG("output = %s\n", output->name);
 
     if (current->num == -1) {
@@ -769,6 +776,12 @@ Con *workspace_prev_on_output(void) {
         NODES_FOREACH_REVERSE (output_get_content(output)) {
             if (child->type != CT_WORKSPACE || child->num == -1)
                 continue;
+            if (child == current) {
+                found_current = true;
+            } else if (child->num == current->num && found_current) {
+                prev = child;
+                goto workspace_prev_on_output_end;
+            }
             /* Need to check child against current and previous because we
              * are traversing multiple lists and thus are not guaranteed
              * the relative order between the list of workspaces. */
@@ -779,7 +792,6 @@ Con *workspace_prev_on_output(void) {
 
     /* Find previous named workspace. */
     if (!prev) {
-        bool found_current = false;
         NODES_FOREACH_REVERSE (output_get_content(output)) {
             if (child->type != CT_WORKSPACE)
                 continue;

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -581,8 +581,7 @@ Con *workspace_next(void) {
                 if (child == current) {
                     found_current = true;
                 } else if (child->num == -1 && found_current) {
-                    next = child;
-                    return next;
+                    return child;
                 }
             }
         }
@@ -604,8 +603,7 @@ Con *workspace_next(void) {
                 if (child == current) {
                     found_current = true;
                 } else if (child->num == current->num && found_current) {
-                    next = child;
-                    return next;
+                    return child;
                 }
                 /* Need to check child against current and next because we are
                  * traversing multiple lists and thus are not guaranteed the
@@ -652,8 +650,7 @@ Con *workspace_prev(void) {
                     if (child == current) {
                         found_current = true;
                     } else if (child->num == -1 && found_current) {
-                        prev = child;
-                        return prev;
+                        return child;
                     }
                 }
             }
@@ -676,8 +673,7 @@ Con *workspace_prev(void) {
                 if (child == current) {
                     found_current = true;
                 } else if (child->num == current->num && found_current) {
-                    prev = child;
-                    return prev;
+                    return child;
                 }
                 /* Need to check child against current and previous because we
                  * are traversing multiple lists and thus are not guaranteed
@@ -717,8 +713,7 @@ Con *workspace_next_on_output(void) {
             if (child == current) {
                 found_current = true;
             } else if (child->num == current->num && found_current) {
-                next = child;
-                goto workspace_next_on_output_end;
+                return child;
             }
             /* Need to check child against current and next because we are
              * traversing multiple lists and thus are not guaranteed the
@@ -736,8 +731,7 @@ Con *workspace_next_on_output(void) {
             if (child == current) {
                 found_current = true;
             } else if (child->num == -1 && (current->num != -1 || found_current)) {
-                next = child;
-                goto workspace_next_on_output_end;
+                return child;
             }
         }
     }
@@ -751,7 +745,7 @@ Con *workspace_next_on_output(void) {
                 next = child;
         }
     }
-workspace_next_on_output_end:
+
     return next;
 }
 
@@ -779,8 +773,7 @@ Con *workspace_prev_on_output(void) {
             if (child == current) {
                 found_current = true;
             } else if (child->num == current->num && found_current) {
-                prev = child;
-                goto workspace_prev_on_output_end;
+                return child;
             }
             /* Need to check child against current and previous because we
              * are traversing multiple lists and thus are not guaranteed
@@ -798,8 +791,7 @@ Con *workspace_prev_on_output(void) {
             if (child == current) {
                 found_current = true;
             } else if (child->num == -1 && (current->num != -1 || found_current)) {
-                prev = child;
-                goto workspace_prev_on_output_end;
+                return child;
             }
         }
     }
@@ -814,7 +806,6 @@ Con *workspace_prev_on_output(void) {
         }
     }
 
-workspace_prev_on_output_end:
     return prev;
 }
 

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -561,12 +561,12 @@ Con *workspace_next(void) {
     Con *current = con_get_workspace(focused);
     Con *next = NULL, *first = NULL, *first_opposite = NULL;
     Con *output;
+    bool found_current = false;
 
     if (current->num == -1) {
         /* If currently a named workspace, find next named workspace. */
         if ((next = TAILQ_NEXT(current, nodes)) != NULL)
             return next;
-        bool found_current = false;
         TAILQ_FOREACH (output, &(croot->nodes_head), nodes) {
             /* Skip outputs starting with __, they are internal. */
             if (con_is_internal(output))
@@ -601,6 +601,12 @@ Con *workspace_next(void) {
                     first_opposite = child;
                 if (child->num == -1)
                     break;
+                if (child == current) {
+                    found_current = true;
+                } else if (child->num == current->num && found_current) {
+                    next = child;
+                    return next;
+                }
                 /* Need to check child against current and next because we are
                  * traversing multiple lists and thus are not guaranteed the
                  * relative order between the list of workspaces. */
@@ -624,6 +630,7 @@ Con *workspace_prev(void) {
     Con *current = con_get_workspace(focused);
     Con *prev = NULL, *first_opposite = NULL, *last = NULL;
     Con *output;
+    bool found_current = false;
 
     if (current->num == -1) {
         /* If named workspace, find previous named workspace. */
@@ -631,7 +638,6 @@ Con *workspace_prev(void) {
         if (prev && prev->num != -1)
             prev = NULL;
         if (!prev) {
-            bool found_current = false;
             TAILQ_FOREACH_REVERSE (output, &(croot->nodes_head), nodes_head, nodes) {
                 /* Skip outputs starting with __, they are internal. */
                 if (con_is_internal(output))
@@ -667,6 +673,12 @@ Con *workspace_prev(void) {
                     first_opposite = child;
                 if (child->num == -1)
                     continue;
+                if (child == current) {
+                    found_current = true;
+                } else if (child->num == current->num && found_current) {
+                    prev = child;
+                    return prev;
+                }
                 /* Need to check child against current and previous because we
                  * are traversing multiple lists and thus are not guaranteed
                  * the relative order between the list of workspaces. */

--- a/testcases/t/544-next-prev-dont-skip-number-collisions.t
+++ b/testcases/t/544-next-prev-dont-skip-number-collisions.t
@@ -1,0 +1,38 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests that switching to next/prev workspace doesn't skip those that have
+# the same number as current.
+use i3test;
+
+cmd "workspace 1";
+open_window;
+cmd "workspace 2:bar";
+open_window;
+cmd "workspace 2:foo";
+open_window;
+cmd "workspace 3";
+open_window;
+
+cmd "workspace 2:foo";
+cmd "workspace next";
+is(focused_ws, "2:bar", "move from 2:foo to next is 2:bar");
+
+cmd "workspace 2:bar";
+cmd "workspace prev";
+is(focused_ws, "2:foo", "move from 2:bar to prev is 2:foo");
+
+done_testing;

--- a/testcases/t/544-next-prev-dont-skip-number-collisions.t
+++ b/testcases/t/544-next-prev-dont-skip-number-collisions.t
@@ -16,6 +16,7 @@
 #
 # Tests that switching to next/prev workspace doesn't skip those that have
 # the same number as current.
+# See: #4452
 use i3test;
 
 cmd "workspace 1";

--- a/testcases/t/544-next-prev-dont-skip-number-collisions.t
+++ b/testcases/t/544-next-prev-dont-skip-number-collisions.t
@@ -35,4 +35,12 @@ cmd "workspace 2:bar";
 cmd "workspace prev";
 is(focused_ws, "2:foo", "move from 2:bar to prev is 2:foo");
 
+cmd "workspace 2:foo";
+cmd "workspace next_on_output";
+is(focused_ws, "2:bar", "move from 2:foo to next_on_output is 2:bar");
+
+cmd "workspace 2:bar";
+cmd "workspace prev_on_output";
+is(focused_ws, "2:foo", "move from 2:bar to prev_on_output is 2:foo");
+
 done_testing;


### PR DESCRIPTION
This fixes an issue where, having workspaces: 1, 2:foo, 2:bar, and 3,
moving from 2:foo to next moves us to workspace 3, and moving from 2:bar
to prev moves us to workspace 1.

With this change, moving from 2:foo to next would move us to 2:bar, and
from 2:bar to prev would move us to 2:foo.

Closes #4452