### PR TITLE
Fix segfault when checking i3 configuration

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -282,7 +282,10 @@ bool load_configuration(const char *override_configpath, config_load_t load_type
             if (current->font != NULL) {
                 continue;
             }
-            current->font = sstrdup(config.font.pattern);
+
+            if (config.font.pattern != NULL) {
+                current->font = sstrdup(config.font.pattern);
+            }
         }
     }
 


### PR DESCRIPTION
I've encountered a segfault regression since `4.20.1` where `i3 -c ...` will segfault because of a null string.

I don't know if this is the most correct way to fix this issue. I'm also not sure why the `pattern` string _is_ `0x0` (according to gdb)