### PR TITLE
config: set bar block font to i3-wide font *after* parsing

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -273,6 +273,15 @@ bool load_configuration(const char *override_configpath, config_load_t load_type
         set_font(&config.font);
     }
 
+    /* Make bar config blocks without a configured font use the i3-wide font. */
+    Barconfig *current;
+    TAILQ_FOREACH (current, &barconfigs, configs) {
+        if (current->font != NULL) {
+            continue;
+        }
+        current->font = sstrdup(config.font.pattern);
+    }
+
     if (load_type == C_RELOAD) {
         translate_keysyms();
         grab_all_keys(conn);

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -163,15 +163,9 @@ i3_event_state_mask_t event_state_from_str(const char *str) {
     return result;
 }
 
-static char *font_pattern;
-
 CFGFUN(font, const char *font) {
     config.font = load_font(font, true);
     set_font(&config.font);
-
-    /* Save the font pattern for using it as bar font later on */
-    FREE(font_pattern);
-    font_pattern = sstrdup(font);
 }
 
 CFGFUN(binding, const char *bindtype, const char *modifiers, const char *key, const char *release, const char *border, const char *whole_window, const char *exclude_titlebar, const char *command) {
@@ -751,10 +745,6 @@ CFGFUN(bar_finish) {
         sasprintf(&current_bar->id, "bar-%d", config.number_barconfigs);
 
     config.number_barconfigs++;
-
-    /* If no font was explicitly set, we use the i3 font as default */
-    if (current_bar->font == NULL && font_pattern != NULL)
-        current_bar->font = sstrdup(font_pattern);
 
     TAILQ_INSERT_TAIL(&barconfigs, current_bar, configs);
     /* Simply reset the pointer, but don't free the resources. */

--- a/testcases/t/317-bar-config-font-order.t
+++ b/testcases/t/317-bar-config-font-order.t
@@ -1,0 +1,39 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • http://onyxneon.com/books/modern_perl/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Verifies that bar config blocks get the i3-wide font configured,
+# regardless of where the font is configured in the config file
+# (before or after the bar config blocks).
+# Ticket: #5031
+# Bug still in: 4.20-105-g4db383e4
+use i3test i3_config => <<'EOT';
+# i3 config file (v4)
+
+bar {
+  # no font directive here, no i3-wide font configured (yet)
+}
+
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+EOT
+
+my $i3 = i3(get_socket_path(0));
+my $bars = $i3->get_bar_config()->recv;
+
+my $bar_id = shift @$bars;
+my $bar_config = $i3->get_bar_config($bar_id)->recv;
+is($bar_config->{font}, 'fixed', 'font ok');
+
+done_testing;


### PR DESCRIPTION
Otherwise, the font directive needs to come before bar blocks, which is surprising to users.

fixes https://github.com/i3/i3/issues/5031