### PR TITLE
Allow text drawing to use the alpha channel.

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1118,7 +1118,8 @@ client.background::
         which do not cover the whole area of this window expose the color. Note
         that this colorclass only takes a single color.
 
-Colors are in HTML hex format (#rrggbb), see the following example:
+Colors are in HTML hex format (#rrggbb, optionally #rrggbbaa), see the following
+example:
 
 *Examples (default colors)*:
 ----------------------------------------------------------------------
@@ -1970,8 +1971,8 @@ bar {
 
 === Colors
 
-As with i3, colors are in HTML hex format (#rrggbb). The following colors can
-be configured at the moment:
+As with i3, colors are in HTML hex format (#rrggbb, optionally #rrggbbaa). The
+following colors can be configured at the moment:
 
 background::
 	Background color of the bar.

--- a/libi3/font.c
+++ b/libi3/font.c
@@ -21,6 +21,7 @@ static xcb_visualtype_t *root_visual_type;
 static double pango_font_red;
 static double pango_font_green;
 static double pango_font_blue;
+static double pango_font_alpha;
 
 static PangoLayout *create_layout_with_dpi(cairo_t *cr) {
     PangoLayout *layout;
@@ -102,7 +103,7 @@ static void draw_text_pango(const char *text, size_t text_len,
 
     /* Do the drawing */
     cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
-    cairo_set_source_rgb(cr, pango_font_red, pango_font_green, pango_font_blue);
+    cairo_set_source_rgba(cr, pango_font_red, pango_font_green, pango_font_blue, pango_font_alpha);
     pango_cairo_update_layout(cr, layout);
     pango_layout_get_pixel_size(layout, NULL, &height);
     /* Center the piece of text vertically. */
@@ -303,6 +304,7 @@ void set_font_colors(xcb_gcontext_t gc, color_t foreground, color_t background) 
             pango_font_red = foreground.red;
             pango_font_green = foreground.green;
             pango_font_blue = foreground.blue;
+            pango_font_alpha = foreground.alpha;
             break;
     }
 }

--- a/libi3/get_colorpixel.c
+++ b/libi3/get_colorpixel.c
@@ -30,17 +30,27 @@ SLIST_HEAD(colorpixel_head, Colorpixel) colorpixels;
  *
  */
 uint32_t get_colorpixel(const char *hex) {
-    char strgroups[3][3] = {
+    char alpha[2];
+    if (strlen(hex) == strlen("#rrggbbaa")) {
+        alpha[0] = hex[7];
+        alpha[1] = hex[8];
+    } else {
+        alpha[0] = alpha[1] = 'F';
+    }
+
+    char strgroups[4][3] = {
         {hex[1], hex[2], '\0'},
         {hex[3], hex[4], '\0'},
-        {hex[5], hex[6], '\0'}};
+        {hex[5], hex[6], '\0'},
+        {alpha[0], alpha[1], '\0'}};
     uint8_t r = strtol(strgroups[0], NULL, 16);
     uint8_t g = strtol(strgroups[1], NULL, 16);
     uint8_t b = strtol(strgroups[2], NULL, 16);
+    uint8_t a = strtol(strgroups[3], NULL, 16);
 
     /* Shortcut: if our screen is true color, no need to do a roundtrip to X11 */
     if (root_screen == NULL || root_screen->root_depth == 24 || root_screen->root_depth == 32) {
-        return (0xFFUL << 24) | (r << 16 | g << 8 | b);
+        return (a << 24) | (r << 16 | g << 8 | b);
     }
 
     /* Lookup this colorpixel in the cache */

--- a/release-notes/changes/2-text-alpha-channel
+++ b/release-notes/changes/2-text-alpha-channel
@@ -1,0 +1,1 @@
+colors now support an optional alpha value at the end (#rrggbbaa)


### PR DESCRIPTION
This is the last remaining diff from the i3-gaps tree.

related to https://github.com/i3/i3/issues/3724

Tested using the following config with picom:
```
bar {
	i3bar_command i3bar -t
	status_command i3status
	colors {
		# fully	transparent text on opaque background:
		statusline #ffffff00
		background #000000ff
	}
}
```