### PR TITLE
Lower severity of missing include path specified from error to info.

### DIFF
--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -29,8 +29,7 @@ CFGFUN(include, const char *pattern) {
     for (size_t i = 0; i < p.we_wordc; i++) {
         char resolved_path[PATH_MAX] = {'\0'};
         if (realpath(w[i], resolved_path) == NULL) {
-            ELOG("realpath(%s): %s\n", w[i], strerror(errno));
-            result->has_errors = true;
+            LOG("Skipping %s: %s\n", w[i], strerror(errno));
             continue;
         }
 


### PR DESCRIPTION
Addresses:  https://github.com/i3/i3/issues/4494

NOTE: As a very minor change to an unreleased feature I did not think it needs docs, but am happy to add something if that's desired.

## Testing Done

1. Build and copy binary to system exhibiting error due to missing config directory.  
2. Log back into session
3. Observe no nagbar error message nor syslog entry relating to invalid directory

