### PR TITLE
Sanitise LESS environment variable in i3-sensible-pager.

### DIFF
--- a/i3-sensible-pager
+++ b/i3-sensible-pager
@@ -8,6 +8,11 @@
 # Distributions/packagers can enhance this script with a
 # distribution-specific mechanism to find the preferred pager.
 
+# The less -E and -F options exit immediately for short files, strip if present.
+case "$LESS" in
+  *[EF]*) LESS=`echo "$LESS" | tr -d EF`
+esac
+
 # Hopefully one of these is installed (no flamewars about preference please!):
 # We don't use 'more' because it will exit if the file is too short.
 # Worst case scenario we'll open the file in your editor.


### PR DESCRIPTION
When an error is encountered such as "The configured command for this shortcut
could not be run successfully", the "show errors" button on i3-nagbar doesn't
work if $PAGER is less, and $LESS contains either the -E or -F flag (the
window pops up, but immediately disappears).

Strip these flags from the LESS environment variable before invoking $pager.

Fixes: #5039