### PR TITLE
Revert "gaps: use logical_px() to work correctly on hi-dpi monitors"

### DIFF
--- a/release-notes/changes/1-gaps-hidpi
+++ b/release-notes/changes/1-gaps-hidpi
@@ -1,1 +1,0 @@
-gaps: use logical_px() to scale pixel values to hi-dpi

--- a/src/render.c
+++ b/src/render.c
@@ -59,11 +59,6 @@ void render_con(Con *con) {
         inset.width -= inset.x;
         inset.height -= inset.y;
 
-        inset.x = logical_px(inset.x);
-        inset.y = logical_px(inset.y);
-        inset.width = logical_px(inset.width);
-        inset.height = logical_px(inset.height);
-
         if (con->fullscreen_mode == CF_NONE) {
             params.rect = rect_add(params.rect, inset);
             con->rect = rect_add(con->rect, inset);


### PR DESCRIPTION
This reverts commit 6b658f88be50d5251f85eaf6f838d6c67ebaac95.

The commit was misguided: the pixel values are already run through logical_px() when parsing the configuration directive or command, so they should not be run through another logical_px() pass at rendering time.

related to https://github.com/i3/i3/issues/3724 