### PR TITLE
fix travis/check-spelling.pl for updated API

### DIFF
--- a/travis/check-spelling.pl
+++ b/travis/check-spelling.pl
@@ -11,6 +11,7 @@ use warnings;
 use v5.10;
 use autodie;
 use lib 'testcases/lib';
+use lib '/usr/share/lintian/lib';
 use i3test::Util qw(slurp);
 use Lintian::Spelling qw(check_spelling);
 
@@ -20,8 +21,6 @@ use Lintian::Profile;
 
 my $profile = Lintian::Profile->new;
 $profile->load('debian', ['/usr/share/lintian']);
-
-Lintian::Data->set_vendor($profile);
 
 my $exitcode = 0;
 
@@ -42,7 +41,7 @@ my @binaries = qw(
     build/i3bar
 );
 for my $binary (@binaries) {
-    check_spelling(slurp($binary), $binary_spelling_exceptions, sub {
+    check_spelling($profile, slurp($binary), $binary_spelling_exceptions, sub {
         my ($current, $fixed) = @_;
         say STDERR qq|Binary "$binary" contains a spelling error: "$current" should be "$fixed"|;
         $exitcode = 1;
@@ -57,7 +56,7 @@ my $manpage_spelling_exceptions = {
 for my $name (glob('build/man/*.1')) {
     for my $line (split(/\n/, slurp($name))) {
         next if $line =~ /^\.\\\"/o;
-        check_spelling($line, $manpage_spelling_exceptions, sub {
+        check_spelling($profile, $line, $manpage_spelling_exceptions, sub {
             my ($current, $fixed) = @_;
             say STDERR qq|Manpage "$name" contains a spelling error: "$current" should be "$fixed"|;
             $exitcode = 1;


### PR DESCRIPTION
I noticed that there is a `spellintian` program, too, that we could ideally just call.

However, that program does not work well with i3 binary files right now:

```
$ spellintian build/i3         
spellintian: can't decode ill-formed UTF-8 octet sequence <F8> in position 40 at /usr/share/perl5/Path/Tiny.pm line 1809.
```

I’ll file a bug about that and then maybe we can do away with check-spelling.pl in favor of calling `spellintian`