### PR TITLE
Tiling drag threshold tweaks, default change, configuration directive

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -196,6 +196,7 @@ provided by the i3 https://github.com/i3/i3/blob/next/etc/config.keycodes[defaul
 
 Floating windows are always on top of tiling windows.
 
+[[tiling_drag]]
 === Moving tiling containers with the mouse
 
 Since i3 4.21, it's possible to drag tiling containers using the mouse. The
@@ -1401,6 +1402,29 @@ fullscreen toggle
 # this line is not continued \
 bindsym Mod1+F fullscreen toggle
 -------------------
+
+[[config_tiling_drag]]
+=== Tiling drag
+
+You can configure how to initiate the tiling drag feature (see <<tiling_drag>>).
+
+*Syntax*:
+--------------------------------
+tiling_drag off
+tiling_drag modifier|titlebar [modifier|titlebar]
+--------------------------------
+
+*Examples*:
+--------------------------------
+# Only initiate a tiling drag when the modifier is held:
+tiling_drag modifier
+
+# Initiate a tiling drag on either titlebar click or held modifier:
+tiling_drag modifier titlebar
+
+# Disable tiling drag altogether
+tiling_drag off
+--------------------------------
 
 == Configuring i3bar
 

--- a/etc/config
+++ b/etc/config
@@ -49,6 +49,10 @@ set $right semicolon
 # use Mouse+Mod1 to drag floating windows to their wanted position
 floating_modifier Mod1
 
+# move tiling windows via drag & drop by left-clicking into the title bar,
+# or left-clicking anywhere into the window while holding the floating modifier.
+tiling_drag modifier titlebar
+
 # start a terminal
 bindsym Mod1+Return exec i3-sensible-terminal
 

--- a/etc/config.keycodes
+++ b/etc/config.keycodes
@@ -43,6 +43,10 @@ bindsym XF86AudioMicMute exec --no-startup-id pactl set-source-mute @DEFAULT_SOU
 # Use Mouse+$mod to drag floating windows to their wanted position
 floating_modifier $mod
 
+# move tiling windows via drag & drop by left-clicking into the title bar,
+# or left-clicking anywhere into the window while holding the floating modifier.
+tiling_drag modifier titlebar
+
 # start a terminal
 bindcode $mod+36 exec i3-sensible-terminal
 

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -65,6 +65,7 @@ CFGFUN(assign, const char *workspace, bool is_number);
 CFGFUN(no_focus);
 CFGFUN(ipc_socket, const char *path);
 CFGFUN(ipc_kill_timeout, const long timeout_ms);
+CFGFUN(tiling_drag, const char *value);
 CFGFUN(restart_state, const char *path);
 CFGFUN(popup_during_fullscreen, const char *value);
 CFGFUN(color, const char *colorclass, const char *border, const char *background, const char *text, const char *indicator, const char *child_border);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -14,6 +14,7 @@
 
 #include "queue.h"
 #include "i3.h"
+#include "tiling_drag.h"
 
 typedef struct IncludedFile IncludedFile;
 typedef struct Config Config;
@@ -265,6 +266,8 @@ struct Config {
 
     /* The number of currently parsed barconfigs */
     int number_barconfigs;
+
+    tiling_drag_t tiling_drag;
 };
 
 /**

--- a/include/tiling_drag.h
+++ b/include/tiling_drag.h
@@ -10,6 +10,16 @@
 #pragma once
 
 /**
+ * Tiling drag initiation modes.
+ */
+typedef enum {
+    TILING_DRAG_OFF = 0,
+    TILING_DRAG_MODIFIER = 1,
+    TILING_DRAG_TITLEBAR = 2,
+    TILING_DRAG_MODIFIER_OR_TITLEBAR = 3
+} tiling_drag_t;
+
+/**
  * Initiates a mouse drag operation on a tiled window.
  *
  */

--- a/include/tiling_drag.h
+++ b/include/tiling_drag.h
@@ -13,4 +13,4 @@
  * Initiates a mouse drag operation on a tiled window.
  *
  */
