### PR TITLE
testsuite: catch i3 SIGSEGV by installing SIGCHLD handler

### DIFF
--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -798,6 +798,8 @@ sub exit_gracefully {
     my ($pid, $socketpath) = @_;
     $socketpath ||= get_socket_path();
 
+    $SIG{CHLD} = undef;
+
     my $exited = 0;
     eval {
         say "Exiting i3 cleanly...";
@@ -835,6 +837,8 @@ C<launch_with_config>).
 sub exit_forcefully {
     my ($pid, $signal) = @_;
     $signal ||= 'TERM';
+
+    $SIG{CHLD} = undef;
 
     # Send the given signal to the i3 instance and wait for up to 10s
     # for it to terminate.
@@ -958,6 +962,18 @@ sub launch_with_config {
 
         return ${^CHILD_ERROR_NATIVE};
     }
+
+    $SIG{CHLD} = sub {
+	# don't change $! and $? outside handler
+	local ($!, $?);
+
+	my $child = waitpid -1, POSIX::WNOHANG;
+	warn "SIGCHLD, waitpid() = $child";
+	if ($child == $i3_pid) {
+	    warn "i3 died, exiting!";
+	    exit 1;
+	}
+    };
 
     # force update of the cached socket path in lib/i3test
     # as soon as i3 has started


### PR DESCRIPTION
The testsuite already contains quite a number of SIGCHLD handler installation/un-installations. Here is my attempt at an inventary.

1. complete-run.pl installs a SIGCHLD handler in the `start_xserver()` function call, which prints an error and exits when all x server processes have exited.

2. In the TestWorker child process, a SIGCHLD handler is installed to reap dead test child processes.

3. The TestWorker child process forks another child process for running the test file, where the previously installed SIGCHLD handler (point 2) is unset.

   This is where this commit comes in: it installs a SIGCHLD handler in the test file child process, which will trigger when the i3 subprocess dies.

4. (For completeness: i3test.pm defines an END block where it unsets the previous SIGCHLD handler before it kills the subprocesses.)

With this commit, when i3 segfaults, the output will look like this:

    Writing logfile to 'testsuite-2022-09-10-21-14-46-4.20-103-gb242bceb/complete-run.log'...
    [:100] /home/michael/i3/testcases/t/167-workspace_layout.t: BAILOUT
    completed 0 of 1 tests
    test /home/michael/i3/testcases/t/167-workspace_layout.t bailed out:
    could not kill i3: No such process

fixes https://github.com/i3/i3/issues/4437