### PR TITLE
Escape ~ to prevent interpretation as subscript.

### DIFF
--- a/man/i3-config-wizard.man
+++ b/man/i3-config-wizard.man
@@ -35,7 +35,7 @@ used.
 
 == DESCRIPTION
 
-i3-config-wizard is started by i3 in its default config, unless ~/.i3/config
+i3-config-wizard is started by i3 in its default config, unless \~/.i3/config
 exists. i3-config-wizard creates a keysym based i3 config file (based on
 /etc/i3/config.keycodes) in ~/.i3/config.
 


### PR DESCRIPTION
Escape first ~ in paragraph to prevent interpretation as subscript text.  Diff to generated XML:

```
 <title>DESCRIPTION</title>
-<simpara>i3-config-wizard is started by i3 in its default config, unless <subscript>/.i3/config
+<simpara>i3-config-wizard is started by i3 in its default config, unless ~/.i3/config
 exists. i3-config-wizard creates a keysym based i3 config file (based on
-/etc/i3/config.keycodes) in </subscript>/.i3/config.</simpara>
+/etc/i3/config.keycodes) in ~/.i3/config.</simpara>
 <simpara>The advantage of using keysyms is that the config file is easy to read,
```