-void tiling_drag(Con *con, xcb_button_press_event_t *event);
+void tiling_drag(Con *con, xcb_button_press_event_t *event, bool use_threshold);

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -53,6 +53,7 @@ state INITIAL:
   'ipc_kill_timeout'                       -> IPC_KILL_TIMEOUT
   'restart_state'                          -> RESTART_STATE
   'popup_during_fullscreen'                -> POPUP_DURING_FULLSCREEN
+  'tiling_drag'                            -> TILING_DRAG
   exectype = 'exec_always', 'exec'         -> EXEC
   colorclass = 'client.background'
       -> COLOR_SINGLE
@@ -329,6 +330,18 @@ state RESTART_STATE:
 state POPUP_DURING_FULLSCREEN:
   value = 'ignore', 'leave_fullscreen', 'smart'
       -> call cfg_popup_during_fullscreen($value)
+
+state TILING_DRAG_MODE:
+  value = 'modifier', 'titlebar'
+      ->
+  end
+      -> call cfg_tiling_drag($value)
+
+state TILING_DRAG:
+  off = '0', 'no', 'false', 'off', 'disable', 'inactive'
+      -> call cfg_tiling_drag($off)
+  value = 'modifier', 'titlebar'
+      -> TILING_DRAG_MODE
 
 # client.background <hexcolor>
 state COLOR_SINGLE:

--- a/release-notes/changes/1-tiling-drag
+++ b/release-notes/changes/1-tiling-drag
@@ -1,0 +1,1 @@
+tiling drag is now configurable, and defaults to “modifier” for existing configs

