### PR TITLE
Fix segfault during config validation (#5167)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -275,11 +275,13 @@ bool load_configuration(const char *override_configpath, config_load_t load_type
 
     /* Make bar config blocks without a configured font use the i3-wide font. */
     Barconfig *current;
-    TAILQ_FOREACH (current, &barconfigs, configs) {
-        if (current->font != NULL) {
-            continue;
+    if (load_type != C_VALIDATE) {
+        TAILQ_FOREACH (current, &barconfigs, configs) {
+            if (current->font != NULL) {
+                continue;
+            }
+            current->font = sstrdup(config.font.pattern);
         }
-        current->font = sstrdup(config.font.pattern);
     }
 
     if (load_type == C_RELOAD) {


### PR DESCRIPTION
A bug was introduced in #5118 in which configs with bar blocks will segfault during validation. They were copying the i3 font which is not set during validation. This PR simply checks that the `load_type` is not validate before copying the font. Fixes #5167.