### PR TITLE
"Contact us" turned into a link to /contact/

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -4,7 +4,7 @@ Michael Stapelberg <michael@i3wm.org>
 
 This document contains all the information you need to configure and use the i3
 window manager. If it does not, please check https://www.reddit.com/r/i3wm/
-first, then contact us on IRC (preferred) or post your question(s) on the
+first, then https://i3wm.org/contact/[contact us] on IRC (preferred) or post your question(s) on the
 mailing list.
 
 == Default keybindings


### PR DESCRIPTION
Linking to both IRC and mailing list separately seems a bit much to me