### PR TITLE
handlers.c: send an "output" event on monitor configuration change

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -62,3 +62,4 @@ option is enabled and only then sets a screenshot as background.
   • ipc: return proper signed int for container positions: negative values were
     returned as large 32 bits integers
   • fix crash with "layout default"
+  • send an "output" event on XRandR 1.5 monitor configuration change

--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -3,7 +3,7 @@
  │ Release notes for i3 v4.20   │
  └──────────────────────────────┘
 
-This is i3 v4.19. This version is considered stable. All users of i3 are
+This is i3 v4.20. This version is considered stable. All users of i3 are
 strongly encouraged to upgrade.
 
 Background/wallpaper workaround:

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -1074,6 +1074,8 @@ static void handle_configure_notify(xcb_configure_notify_event_t *event) {
         return;
     }
     randr_query_outputs();
+
+    ipc_send_event("output", I3_IPC_EVENT_OUTPUT, "{\"change\":\"unspecified\"}");
 }
 
 /*


### PR DESCRIPTION
When adding/removing a monitor, the outputs are likely to be modified.
Send an IPC event "output", like when there is a screen configuration
change.

Signed-off-by: Vincent Bernat <vincent@bernat.ch>