### PR TITLE
Fix bug where long commands crash i3

### DIFF
--- a/generate-command-parser.pl
+++ b/generate-command-parser.pl
@@ -228,8 +228,15 @@ for my $state (@keys) {
             ($call_identifier) = ($next_state =~ /^call ([0-9]+)$/);
             $next_state = '__CALL';
         }
-        my $identifier = $token->{identifier};
-        say $tokfh qq|    { "$token_name", "$identifier", $next_state, { $call_identifier } },|;
+        my $identifier;
+        # Set $identifier to NULL if there is no identifier
+        if ($token->{identifier} eq ""){
+            $identifier = "NULL"
+        }
+        else{
+            $identifier = qq|"$token->{identifier}"|;
+        }
+        say $tokfh qq|    { "$token_name", $identifier, $next_state, { $call_identifier } },|;
     }
     say $tokfh '};';
 }

--- a/testcases/t/315-long-commands.t
+++ b/testcases/t/315-long-commands.t
@@ -1,0 +1,46 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Test that commands with more than 10 non-identified words doesn't works
+# 10 is the magic number chosen for the stack size which is why it's used here
+# Ticket: #2968
+# Bug still in: 4.19.2-103-gfc65ca36
+use i3test;
+
+######################################################################
+# 1) run a long command
+######################################################################
+
+my $i3 = i3(get_socket_path());
+my $tmp = fresh_workspace;
+
+my $floatwin = open_floating_window;
+
+
+my ($absolute_before, $top_before) = $floatwin->rect;
+
+cmd 'move window container to window container to window container to left';
+
+sync_with_i3;
+
+my ($absolute, $top) = $floatwin->rect;
+
+is($absolute->x, ($absolute_before->x - 10), 'moved 10 px to the left');
+is($absolute->y, $absolute_before->y, 'y not changed');
+is($absolute->width, $absolute_before->width, 'width not changed');
+is($absolute->height, $absolute_before->height, 'height not changed');
+
+done_testing;


### PR DESCRIPTION
Commands with more than 10 words would result in i3 crashing. The root cause is that the stack which holds arguments with identifiers is only 10 big, but `generate-command-parser.pl` was giving every word an identifier of "" (empty string). This behavior could have been correct, but everywhere this value was referenced compares it to `NULL` instead of empty string. [Here](https://github.com/i3/i3/blob/36ba1043d50d815b65b7f22619611a420726e8e3/src/commands_parser.c#L281) for example.

It could be argued that the command `move window container to window container to window container to left` is invalid and therefore shouldn't be tested for. If so, I can remove the testcase. But crashing on that kind of input should be fixed in any case.

Also, this bug could be fixed in the opposite way, where we change all of the checks against `NULL` to check against `'\0'`. This way was simpler and seemed like what the desired behavior was all along to me.

Another interesting component to this bug is that it doesn't effect the config parser, only the command parser. That's because identifiers in `config_parser.c` are handled a little differently. When we push an identified string on the stack it appends the values together [if they have the same identifier](https://github.com/i3/i3/blob/36ba1043d50d815b65b7f22619611a420726e8e3/src/config_parser.c#L90) which causes all of the words with empty string as an identifier to take up only one spot on the stack.

Fixes #2968