### PR TITLE
Implement window icon positioning configuration

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -36,7 +36,7 @@ option is enabled and only then sets a screenshot as background.
   • i3-dump-log -f now uses UNIX sockets instead of pthreads. The UNIX socket approach
     should be more reliable and also more portable.
   • Implement the include config directive
-  • Implement optionally showing window icons in titlebar
+  • Implement optionally showing window icons in titlebar and setting their position
   • Allow for_window to match against WM_CLIENT_MACHINE
   • Add %machine placeholder (WM_CLIENT_MACHINE) to title_format
   • Allow multiple output names in 'move container|workspace to output'

--- a/docs/userguide
+++ b/docs/userguide
@@ -2715,6 +2715,7 @@ specific windows or for all windows (using the <<for_window>> directive).
 -----------------------------
 title_window_icon <yes|no>
 title_window_icon padding <px>
+title_window_icon position <left|right|title>
 ------------------------------
 
 *Examples*:
@@ -2727,6 +2728,11 @@ for_window [class=".*"] title_window_icon on
 
 # enable window icons for all windows with extra horizontal padding
 for_window [class=".*"] title_window_icon padding 3px
+
+# set the window icon position for all windows to the right (this doesn't show the
+# window icon if it isn't set to be shown using either "title_window_icon on" or
+# "title_window_icon padding")
+for_window [class=".*"] title_window_icon position right
 -------------------------------------------------------------------------------------
 
 === Changing border style

--- a/include/commands.h
+++ b/include/commands.h
@@ -337,3 +337,9 @@ void cmd_debuglog(I3_CMD, const char *argument);
  *
  */
 void cmd_title_window_icon(I3_CMD, const char *enable, int padding);
+
+/**
+ * Implementation of 'title_window_icon position <left|right|title>'
+ *
+ */
+void cmd_title_window_icon_position(I3_CMD, const char *position);

--- a/include/data.h
+++ b/include/data.h
@@ -606,6 +606,15 @@ struct mark_t {
 };
 
 /**
+ * Window icon position.
+ */
+typedef enum {
+    ICON_POSITION_LEFT,
+    ICON_POSITION_RIGHT,
+    ICON_POSITION_TITLE
+} icon_position;
+
+/**
  * A 'Con' represents everything from the X11 root window down to a single X11 window.
  *
  */
