### PR TITLE
Correct short form of raw option in i3-msg manpage

### DIFF
--- a/man/i3-msg.man
+++ b/man/i3-msg.man
@@ -36,7 +36,7 @@ Instead of exiting right after receiving the first subscribed event,
 wait indefinitely for all of them. Can only be used with "-t subscribe".
 See the "subscribe" IPC message type below for details.
 
-*-q, --raw*::
+*-r, --raw*::
 Display the raw JSON reply instead of pretty-printing errors (for commands) or
 displaying the top-level config file contents (for GET_CONFIG).
 


### PR DESCRIPTION
It looks like the recently-added `raw` option to i3-msg has a typo in the manpage :)

Apologies for the tiny PR - noticed this one while checking something else out and thought it was quicker to raise a PR than to raise an issue and make someone else fix it....