### PR TITLE
Remove outdated //-style commented-out code

### DIFF
--- a/i3-config-wizard/main.c
+++ b/i3-config-wizard/main.c
@@ -332,8 +332,6 @@ static char *rewrite_binding(const char *input) {
         while ((*walk == ' ' || *walk == '\t') && *walk != '\0')
             walk++;
 
-        //printf("remaining input: %s\n", walk);
-
         cmdp_token_ptr *ptr = &(tokens[state]);
         for (c = 0; c < ptr->n; c++) {
             token = &(ptr->array[c]);
@@ -426,15 +424,13 @@ static char *rewrite_binding(const char *input) {
             }
 
             if (strcmp(token->name, "end") == 0) {
-                //printf("checking for end: *%s*\n", walk);
                 if (*walk == '\0' || *walk == '\n' || *walk == '\r') {
                     if ((result = next_state(token)) != NULL)
                         return result;
-                    /* To make sure we start with an appropriate matching
-                     * datastructure for commands which do *not* specify any
+                    /* To make sure we start with an appropriate matching data
+                     * structure for commands which do *not* specify any
                      * criteria, we re-initialize the criteria system after
                      * every command. */
-                    // TODO: make this testable
                     walk++;
                     break;
                 }

--- a/include/config_parser.h
+++ b/include/config_parser.h
@@ -41,18 +41,18 @@ struct parser_ctx {
     Match current_match;
 
     /* A list which contains the states that lead to the current state, e.g.
-   * INITIAL, WORKSPACE_LAYOUT.
-   * When jumping back to INITIAL, statelist_idx will simply be set to 1
-   * (likewise for other states, e.g. MODE or BAR).
-   * This list is used to process the nearest error token. */
+     * INITIAL, WORKSPACE_LAYOUT.
+     * When jumping back to INITIAL, statelist_idx will simply be set to 1
+     * (likewise for other states, e.g. MODE or BAR).
+     * This list is used to process the nearest error token. */
     int statelist[10];
     /* NB: statelist_idx points to where the next entry will be inserted */
     int statelist_idx;
 
     /*******************************************************************************
-   * The (small) stack where identified literals are stored during the parsing
-   * of a single config directive (like $workspace).
-   ******************************************************************************/
+     * The (small) stack where identified literals are stored during the parsing
+     * of a single config directive (like $workspace).
+     ******************************************************************************/
     struct stack *stack;
 
     struct variables_head variables;

--- a/include/data.h
+++ b/include/data.h
@@ -663,8 +663,8 @@ struct Con {
     char *title_format;
 
     /** Whether the window icon should be displayed, and with what padding. -1
-      * means display no window icon (default behavior), 0 means display without
-      * any padding, 1 means display with 1 pixel of padding and so on. */
+     * means display no window icon (default behavior), 0 means display without
+     * any padding, 1 means display with 1 pixel of padding and so on. */
     int window_icon_padding;
 
     /* a sticky-group is an identifier which bundles several containers to a

--- a/include/randr.h
+++ b/include/randr.h
@@ -51,12 +51,6 @@ void output_init_con(Output *output);
 void init_ws_for_output(Output *output);
 
 /**
- * Initializes the specified output, assigning the specified workspace to it.
- *
- */
-//void initialize_output(xcb_connection_t *conn, Output *output, Workspace *workspace);
-
-/**
  * (Re-)queries the outputs via RandR and stores them in the list of outputs.
  *
  */

--- a/src/con.c
+++ b/src/con.c
@@ -887,8 +887,6 @@ void con_unmark(Con *con, const char *name) {
 Con *con_for_window(Con *con, i3Window *window, Match **store_match) {
     Con *child;
     Match *match;
-    //DLOG("searching con for window %p starting at con %p\n", window, con);
-    //DLOG("class == %s\n", window->class_class);
 
     TAILQ_FOREACH (child, &(con->nodes_head), nodes) {
         TAILQ_FOREACH (match, &(child->swallow_head), matches) {
@@ -1047,8 +1045,8 @@ void con_fix_percent(Con *con) {
     Con *child;
     int children = con_num_children(con);
 
-    // calculate how much we have distributed and how many containers
-    // with a percentage set we have
+    /* calculate how much we have distributed and how many containers with a
+     * percentage set we have */
     double total = 0.0;
     int children_with_percent = 0;
     TAILQ_FOREACH (child, &(con->nodes_head), nodes) {
@@ -1058,8 +1056,8 @@ void con_fix_percent(Con *con) {
         }
     }
 
-    // if there were children without a percentage set, set to a value that
-    // will make those children proportional to all others
+    /* if there were children without a percentage set, set to a value that
+     * will make those children proportional to all others */
     if (children_with_percent != children) {
         TAILQ_FOREACH (child, &(con->nodes_head), nodes) {
             if (child->percent <= 0.0) {
@@ -1072,8 +1070,8 @@ void con_fix_percent(Con *con) {
         }
     }
 
-    // if we got a zero, just distribute the space equally, otherwise
-    // distribute according to the proportions we got
+    /* if we got a zero, just distribute the space equally, otherwise
+     * distribute according to the proportions we got */
     if (total == 0.0) {
         TAILQ_FOREACH (child, &(con->nodes_head), nodes) {
             child->percent = 1.0 / children;
@@ -2237,7 +2235,6 @@ void con_set_urgency(Con *con, bool urgent) {
     } else
         DLOG("Discarding urgency WM_HINT because timer is running\n");
 
-    //CLIENT_LOG(con);
     if (con->window) {
         if (con->urgent) {
             gettimeofday(&con->window->urgent, NULL);

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -165,8 +165,6 @@ static void clear_stack(struct stack *ctx) {
 static void next_state(const cmdp_token *token, struct parser_ctx *ctx) {
     cmdp_state _next_state = token->next_state;
 
-    //printf("token = name %s identifier %s\n", token->name, token->identifier);
-    //printf("next_state = %d\n", token->next_state);
     if (token->next_state == __CALL) {
         struct ConfigResultIR subcommand_output = {
             .ctx = ctx,
@@ -254,7 +252,6 @@ static void parse_config(struct parser_ctx *ctx, const char *input, struct conte
     bool token_handled;
     linecnt = 1;
 
-// TODO: make this testable
 #ifndef TEST_PARSER
     struct ConfigResultIR subcommand_output = {
         .ctx = ctx,
@@ -269,8 +266,6 @@ static void parse_config(struct parser_ctx *ctx, const char *input, struct conte
          * separate configuration directives. */
         while ((*walk == ' ' || *walk == '\t') && *walk != '\0')
             walk++;
-
-        //printf("remaining input: %s\n", walk);
 
         cmdp_token_ptr *ptr = &(tokens[ctx->state]);
         token_handled = false;
@@ -378,7 +373,6 @@ static void parse_config(struct parser_ctx *ctx, const char *input, struct conte
             }
 
             if (strcmp(token->name, "end") == 0) {
-                //printf("checking for end: *%s*\n", walk);
                 if (*walk == '\0' || *walk == '\n' || *walk == '\r') {
                     next_state(token, ctx);
                     token_handled = true;
@@ -386,7 +380,6 @@ static void parse_config(struct parser_ctx *ctx, const char *input, struct conte
                      * datastructure for commands which do *not* specify any
                      * criteria, we re-initialize the criteria system after
                      * every command. */
-// TODO: make this testable
 #ifndef TEST_PARSER
                     cfg_criteria_init(&(ctx->current_match), &subcommand_output, INITIAL);
 #endif

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -70,11 +70,9 @@ bool event_is_ignored(const int sequence, const int response_type) {
             event->response_type != response_type)
             continue;
 
-        /* instead of removing a sequence number we better wait until it gets
-         * garbage collected. it may generate multiple events (there are multiple
-         * enter_notifies for one configure_request, for example). */
-        //SLIST_REMOVE(&ignore_events, event, Ignore_Event, ignore_events);
-        //free(event);
+        /* Instead of removing & freeing a sequence number we better wait until
+         * it gets garbage collected. It may generate multiple events (there
+         * are multiple enter_notifies for one configure_request, for example). */
         return true;
     }
 
@@ -1346,7 +1344,7 @@ static void property_notify(uint8_t state, xcb_window_t window, xcb_atom_t atom)
     }
 
     if (handler == NULL) {
-        //DLOG("Unhandled property notify for atom %d (0x%08x)\n", atom, atom);
+        /* DLOG("Unhandled property notify for atom %d (0x%08x)\n", atom, atom); */
         return;
     }
 
@@ -1524,7 +1522,7 @@ void handle_event(int type, xcb_generic_event_t *event) {
             break;
 
         default:
-            //DLOG("Unhandled event of type %d\n", type);
+            /* DLOG("Unhandled event of type %d\n", type); */
             break;
     }
 }

--- a/src/x.c
+++ b/src/x.c
@@ -881,7 +881,6 @@ void x_push_node(Con *con) {
     con_state *state;
     Rect rect = con->rect;
 
-    //DLOG("Pushing changes for node %p / %s\n", con, con->name);
     state = state_for_frame(con->frame.id);
 
     if (state->name != NULL) {
@@ -994,8 +993,9 @@ void x_push_node(Con *con) {
                 win_depth = con->window->depth;
 
             /* Ensure we have valid dimensions for our surface. */
-            // TODO This is probably a bug in the condition above as we should never enter this path
-            //      for height == 0. Also, we should probably handle width == 0 the same way.
+            /* TODO: This is probably a bug in the condition above as we should
+             * never enter this path for height == 0. Also, we should probably
+             * handle width == 0 the same way. */
             int width = MAX((int32_t)rect.width, 1);
             int height = MAX((int32_t)rect.height, 1);
 
@@ -1014,8 +1014,8 @@ void x_push_node(Con *con) {
             con->pixmap_recreated = true;
 
             /* Don’t render the decoration for windows inside a stack which are
-             * not visible right now */
-            // TODO Should this work the same way for L_TABBED?
+             * not visible right now
+             * TODO: Should this work the same way for L_TABBED? */
             if (!con->parent ||
                 con->parent->layout != L_STACKED ||
                 TAILQ_FIRST(&(con->parent->focus_head)) == con)
@@ -1126,7 +1126,6 @@ static void x_push_node_unmaps(Con *con) {
     Con *current;
     con_state *state;
 
-    //DLOG("Pushing changes (with unmaps) for node %p / %s\n", con, con->name);
     state = state_for_frame(con->frame.id);
 
     /* map/unmap if map state changed, also ensure that the child window
@@ -1202,7 +1201,6 @@ void x_push_changes(Con *con) {
     }
 
     DLOG("-- PUSHING WINDOW STACK --\n");
-    //DLOG("Disabling EnterNotify\n");
     /* We need to keep SubstructureRedirect around, otherwise clients can send
      * ConfigureWindow requests and get them applied directly instead of having
      * them become ConfigureRequests that i3 handles. */
@@ -1211,7 +1209,6 @@ void x_push_changes(Con *con) {
         if (state->mapped)
             xcb_change_window_attributes(conn, state->id, XCB_CW_EVENT_MASK, values);
     }
-    //DLOG("Done, EnterNotify disabled\n");
     bool order_changed = false;
     bool stacking_changed = false;
 
@@ -1241,14 +1238,12 @@ void x_push_changes(Con *con) {
         if (con_has_managed_window(state->con))
             memcpy(walk++, &(state->con->window->id), sizeof(xcb_window_t));
 
-        //DLOG("stack: 0x%08x\n", state->id);
         con_state *prev = CIRCLEQ_PREV(state, state);
         con_state *old_prev = CIRCLEQ_PREV(state, old_state);
         if (prev != old_prev)
             order_changed = true;
         if ((state->initial || order_changed) && prev != CIRCLEQ_END(&state_head)) {
             stacking_changed = true;
-            //DLOG("Stacking 0x%08x above 0x%08x\n", prev->id, state->id);
             uint32_t mask = 0;
             mask |= XCB_CONFIG_WINDOW_SIBLING;
             mask |= XCB_CONFIG_WINDOW_STACK_MODE;
@@ -1301,13 +1296,11 @@ void x_push_changes(Con *con) {
         warp_to = NULL;
     }
 
-    //DLOG("Re-enabling EnterNotify\n");
     values[0] = FRAME_EVENT_MASK;
     CIRCLEQ_FOREACH_REVERSE (state, &state_head, state) {
         if (state->mapped)
             xcb_change_window_attributes(conn, state->id, XCB_CW_EVENT_MASK, values);
     }
-    //DLOG("Done, EnterNotify re-enabled\n");
 
     x_deco_recurse(con);
 
@@ -1393,9 +1386,6 @@ void x_push_changes(Con *con) {
         CIRCLEQ_REMOVE(&old_state_head, state, old_state);
         CIRCLEQ_INSERT_TAIL(&old_state_head, state, old_state);
     }
-    //CIRCLEQ_FOREACH(state, &old_state_head, old_state) {
-    //    DLOG("old stack: 0x%08x\n", state->id);
-    //}
 
     xcb_flush(conn);
 }
@@ -1408,7 +1398,6 @@ void x_push_changes(Con *con) {
 void x_raise_con(Con *con) {
     con_state *state;
     state = state_for_frame(con->frame.id);
-    //DLOG("raising in new stack: %p / %s / %s / xid %08x\n", con, con->name, con->window ? con->window->name_json : "", state->id);
 
     CIRCLEQ_REMOVE(&state_head, state, state);
     CIRCLEQ_INSERT_HEAD(&state_head, state, state);


### PR DESCRIPTION
This makes the whole code-base have zero changes with clang-format (v13).