@@ -664,6 +673,13 @@ struct Con {
       * means display no window icon (default behavior), 0 means display without
       * any padding, 1 means display with 1 pixel of padding and so on. */
     int window_icon_padding;
+
+    /** The position of the window icon, if enabled.
+      * ICON_POSITION_LEFT means position the icon at the left of the title bar.
+      * ICON_POSITION_RIGHT means position the icon at the right of the title bar.
+      * ICON_POSITION_TITLE means position the icon to the left of the title (exact
+      * position depends on title alignment). */
+    icon_position window_icon_position;
 
     /* a sticky-group is an identifier which bundles several containers to a
      * group. The contents are shared between all of them, that is they are

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -466,16 +466,28 @@ state TITLE_FORMAT:
 state TITLE_WINDOW_ICON:
   'padding'
     -> TITLE_WINDOW_ICON_PADDING
+  'position'
+    -> TITLE_WINDOW_ICON_POSITION
   enable = '1', 'yes', 'true', 'on', 'enable', 'active', '0', 'no', 'false', 'off', 'disable', 'inactive'
     -> call cmd_title_window_icon($enable, 0)
 
 state TITLE_WINDOW_ICON_PADDING:
-  end
-    -> call cmd_title_window_icon($enable, &padding)
+  padding = number
+    -> TITLE_WINDOW_ICON_PADDING_SUFFIX
+
+state TITLE_WINDOW_ICON_PADDING_SUFFIX:
   'px'
     -> call cmd_title_window_icon($enable, &padding)
-  padding = number
-    ->
+  end
+    -> call cmd_title_window_icon($enable, &padding)
+
+state TITLE_WINDOW_ICON_POSITION:
+  position_value = 'left', 'right', 'title'
+    -> TITLE_WINDOW_ICON_POSITION_END
+
+state TITLE_WINDOW_ICON_POSITION_END:
+  end
+    -> call cmd_title_window_icon_position($position_value)
 
 # bar (hidden_state hide|show|toggle)|(mode dock|hide|invisible|toggle) [<bar_id>]
 state BAR:

--- a/src/con.c
+++ b/src/con.c
@@ -44,6 +44,7 @@ Con *con_new_skeleton(Con *parent, i3Window *window) {
     new->border_style = config.default_border;
     new->current_border_width = -1;
     new->window_icon_padding = -1;
+    new->window_icon_position = ICON_POSITION_TITLE;
     if (window) {
         new->depth = window->depth;
     } else {

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -501,6 +501,20 @@ void dump_node(yajl_gen gen, struct Con *con, bool inplace_restart) {
     ystr("window_icon_padding");
     y(integer, con->window_icon_padding);
 
+    ystr("window_icon_position");
+    switch (con->window_icon_position) {
+        case ICON_POSITION_LEFT:
+            ystr("left");
+            break;
+        case ICON_POSITION_RIGHT:
+            ystr("right");
+            break;
+        case ICON_POSITION_TITLE:
+        default:
+            ystr("title");
+            break;
+    }
+
     if (con->type == CT_WORKSPACE) {
         ystr("num");
         y(integer, con->num);

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -435,6 +435,14 @@ static int json_string(void *ctx, const unsigned char *val, size_t len) {
         } else if (strcasecmp(last_key, "previous_workspace_name") == 0) {
             FREE(previous_workspace_name);
             previous_workspace_name = sstrndup((const char *)val, len);
+        } else if (strcasecmp(last_key, "window_icon_position") == 0) {
+            if (strcasecmp((const char *)val, "left") == 0) {
+                json_node->window_icon_position = ICON_POSITION_LEFT;
+            } else if (strcasecmp((const char *)val, "right") == 0) {
+                json_node->window_icon_position = ICON_POSITION_RIGHT;
+            } else if (strcasecmp((const char *)val, "title") == 0) {
+                json_node->window_icon_position = ICON_POSITION_TITLE;
+            }
         }
     }
     return 1;

--- a/testcases/t/116-nestedcons.t
+++ b/testcases/t/116-nestedcons.t
@@ -74,6 +74,7 @@ my $expected = {
     current_border_width => -1,
     marks => $ignore,
     window_icon_padding => -1,
+    window_icon_position => 'title',
 };
 
 # a shallow copy is sufficient, since we only ignore values at the root

--- a/testcases/t/314-window-icon-padding.t
+++ b/testcases/t/314-window-icon-padding.t
@@ -24,6 +24,13 @@ sub window_icon_padding {
     return $nodes->[0]->{'window_icon_padding'};
 }
 
+sub window_icon_position {
+    my ($ws) = @_;
+    my ($nodes, $focus) = get_ws_content($ws);
+    ok(@{$nodes} == 1, 'precisely one container on workspace');
+    return $nodes->[0]->{'window_icon_position'};
+}
+
 my $config = <<"EOT";
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
@@ -34,9 +41,17 @@ my $tmp = fresh_workspace;
 
 cmd 'open';
 is(window_icon_padding($tmp), -1, 'window_icon_padding defaults to -1');
+is(window_icon_position($tmp), 'title', 'window_icon_position defaults to title');
 
 cmd 'title_window_icon on';
 isnt(window_icon_padding($tmp), -1, 'window_icon_padding no longer -1');
+is(window_icon_position($tmp), 'title', 'window_icon_position defaults to title');
+
+cmd 'title_window_icon position left';
+is(window_icon_position($tmp), 'left', 'window_icon_position is now left');
+
+cmd 'title_window_icon position right';
+is(window_icon_position($tmp), 'right', 'window_icon_position is now right');
 
 exit_gracefully($pid);
 
@@ -49,6 +64,7 @@ $config = <<"EOT";
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 for_window [class=".*"] title_window_icon padding 3px
+for_window [class=".*"] title_window_icon position right
 EOT
 $pid = launch_with_config($config);
 
@@ -56,6 +72,7 @@ $tmp = fresh_workspace;
 
 open_window;
 is(window_icon_padding($tmp), 3, 'window_icon_padding set to 3');
+is(window_icon_position($tmp), 'right', 'window_icon_position set to right');
 
 exit_gracefully($pid);
 


### PR DESCRIPTION
Enhance the work that landed in #4439 by allowing customisation of the icon position.

This feature defaults to following the title alignment, and can be tuned for individual windows to be on the left (which is the behaviour prior to this commit) or on the right.