### PR TITLE
tiling_drag: con_rect_plus_deco_height: Fix underflow

### DIFF
--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -19,7 +19,11 @@ static xcb_window_t create_drop_indicator(Rect rect);
 static Rect con_rect_plus_deco_height(Con *con) {
     Rect rect = con->rect;
     rect.height += con->deco_rect.height;
-    rect.y -= con->deco_rect.height;
+    if (rect.y < con->deco_rect.height) {
+        rect.y = 0;
+    } else {
+        rect.y -= con->deco_rect.height;
+    }
     return rect;
 }
 


### PR DESCRIPTION
Fixes #5069

This looks a bit hackish as a fix for the issue, maybe we should investigate for a better solution. But still, this improves on the previous situation and the check itself would stay after a better fix.