### PR TITLE
i3-dmenu-desktop test: Do not autostart i3

### DIFF
--- a/testcases/t/318-i3-dmenu-desktop.t
+++ b/testcases/t/318-i3-dmenu-desktop.t
@@ -18,7 +18,7 @@
 # and sends the command to i3 for execution.
 # Ticket: #5152, #5156
 # Bug still in: 4.21-17-g389d555d
-use i3test;
+use i3test i3_autostart => 0;
 use i3test::Util qw(slurp);
 use File::Temp qw(tempfile tempdir);
 use POSIX qw(mkfifo);


### PR DESCRIPTION
This actually fixes a hang that happens on my machine for some reason. Regardless, starting i3 is not necessary for this test.