--- a/src/click.c
+++ b/src/click.c
@@ -229,7 +229,8 @@ static void route_click(Con *con, xcb_button_press_event_t *event, const bool mo
 
     /* 2: floating modifier pressed, initiate a drag */
     if (mod_pressed && event->detail == XCB_BUTTON_INDEX_1 && !floatingcon) {
-        tiling_drag(con, event);
+        const bool use_threshold = !mod_pressed;
+        tiling_drag(con, event, use_threshold);
         allow_replay_pointer(event->time);
         return;
     }
@@ -307,7 +308,8 @@ static void route_click(Con *con, xcb_button_press_event_t *event, const bool mo
     /* 8: floating modifier pressed, initiate a drag */
     if ((mod_pressed || dest == CLICK_DECORATION) && event->detail == XCB_BUTTON_INDEX_1) {
         allow_replay_pointer(event->time);
-        tiling_drag(con, event);
+        const bool use_threshold = !mod_pressed;
+        tiling_drag(con, event, use_threshold);
         return;
     }
 

--- a/src/click.c
+++ b/src/click.c
@@ -228,7 +228,9 @@ static void route_click(Con *con, xcb_button_press_event_t *event, const bool mo
     }
 
     /* 2: floating modifier pressed, initiate a drag */
-    if (mod_pressed && event->detail == XCB_BUTTON_INDEX_1 && !floatingcon) {
+    if (mod_pressed && is_left_click && !floatingcon &&
+        (config.tiling_drag == TILING_DRAG_MODIFIER ||
+         config.tiling_drag == TILING_DRAG_MODIFIER_OR_TITLEBAR)) {
         const bool use_threshold = !mod_pressed;
         tiling_drag(con, event, use_threshold);
         allow_replay_pointer(event->time);
@@ -305,8 +307,11 @@ static void route_click(Con *con, xcb_button_press_event_t *event, const bool mo
         return;
     }
 
-    /* 8: floating modifier pressed, initiate a drag */
-    if ((mod_pressed || dest == CLICK_DECORATION) && event->detail == XCB_BUTTON_INDEX_1) {
+    /* 8: floating modifier pressed, or click in titlebar, initiate a drag */
+    if (is_left_click &&
+        ((config.tiling_drag == TILING_DRAG_TITLEBAR && dest == CLICK_DECORATION) ||
+         (config.tiling_drag == TILING_DRAG_MODIFIER_OR_TITLEBAR &&
+          (mod_pressed || dest == CLICK_DECORATION)))) {
         allow_replay_pointer(event->time);
         const bool use_threshold = !mod_pressed;
         tiling_drag(con, event, use_threshold);

--- a/src/config.c
+++ b/src/config.c
@@ -222,6 +222,8 @@ bool load_configuration(const char *override_configpath, config_load_t load_type
 
     config.focus_wrapping = FOCUS_WRAPPING_ON;
 
+    config.tiling_drag = TILING_DRAG_MODIFIER;
+
     FREE(current_configpath);
     current_configpath = get_config_path(override_configpath, true);
     if (current_configpath == NULL) {

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -560,6 +560,20 @@ CFGFUN(ipc_kill_timeout, const long timeout_ms) {
     ipc_set_kill_timeout(timeout_ms / 1000.0);
 }
 
+CFGFUN(tiling_drag, const char *value) {
+    if (strcmp(value, "modifier") == 0) {
+        config.tiling_drag = TILING_DRAG_MODIFIER;
+    } else if (strcmp(value, "titlebar") == 0) {
+        config.tiling_drag = TILING_DRAG_TITLEBAR;
+    } else if (strcmp(value, "modifier,titlebar") == 0 ||
+               strcmp(value, "titlebar,modifier") == 0) {
+        /* Switch the above to strtok() or similar if we ever grow more options */
+        config.tiling_drag = TILING_DRAG_MODIFIER_OR_TITLEBAR;
+    } else {
+        config.tiling_drag = TILING_DRAG_OFF;
+    }
+}
+
 /*******************************************************************************
  * Bar configuration (i3bar)
  ******************************************************************************/

--- a/src/drag.c
+++ b/src/drag.c
@@ -42,7 +42,8 @@ struct drag_x11_cb {
 
 static bool threshold_exceeded(uint32_t x1, uint32_t y1,
                                uint32_t x2, uint32_t y2) {
-    const uint32_t threshold = 9;
+    /* The threshold is about the height of one window decoration. */
+    const uint32_t threshold = logical_px(15);
     return (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) > threshold * threshold;
 }
 

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -267,7 +267,7 @@ static xcb_window_t create_drop_indicator(Rect rect) {
  * Initiates a mouse drag operation on a tiled window.
  *
  */
-void tiling_drag(Con *con, xcb_button_press_event_t *event) {
+void tiling_drag(Con *con, xcb_button_press_event_t *event, bool use_threshold) {
     DLOG("Start dragging tiled container: con = %p\n", con);
     bool set_focus = (con == focused);
     bool set_fs = con->fullscreen_mode != CF_NONE;
@@ -283,7 +283,6 @@ void tiling_drag(Con *con, xcb_button_press_event_t *event) {
     xcb_window_t indicator = 0;
     const struct callback_params params = {&indicator, &target, &direction, &drop_type};
 
-    const bool use_threshold = true;
     drag_result_t drag_result = drag_pointer(con, event, XCB_NONE, XCURSOR_CURSOR_MOVE, use_threshold, drag_callback, &params);
 
     /* Dragging is done. We don't need the indicator window any more. */

--- a/testcases/t/201-config-parser.t
+++ b/testcases/t/201-config-parser.t
@@ -549,6 +549,7 @@ my $expected_all_tokens = "ERROR: CONFIG: Expected one of these tokens: <end>, '
         ipc_kill_timeout
         restart_state
         popup_during_fullscreen
+	tiling_drag
         exec_always
         exec
         client.background


### PR DESCRIPTION
See the individual commits for details. The most important high-level changes:

1. The drag threshold is run through `logical_px()` for hi-dpi displays, and tweaked to match roughly the height of one window decoration. For users of very imprecise mouse movements, either stay within one window decoration height or change `tiling_drag` to `tiling_drag modifier` or `tiling_drag off` entirely.
2. The tiling drag feature is now configurable via the `tiling_drag` directive. It matches exactly the two places where we initiate a `tiling_drag()` call, which keeps things easy to explain and doesn’t explode complexity (like e.g. https://github.com/i3/i3/issues/5185 suggested).
3. The default behavior is changed from `tiling_drag modifier_or_titlebar` to `tiling_drag modifier`, which will get into fewer people’s ways. For new configs (i.e. users who have fewer expectations regarding existing behavior), we include `tiling_drag modifier_or_titlebar` in the config file. I think this is a good compromise to keep existing workflows working, while still making the feature available.