### PR TITLE
GitHub Actions: skip build + test steps in meson dist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       if: ${{ failure() }}
     - name: build dist tarball
       run: |
-        docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 -e CC ${{ env.BASENAME }} /bin/sh -c 'rm -rf distbuild; mkdir distbuild && cd distbuild && meson .. -Ddocs=true -Dmans=true && ninja -v dist'
+        docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 -e CC ${{ env.BASENAME }} /bin/sh -c 'rm -rf distbuild; mkdir distbuild && cd distbuild && meson .. -Ddocs=true -Dmans=true && meson dist --no-tests'
     - name: build Debian packages
       run: |
         echo "::group::Debian amd64"


### PR DESCRIPTION
Originally I thought we should remove the build and test steps in favor of the “meson dist” step. But, then we lose verbose build command lines and access to the test logs, and having the failing test logs readily available is critical.

So, instead, let’s make the “meson dist” step not repeat the work that was already done in earlier steps. The Meson manual even documents the --no-tests flag precisely for our use case:

> The meson dist command has a --no-tests option to skip build and tests steps
> of generated packages. It can be used to not waste time for example when done
> in CI that already does its own testing.

From https://mesonbuild.com/Creating-releases.html

fixes https://github.com/i3/i3/issues/5145