### PR TITLE
Ignore stickiness for fullscreen windows

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -424,7 +424,12 @@ bool con_is_hidden(Con *con) {
  *
  */
 bool con_is_sticky(Con *con) {
-    if (con->sticky)
+    /*
+     * If a window is both sticky and fullscreen, don't consider it sticky, as it
+     * would then make no sense to switch between workspaces - user will only see this
+     * window
+     */
+    if (con->sticky && con->fullscreen_mode == CF_NONE)
         return true;
 
     Con *child;


### PR DESCRIPTION
Hello!
I encountered behavior that I myself considered an issue: I was watching a movie in a (floating fullscreen) video player and wanted to switch to another workspace for a minute, so I exited fullscreen, made the window sticky, and switch to another workspace. Then I went back, put it back to fullscreen, and kept watching. A little later when I needed to switch to another workspace again just for a moment, I decided not to leave fullscreen mode but just do my stuff quickly and then go back. However, as it was floating, sticky and fullscreen at the same time, I couldn't see any other windows.

I thought it would be more convenient to ignore stickiness for windows that are fullscreen and made a patch for myself to achieve this.

I apologize for not creating an issue first, as described in the contributing guideline, but I have written this patch for myself, and I am only creating the PR in case you need it as well. So, if you consider this an expected behavior, I am sorry for taking your time.