### PR TITLE
tiling drag: fix cursor (wrong argument passed)

### DIFF
--- a/release-notes/bugfixes/3-drag-cursor
+++ b/release-notes/bugfixes/3-drag-cursor
@@ -1,0 +1,1 @@
+fix tiling drag cursor: should be “move”, accidentally was “top right corner”

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -283,7 +283,8 @@ void tiling_drag(Con *con, xcb_button_press_event_t *event) {
     xcb_window_t indicator = 0;
     const struct callback_params params = {&indicator, &target, &direction, &drop_type};
 
-    drag_result_t drag_result = drag_pointer(con, event, XCB_NONE, BORDER_TOP, XCURSOR_CURSOR_MOVE, drag_callback, &params);
+    const bool use_threshold = true;
+    drag_result_t drag_result = drag_pointer(con, event, XCB_NONE, XCURSOR_CURSOR_MOVE, use_threshold, drag_callback, &params);
 
     /* Dragging is done. We don't need the indicator window any more. */
     xcb_destroy_window(conn, indicator);


### PR DESCRIPTION
Currently, the cursor is XCURSOR_CURSOR_TOP_RIGHT_CORNER (== BORDER_TOP), but the intended cursor was XCURSOR_CURSOR_MOVE.

noticed this as part of https://github.com/i3/i3/issues/5198