### PR TITLE
Make it possible to use environment variables in the config (#5077)

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -931,6 +931,41 @@ set_from_resource $<name> <resource_name> <fallback>
 set_from_resource $black i3wm.color0 #000000
 ----------------------------------------------------------------------------
 
+[[environment_variables]]
+=== Environment variables
+
+<<variables>> can also be created from environment variables.
+This is useful, for example, to pass along values which you need in other
+places.
+
+It important to note, however, that the variable must be known
+*by the time i3 is started*, so just because the variable is set by the time
+you open a shell doesn't mean it's set when i3 launches.
+
+Depending on how you start i3, you need to set environment variables in different
+places: if you start it with `startx`, you need to set them (either bei `export`ing
+them, or by sourcing some config file in which they are set) in your `~/.xinitrc`.
+If login via a display manager like SDDM, you need to check which files it reads on
+login (usually one of `~/.login`,  `~/.profile`, `~/.zprofile`, `~/.xsessionrc`,
+`~/.xsession`, etc.). It's best to check with the docs of your display manager and
+read https://unix.stackexchange.com/a/4628/[this].
+
+*Syntax*:
+----------------------------------------------------
+set_from_env $<name> <environment_variable> <fallback>
+----------------------------------------------------
+
+*Example*:
+----------------------------------------------------------------------------
+# The environment should contain a variable $FONT by the time the i3
+# config is loaded. So your xinitrc could look like:
+#     ...
+#     export FONT Hack
+#     ...
+#     exec i3
+set_from_env $font FONT fixed
+----------------------------------------------------------------------------
+
 [[assign_workspace]]
 === Automatically putting clients on specific workspaces
 

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -20,6 +20,7 @@ state INITIAL:
   'set '                                   -> IGNORE_LINE
   'set	'                                  -> IGNORE_LINE
   'set_from_resource'                      -> IGNORE_LINE
+  'set_from_env'                           -> IGNORE_LINE
   'include'                                -> INCLUDE
   bindtype = 'bindsym', 'bindcode', 'bind' -> BINDING
   'bar'                                    -> BARBRACE

--- a/replace.sh
+++ b/replace.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+git pull --autostash
+cd build
+ninja
+
+i3path=$(which i3)
+sudo mv $i3path $i3path.old
+sudo cp i3 $i3path

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -508,6 +508,7 @@ EOT
 
 my $expected_all_tokens = "ERROR: CONFIG: Expected one of these tokens: <end>, '#', '" . join("', '", 'set ', 'set	', qw(
         set_from_resource
+        set_from_env
         include
         bindsym
         bindcode

--- a/testcases/t/547-environment.t
+++ b/testcases/t/547-environment.t
@@ -1,0 +1,53 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests for using environment variables in the config.
+use i3test i3_autostart => 0;
+
+sub get_marks {
+    return i3(get_socket_path())->get_marks->recv;
+}
+
+my $config = <<EOT;
+# i3 config file (v4)
+#font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+set_from_env \$mark mark none
+for_window [class=worksforme] mark \$mark
+
+set_from_env \$othermark doesnotexist none
+for_window [class=doesnotworkforme] mark \$othermark
+
+EOT
+
+$ENV{'mark'} = 'works';
+delete $ENV{'doesnotworkforme'};
+
+my $pid = launch_with_config($config);
+
+open_window(wm_class => 'worksforme');
+sync_with_i3;
+is_deeply(get_marks(), [ 'works' ], 'the environment variable has loaded correctly');
+
+cmd 'kill';
+
+open_window(wm_class => 'doesnotworkforme');
+sync_with_i3;
+is_deeply(get_marks(), [ 'none' ], 'the environment variable fallback was used');
+
+exit_gracefully($pid);
+
+done_testing;


### PR DESCRIPTION
`set_from_env` is implemented analogously to `set_from_resource`.

See issue #5077.