### PR TITLE
Use proper WM_Sx registration for i3

### DIFF
--- a/release-notes/bugfixes/5-fix-wm-registration
+++ b/release-notes/bugfixes/5-fix-wm-registration
@@ -1,0 +1,1 @@
+changed WM registration selection from WM_S_S<screen> to WM_S<screen>

--- a/src/main.c
+++ b/src/main.c
@@ -696,11 +696,11 @@ int main(int argc, char *argv[]) {
     /* Acquire the WM_Sn selection. */
     {
         /* Get the WM_Sn atom */
-        char *atom_name = xcb_atom_name_by_screen("WM_S", conn_screen);
+        char *atom_name = xcb_atom_name_by_screen("WM", conn_screen);
         wm_sn_selection_owner = xcb_generate_id(conn);
 
         if (atom_name == NULL) {
-            ELOG("xcb_atom_name_by_screen(\"WM_S\", %d) failed, exiting\n", conn_screen);
+            ELOG("xcb_atom_name_by_screen(\"WM\", %d) failed, exiting\n", conn_screen);
             return 1;
         }
 

--- a/testcases/t/545-i3-registration.t
+++ b/testcases/t/545-i3-registration.t
@@ -1,0 +1,11 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Tests whether our WM registration is done with the correct WM_S0 selection.
+
+use i3test;
+
+my $x = X11::XCB::Connection->new;
+my $reply = $x->get_selection_owner($x->atom(name => 'WM_S0')->id);
+ok($reply, "registration successful");
+done_testing;


### PR DESCRIPTION
i3's WM ownership is registered with the X Atom WM_S_S0 (for screen0),
instead of the correct WM_S0.  The relevant xcb-util API didn't
change, this is simply a bug in i3 that has always been there:
https://gitlab.freedesktop.org/xorg/lib/libxcb-util/-/blob/0.4.0/src/atoms.c#L65