### PR TITLE
unflake t/289-ipc-shutdown-event.t

### DIFF
--- a/testcases/t/289-ipc-shutdown-event.t
+++ b/testcases/t/289-ipc-shutdown-event.t
@@ -21,7 +21,9 @@
 #
 # Ticket: #2318
 # Bug still in: 4.12-46-g2123888
-use i3test;
+use i3test i3_autostart => 0;
+
+my $pid = launch_with_config('-default');
 
 # We cannot use events_for in this test as we cannot send events after
 # issuing the restart/shutdown command.
@@ -59,7 +61,7 @@ $i3->subscribe({
         }
     })->recv;
 
-cmd 'exit';
+exit_gracefully($pid);
 
 $e = $cv->recv;
 


### PR DESCRIPTION
Before this commit, the test was flaky: it relied on the Perl test process sending the kill() system call before i3 exited. This can easily be triggered by adding a sleep(1) after the “cmd 'exit'” line.

This is because with i3_autostart => 1 (the default), i3test.pm kills i3 or bails out if it can’t.

So, we instead set i3_autostart => 0 and launch i3 ourselves. This will unfortunately still make the code kill i3 and bail out, because launch_with_config updates the $i3_pid variable that i3test.pm uses for tracking whether it should clean up i3.
The solution is to exit i3 by calling exit_gracefully, which will make the i3test.pm state correct.

related to https://github.com/i3/i3/issues/3009