### PR TITLE
motif: restore window border correctly

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -1189,7 +1189,7 @@ static bool handle_motif_hints_change(Con *con, xcb_get_property_reply_t *prop) 
     border_style_t motif_border_style;
     window_update_motif_hints(con->window, prop, &motif_border_style);
 
-    if (motif_border_style != con->border_style && motif_border_style != BS_NORMAL) {
+    if (motif_border_style != con->border_style) {
         DLOG("Update border style of con %p to %d\n", con, motif_border_style);
         con_set_border_style(con, motif_border_style, con->current_border_width);
 

--- a/src/window.c
+++ b/src/window.c
@@ -416,11 +416,9 @@ void window_update_hints(i3Window *win, xcb_get_property_reply_t *prop, bool *ur
  *
  */
 void window_update_motif_hints(i3Window *win, xcb_get_property_reply_t *prop, border_style_t *motif_border_style) {
-    /* This implementation simply mirrors Gnome's Metacity. Official
-     * documentation of this hint is nowhere to be found.
-     * For more information see:
-     * https://people.gnome.org/~tthurman/docs/metacity/xprops_8h-source.html
-     * https://stackoverflow.com/questions/13787553/detect-if-a-x11-window-has-decorations
+    /* See `man VendorShell' for more info, `XmNmwmDecorations' section:
+     * https://linux.die.net/man/3/vendorshell
+     * The following constants are adapted from <Xm/MwmUtil.h>.
      */
 #define MWM_HINTS_FLAGS_FIELD 0
 #define MWM_HINTS_DECORATIONS_FIELD 2


### PR DESCRIPTION
Found this while writing a client library, it appears `_MOTIF_WM_HINTS` works for updating the decorations to something **other than** `BS_NORMAL`, because, as you can see in the diff, it explicitly does not restore to it! I removed that check, which fixes it, and also replaced the claim about the nonexistent documentation on Motif hints with a link to documentation on it. Seems like #3678 is related and while that does discuss handling this with other type of hints, the fact is that right now interpretations of the hints like `BS_PIXEL` and `BS_NONE` work as expected, while `BS_NORMAL` does not. This causes weird behaviour such as godotengine/godot/issues/40037 where turning the borders off works, but not back on. Sounds like a bug.

Closed this because in fact this does introduce a bug, I understand the fundamental problem now. I'll make a new PR.