### PR TITLE
GH actions: Archive complete logs on test failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,12 @@ jobs:
     - name: run i3 tests
       run: |
         docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 -e CC ${{ env.BASENAME }} ./travis/run-tests.sh
+    - name: Archive test logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-logs
+        path: build/testsuite-*
+      if: ${{ failure() }}
     - name: build dist tarball
       run: |
         docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 -e CC ${{ env.BASENAME }} /bin/sh -c 'rm -rf distbuild; mkdir distbuild && cd distbuild && meson .. -Ddocs=true -Dmans=true && ninja -v dist'


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration#artifact-and-log-retention-policy

> By default, the artifacts and log files generated by workflows are retained for 90 days before they are automatically deleted.