### PR TITLE
Behaviour of workspaces that have both a number and a name

### DIFF
--- a/release-notes/bugfixes/3-numbered-workspace-order
+++ b/release-notes/bugfixes/3-numbered-workspace-order
@@ -1,0 +1,1 @@
+make order of numbered workspace consistent with non-numbered

--- a/src/con.c
+++ b/src/con.c
@@ -116,14 +116,14 @@ static void _con_attach(Con *con, Con *parent, Con *previous, bool ignore_focus)
                 /* we need to insert the container at the beginning */
                 TAILQ_INSERT_HEAD(nodes_head, con, nodes);
             } else {
-                while (current->num != -1 && con->num > current->num) {
+                while (current->num != -1 && con->num >= current->num) {
                     current = TAILQ_NEXT(current, nodes);
                     if (current == TAILQ_END(nodes_head)) {
                         current = NULL;
                         break;
                     }
                 }
-                /* we need to insert con after current, if current is not NULL */
+                /* we need to insert con before current, if current is not NULL */
                 if (current) {
                     TAILQ_INSERT_BEFORE(current, con, nodes);
                 } else {

--- a/testcases/t/503-workspace.t
+++ b/testcases/t/503-workspace.t
@@ -54,16 +54,12 @@ cmd 'workspace 5';
 # ensure workspace 5 stays open
 open_window;
 
-# numbered w/ name workspaces must be created in reverse order compared to
-# other workspace types (because a new numbered w/ name workspace is prepended
-# to the list of similarly numbered workspaces).
-
-cmd 'workspace 6:b';
-# ensure workspace 5 stays open
+cmd 'workspace 6:a';
+# ensure workspace 6:a stays open
 open_window;
 
-cmd 'workspace 6:a';
-# ensure workspace 5 stays open
+cmd 'workspace 6:b';
+# ensure workspace 6:b stays open
 open_window;
 
 ################################################################################
@@ -101,7 +97,7 @@ cmd 'workspace next';
 # later in time and mess up our subsequent tests.
 sync_with_i3;
 
-is(focused_ws, '6:b', 'workspace 6:b focused');
+is(focused_ws, '6:b', 'workspace 6:a focused');
 cmd 'workspace next';
 # We need to sync after changing focus to a different output to wait for the
 # EnterNotify to be processed, otherwise it will be processed at some point
@@ -144,60 +140,5 @@ is(focused_ws, '6:c', 'workspace 6:c focused');
 
 cmd 'workspace prev_on_output';
 is(focused_ws, '2', 'workspace 2 focused');
-
-################################################################################
-# Setup a few more workspaces that have identical numbers (but different names).
-################################################################################
-
-# The current order should still be:
-# output 1: 1, 5
-# output 2: 2
-
-
-cmd 'workspace 1';
-# We need to sync after changing focus to a different output to wait for the
-# EnterNotify to be processed, otherwise it will be processed at some point
-# later in time and mess up our subsequent tests.
-sync_with_i3;
-
-cmd 'workspace 2:a';
-# ensure workspace 2:a stays open
-open_window;
-cmd 'workspace 6:a';
-# ensure workspace 6:a stays open
-open_window;
-cmd 'workspace 6:b';
-# ensure workspace 6:b stays open
-open_window;
-cmd 'workspace 7';
-# ensure workspace 7 stays open
-open_window;
-
-cmd 'workspace 2';
-# We need to sync after changing focus to a different output to wait for the
-# EnterNotify to be processed, otherwise it will be processed at some point
-# later in time and mess up our subsequent tests.
-sync_with_i3;
-
-cmd 'workspace 2:b';
-# ensure workspace 2:b stays open
-open_window;
-
-# The current order should now be:
-# output 1: 1, 2:a, 5, 6:a, 6:b, 7
-# output 2: 2, 2:b
-
-################################################################################
-# Move to next workspaces to the right of existing ones with the same number.
-################################################################################
-
-cmd 'workspace 5';
-# We need to sync after changing focus to a different output to wait for the
-# EnterNotify to be processed, otherwise it will be processed at some point
-# later in time and mess up our subsequent tests.
-sync_with_i3;
-
-cmd 'workspace next';
-is(focused_ws, '6:a', 'workspace 6:a focused');
 
 done_testing;

--- a/testcases/t/503-workspace.t
+++ b/testcases/t/503-workspace.t
@@ -145,4 +145,59 @@ is(focused_ws, '6:c', 'workspace 6:c focused');
 cmd 'workspace prev_on_output';
 is(focused_ws, '2', 'workspace 2 focused');
 
+################################################################################
+# Setup a few more workspaces that have identical numbers (but different names).
+################################################################################
+
+# The current order should still be:
+# output 1: 1, 5
+# output 2: 2
+
+
+cmd 'workspace 1';
+# We need to sync after changing focus to a different output to wait for the
+# EnterNotify to be processed, otherwise it will be processed at some point
+# later in time and mess up our subsequent tests.
+sync_with_i3;
+
+cmd 'workspace 2:a';
+# ensure workspace 2:a stays open
+open_window;
+cmd 'workspace 6:a';
+# ensure workspace 6:a stays open
+open_window;
+cmd 'workspace 6:b';
+# ensure workspace 6:b stays open
+open_window;
+cmd 'workspace 7';
+# ensure workspace 7 stays open
+open_window;
+
+cmd 'workspace 2';
+# We need to sync after changing focus to a different output to wait for the
+# EnterNotify to be processed, otherwise it will be processed at some point
+# later in time and mess up our subsequent tests.
+sync_with_i3;
+
+cmd 'workspace 2:b';
+# ensure workspace 2:b stays open
+open_window;
+
+# The current order should now be:
+# output 1: 1, 2:a, 5, 6:a, 6:b, 7
+# output 2: 2, 2:b
+
+################################################################################
+# Move to next workspaces to the right of existing ones with the same number.
+################################################################################
+
+cmd 'workspace 5';
+# We need to sync after changing focus to a different output to wait for the
+# EnterNotify to be processed, otherwise it will be processed at some point
+# later in time and mess up our subsequent tests.
+sync_with_i3;
+
+cmd 'workspace next';
+is(focused_ws, '6:a', 'workspace 6:a focused');
+
 done_testing;

--- a/testcases/t/528-workspace-next-prev-reversed.t
+++ b/testcases/t/528-workspace-next-prev-reversed.t
@@ -68,11 +68,8 @@ cmd 'workspace D'; open_window;
 cmd 'workspace 4'; open_window;
 cmd 'workspace 5'; open_window;
 cmd 'workspace E'; open_window;
-# numbered w/ name workspaces must be created in reverse order compared to
-# other workspace types (because a new numbered w/ name workspace is prepended
-# to the list of similarly numbered workspaces).
-cmd 'workspace 8:e'; open_window;
 cmd 'workspace 8:d'; open_window;
+cmd 'workspace 8:e'; open_window;
 
 cmd 'focus output right';
 cmd 'workspace 1'; open_window;
@@ -83,19 +80,15 @@ cmd 'workspace F'; open_window;
 cmd 'workspace 6'; open_window;
 cmd 'workspace C'; open_window;
 cmd 'workspace 7'; open_window;
-# numbered w/ name workspaces must be created in reverse order compared to
-# other workspace types (because a new numbered w/ name workspace is prepended
-# to the list of similarly numbered workspaces).
-cmd 'workspace 8:c'; open_window;
-cmd 'workspace 8:b'; open_window;
 cmd 'workspace 8:a'; open_window;
+cmd 'workspace 8:b'; open_window;
+cmd 'workspace 8:c'; open_window;
 
 ################################################################################
 # Use workspace next and verify the correct order.
 # numbered -> numerical sort
 # numbered w/ names -> numerical sort. Workspaces with the same number but
-#     different names sort by output, followed by reverse creation time on each
-#     output.
+#     different names sort by output, followed by creation time on each output.
 # named -> sort by creation time
 ################################################################################
 cmd 'workspace 1';

--- a/testcases/t/535-workspace-next-prev.t
+++ b/testcases/t/535-workspace-next-prev.t
@@ -68,11 +68,8 @@ cmd 'workspace D'; open_window;
 cmd 'workspace 4'; open_window;
 cmd 'workspace 5'; open_window;
 cmd 'workspace E'; open_window;
-# numbered w/ name workspaces must be created in reverse order compared to
-# other workspace types (because a new numbered w/ name workspace is prepended
-# to the list of similarly numbered workspaces).
-cmd 'workspace 8:e'; open_window;
 cmd 'workspace 8:d'; open_window;
+cmd 'workspace 8:e'; open_window;
 
 cmd 'focus output left';
 cmd 'workspace 1'; open_window;
@@ -83,19 +80,15 @@ cmd 'workspace F'; open_window;
 cmd 'workspace 6'; open_window;
 cmd 'workspace C'; open_window;
 cmd 'workspace 7'; open_window;
-# numbered w/ name workspaces must be created in reverse order compared to
-# other workspace types (because a new numbered w/ name workspace is prepended
-# to the list of similarly numbered workspaces).
-cmd 'workspace 8:c'; open_window;
-cmd 'workspace 8:b'; open_window;
 cmd 'workspace 8:a'; open_window;
+cmd 'workspace 8:b'; open_window;
+cmd 'workspace 8:c'; open_window;
 
 ################################################################################
 # Use workspace next and verify the correct order.
 # numbered -> numerical sort
 # numbered w/ names -> numerical sort. Workspaces with the same number but
-#     different names sort by output, followed by reverse creation time on each
-#     output.
+#     different names sort by output, followed by creation time on each output.
 # named -> sort by creation time
 ################################################################################
 cmd 'workspace 1';


### PR DESCRIPTION
This PR adjusts the behaviour of workspaces with both a number and a name in two ways:

* Create new workspaces to the right of existing ones with the same number
  i.e. creating workspaces named "1", "2:a", "2:b", "3" should result in
  that same order rather than "1", "2:b", "2:a", "3".
* Don't skip identically numbered workspaces when moving to next/prev
  eg if you have workspaces: { 1, 2:a, 2:b, 3 } and are on workspace 1,
  then 'workspace next' should traverse 1 -> 2:a -> 2:b -> 3 -> 1 instead
  of 1 -> 2:a -> 3 -> 1.

Fixes #4563 