### PR TITLE
i3-dmenu-desktop: ignore duplicate files and directories

### DIFF
--- a/RELEASE-NOTES-next
+++ b/RELEASE-NOTES-next
@@ -35,6 +35,7 @@ option is enabled and only then sets a screenshot as background.
   • i3-nagbar: add option to position on primary monitor
   • alternate focusing tab/stack children-parent containers by clicking on their titlebars
   • i3bar: use first bar config by default
+  • i3-dmenu-desktop: ignore duplicate files and directories (fixes crash on NixOS)
   • i3-dump-log -f now uses UNIX sockets instead of pthreads. The UNIX socket approach
     should be more reliable and also more portable.
   • Implement the include config directive

--- a/i3-dmenu-desktop
+++ b/i3-dmenu-desktop
@@ -154,6 +154,8 @@ find(
         },
         no_chdir => 1,
         follow_fast => 1,
+        # Ignore any duplicate files and directories and proceed normally:
+        follow_skip => 2,
     },
     @searchdirs
 );


### PR DESCRIPTION
This is required when e.g. mpv is installed in the NixOS global system
environment *and* in the user environment.

Standalone reproducer:
```
mkdir -p test1/share/applications test2/share
ln -svf /usr/share/applications/i3.desktop test1/share/applications
ln -svf $PWD/test1/share/applications test2/share
export XDG_DATA_DIRS='test1/share:test2/share'
i3-dmenu-desktop
```
fixes #4522