### PR TITLE
portability: add missing headers

### DIFF
--- a/include/libi3.h
+++ b/include/libi3.h
@@ -15,6 +15,7 @@
 #include <stdbool.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <sys/stat.h>
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
 #include <xcb/xcb_keysyms.h>


### PR DESCRIPTION
libi3.h defins a macros with the default modes to create a directory.
Those modes are defined in sys/stat.h, so include the necessary header