### PR TITLE
highlight the difference of "workspace N" and "workspace number N"

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -2487,9 +2487,11 @@ bindsym $mod+2 workspace number "2: mail"
 If a workspace does not exist, the command +workspace number "1: mail"+ will
 create workspace "1: mail".
 
-If a workspace with number 1 does already exist, the command will switch to this
+If a workspace with number 1 already exists, the command will switch to this
 workspace and ignore the text part. So even when the workspace has been renamed
-to "1: web", the above command will still switch to it.
+"1: web", the above command will still switch to it.  The command +workspace 1+
+will however create and move to a new workspace "1" alongside the existing
+"1: mail" workspace.
 
 === Moving workspaces to a different screen
 


### PR DESCRIPTION
The fine user's guide suggested a command to dynamically rename workspaces, but after adding it, I was confused that my Mod+4 created a new workspace rather than jumping to my "4: Emacs" workspace.

Turns out the default configuration when I started out with i3 had

```
bindsym $mod1+1 workspace 1
```

I notice that my Fedora now uses `workspace number 1` in its default configuration, so perhaps new users are less likely to experience the same confusion as me.  In any case, please consider whether this change to the docs will clarify usage for others.
