### PR TITLE
tiling drag: only start when there are drop targets

### DIFF
--- a/include/tiling_drag.h
+++ b/include/tiling_drag.h
@@ -9,6 +9,8 @@
  */
 #pragma once
 
+#include "all.h"
+
 /**
  * Tiling drag initiation modes.
  */
@@ -18,6 +20,13 @@ typedef enum {
     TILING_DRAG_TITLEBAR = 2,
     TILING_DRAG_MODIFIER_OR_TITLEBAR = 3
 } tiling_drag_t;
+
+/**
+ * Returns whether there currently are any drop targets.
+ * Used to only initiate a drag when there is something to drop onto.
+ *
+ */
+bool has_drop_targets(void);
 
 /**
  * Initiates a mouse drag operation on a tiled window.

--- a/release-notes/changes/2-tiling-drag-targets
+++ b/release-notes/changes/2-tiling-drag-targets
@@ -1,0 +1,1 @@
+tiling drag: only initiate when there are drop targets

--- a/src/click.c
+++ b/src/click.c
@@ -230,7 +230,8 @@ static void route_click(Con *con, xcb_button_press_event_t *event, const bool mo
     /* 2: floating modifier pressed, initiate a drag */
     if (mod_pressed && is_left_click && !floatingcon &&
         (config.tiling_drag == TILING_DRAG_MODIFIER ||
-         config.tiling_drag == TILING_DRAG_MODIFIER_OR_TITLEBAR)) {
+         config.tiling_drag == TILING_DRAG_MODIFIER_OR_TITLEBAR) &&
+        has_drop_targets()) {
         const bool use_threshold = !mod_pressed;
         tiling_drag(con, event, use_threshold);
         allow_replay_pointer(event->time);
@@ -311,7 +312,8 @@ static void route_click(Con *con, xcb_button_press_event_t *event, const bool mo
     if (is_left_click &&
         ((config.tiling_drag == TILING_DRAG_TITLEBAR && dest == CLICK_DECORATION) ||
          (config.tiling_drag == TILING_DRAG_MODIFIER_OR_TITLEBAR &&
-          (mod_pressed || dest == CLICK_DECORATION)))) {
+          (mod_pressed || dest == CLICK_DECORATION))) &&
+        has_drop_targets()) {
         allow_replay_pointer(event->time);
         const bool use_threshold = !mod_pressed;
         tiling_drag(con, event, use_threshold);


### PR DESCRIPTION
This prevents potentially confusing drag & drop on fullscreen containers and only-containers on workspaces.

fixes https://github.com/i3/i3/issues/5184