### PR TITLE
Keep each release note in a single file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,11 +41,14 @@ Note that bug reports and feature requests for related projects should be filed 
 * Use `clang-format` to format your code.
 * Run the [testsuite](https://i3wm.org/docs/testsuite.html)
 * If your changes should be reported on the next release's changelog, also
-  update the [RELEASE-notes-next](../RELEASE-notes-next) file in the root
-  folder. Example of changes that should be reported are bug fixes present in
-  the latest stable version of i3 and new enhancements. Example of changes that
-  should not be reported are minor code improvements, documentation, regression
-  and fixes for bugs that were introduced in the `next` branch.
+  add a small single-line file starting with a number (see examples) containing
+  a short explanation of your change either in the
+  [changes](../release-notes/changes) or the
+  [bugfixes](../release-notes/bugfixes/) folder. Example of changes that should
+  be reported are bug fixes present in the latest stable version of i3 and new
+  enhancements. Example of changes that should not be reported are minor code
+  improvements, documentation, regression and fixes for bugs that were
+  introduced in the `next` branch.
 
 ## Finding something to do
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: git fetch --prune --unshallow
+    - name: check & print release notes
+      run: ./release-notes/generator.pl
     - name: construct container name
       run: |
         echo "BASENAME=i3wm/travis-base:$(date +'%Y-%m')-$(./travis/ha.sh travis/travis-base.Dockerfile)" >> $GITHUB_ENV

--- a/release-notes/bugfixes/0-example
+++ b/release-notes/bugfixes/0-example
@@ -1,0 +1,1 @@
+fix crash with "layout default"

--- a/release-notes/bugfixes/1-replace-socket
+++ b/release-notes/bugfixes/1-replace-socket
@@ -1,0 +1,1 @@
+Do not replace existing IPC socket on start

--- a/release-notes/changes/0-example
+++ b/release-notes/changes/0-example
@@ -1,0 +1,1 @@
+Acquire the WM_Sn selection when starting as required by ICCCM

--- a/release-notes/changes/1-valid-socket
+++ b/release-notes/changes/1-valid-socket
@@ -1,0 +1,1 @@
+Refuse to start without valid IPC socket

--- a/release-notes/generator.pl
+++ b/release-notes/generator.pl
@@ -1,0 +1,89 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use v5.10;
+use Getopt::Long;
+
+my @template = (
+'
+ ┌──────────────────────────────┐
+ │ Release notes for i3 v4.21   │
+ └──────────────────────────────┘
+
+This is i3 v4.21. This version is considered stable. All users of i3 are
+strongly encouraged to upgrade.
+
+
+ ┌────────────────────────────┐
+ │ Changes in i3 v4.21        │
+ └────────────────────────────┘
+
+',
+'
+ ┌────────────────────────────┐
+ │ Bugfixes                   │
+ └────────────────────────────┘
+
+');
+
+my $print_urls = 0;
+my $result = GetOptions('print-urls' => \$print_urls);
+
+sub read_changefiles {
+    my $dirpath = shift;
+    opendir my $dir, $dirpath or die "Cannot open directory $dirpath: $!";
+    my @files = readdir $dir;
+    closedir $dir;
+
+    my $s = '';
+    for my $filename (@files) {
+        next if $filename eq '.';
+        next if $filename eq '..';
+        next if $filename eq '0-example';
+
+        die "Filename $filename should start with a number (e.g. the pull request number)" unless ($filename =~ /^\d+/);
+
+        $filename = $dirpath . '/' . $filename;
+        open my $in, '<', $filename or die "can't open $filename: $!";
+        my @lines = <$in>;
+        close $in or die "can't close $filename: $!";
+
+        my $content = trim(join("\n  ", map { trim($_) } @lines));
+        die "$filename can't be empty" unless length($content) > 0;
+
+        my $commit = `git log --diff-filter=A --pretty=format:"%H" $filename`;
+        $commit = trim($commit) if defined($commit);
+        die "$filename: git log failed to find commit" if ($?) || (length($commit) == 0);
+
+        my $url = '';
+        if ($print_urls) {
+            my $pr = find_pr($commit);
+            my $url = 'https://github.com/i3/i3/commit/' . $commit;
+            $url = 'https://github.com/i3/i3/pull/' . $pr if defined($pr);
+            $url = $url . "\n";
+        }
+
+        $s = $s . '  • ' . $content . "\n" . $url;
+    }
+    return $s;
+}
+
+sub find_pr {
+    my $hash = shift;
+    my $result = `git log --merges --ancestry-path --oneline $hash..next | grep 'Merge pull request' | tail -n1`;
+    return unless defined($result);
+
+    return unless ($result =~ /Merge pull request .([0-9]+)/);
+    return $1;
+}
+
+sub trim {
+    (my $s = $_[0]) =~ s/^\s+|\s+$//g;
+    return $s;
+}
+
+# Expected to run for i3's git root
+my $changes = read_changefiles('release-notes/changes');
+my $bugfixes = read_changefiles('release-notes/bugfixes');
+
+print $template[0] . $changes . $template[1] . $bugfixes;

--- a/release.sh
+++ b/release.sh
@@ -22,7 +22,8 @@ fi
 
 if [ ! -e "RELEASE-NOTES-${RELEASE_VERSION}" ]
 then
-	echo "RELEASE-NOTES-${RELEASE_VERSION} not found."
+	echo "RELEASE-NOTES-${RELEASE_VERSION} not found. Here is the output from the generator:"
+	./release-notes/generator.pl --print-urls
 	exit 1
 fi
 


### PR DESCRIPTION
To avoid annoying merge conflicts.

~python~ perl script is provided for convenience and simple format checking in
PRs.