### PR TITLE
Extend title length for xmlto

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -229,6 +229,8 @@ if get_option('mans')
       output: '@BASENAME@.1',
       command: [
         xmlto,
+        '--stringparam',
+        'man.th.title.max.length=30',
         'man',
         '-o',
         '@OUTDIR@',


### PR DESCRIPTION
`man.th.title.max.length` defaults to 20 which leads to a broken `.TH` line
for `i3-migrate-config-to-v4.1`:

```
.TH "I3\-MIGRATE\-CONFIG\" "1" "02/01/2021" "i3 4\&.19\&.1" "i3 Manual"
```