### PR TITLE
Fix motif behavior according to spec

### DIFF
--- a/release-notes/bugfixes/1-motif
+++ b/release-notes/bugfixes/1-motif
@@ -1,0 +1,1 @@
+Fix compliance to _MOTIF_WM_HINTS spec when all decorations are set

--- a/testcases/t/548-motif-hints.t
+++ b/testcases/t/548-motif-hints.t
@@ -67,6 +67,7 @@ sub _change_motif_property {
         32, 5,
         pack('L5', 2, 0, $value, 0, 0),
     );
+    $x->flush;
 }
 
 sub open_window_with_motifs {


### PR DESCRIPTION
See https://linux.die.net/man/3/vendorshell
The important part is:
> MWM_DECOR_ALL
> All decorations *except* those specified by other flag bits that are set

Related (but not fixing) #5149, we can merge this independently since it's an improvement on the current situation.

CC @viriuwu