### PR TITLE
Refuse to start without IPC socket

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -683,6 +683,11 @@ int main(int argc, char *argv[]) {
         else
             config.ipc_socket_path = sstrdup(config.ipc_socket_path);
     }
+    /* Create the UNIX domain socket for IPC */
+    int ipc_socket = create_socket(config.ipc_socket_path, &current_socketpath);
+    if (ipc_socket == -1) {
+        die("Could not create the IPC socket: %s", config.ipc_socket_path);
+    }
 
     if (config.force_xinerama) {
         force_xinerama = true;
@@ -988,15 +993,10 @@ int main(int argc, char *argv[]) {
 
     tree_render();
 
-    /* Create the UNIX domain socket for IPC */
-    int ipc_socket = create_socket(config.ipc_socket_path, &current_socketpath);
-    if (ipc_socket == -1) {
-        ELOG("Could not create the IPC socket, IPC disabled\n");
-    } else {
-        struct ev_io *ipc_io = scalloc(1, sizeof(struct ev_io));
-        ev_io_init(ipc_io, ipc_new_client, ipc_socket, EV_READ);
-        ev_io_start(main_loop, ipc_io);
-    }
+    /* Listen to the IPC socket for clients */
+    struct ev_io *ipc_io = scalloc(1, sizeof(struct ev_io));
+    ev_io_init(ipc_io, ipc_new_client, ipc_socket, EV_READ);
+    ev_io_start(main_loop, ipc_io);
 
     /* Chose a file name in /tmp/ based on the PID */
     char *log_stream_socket_path = get_process_filename("log-stream-socket");


### PR DESCRIPTION
This change was (basically) suggested by @orestisfl in
https://github.com/i3/i3/pull/4638#issuecomment-958093518

Testing done:
```
$ I3SOCK=/dev/null DISPLAY=:2 LC_ALL=C build/i3
bind(): Address already in use
i3: Could not create the IPC socket: Address already in use
```
Signed-off-by: Uli Schlachter <psychon@znc.in>

----

Do you want me to also get rid of the `else` branch? The way the code is now, `ipc_io` has a smaller scope, which I like, so I'd at most replace it with `{ }` (so just dropping the `else`).