### PR TITLE
gaps: change workspace rendering to fix sizes with large outer gaps

### DIFF
--- a/src/gaps.c
+++ b/src/gaps.c
@@ -27,7 +27,7 @@ gaps_t calculate_effective_gaps(Con *con) {
         return (gaps_t){0, 0, 0, 0, 0};
 
     gaps_t gaps = {
-        .inner = (workspace->gaps.inner + config.gaps.inner) / 2,
+        .inner = (workspace->gaps.inner + config.gaps.inner),
         .top = 0,
         .right = 0,
         .bottom = 0,
@@ -39,12 +39,6 @@ gaps_t calculate_effective_gaps(Con *con) {
         gaps.bottom = workspace->gaps.bottom + config.gaps.bottom;
         gaps.left = workspace->gaps.left + config.gaps.left;
     }
-
-    /* Outer gaps are added on top of inner gaps. */
-    gaps.top += 2 * gaps.inner;
-    gaps.right += 2 * gaps.inner;
-    gaps.bottom += 2 * gaps.inner;
-    gaps.left += 2 * gaps.inner;
 
     return gaps;
 }

--- a/src/render.c
+++ b/src/render.c
@@ -49,13 +49,28 @@ void render_con(Con *con) {
     DLOG("Rendering node %p / %s / layout %d / children %d\n", con, con->name,
          con->layout, params.children);
 
+    if (con->type == CT_WORKSPACE) {
+        gaps_t gaps = calculate_effective_gaps(con);
+        Rect inset = (Rect){
+            gaps.left,
+            gaps.top,
+            -(gaps.left + gaps.right),
+            -(gaps.top + gaps.bottom),
+        };
+        con->rect = rect_add(con->rect, inset);
+        params.rect = rect_add(params.rect, inset);
+        params.x += gaps.left;
+        params.y += gaps.top;
+    }
+
     if (gaps_should_inset_con(con, params.children)) {
         gaps_t gaps = calculate_effective_gaps(con);
         Rect inset = (Rect){
-            gaps_has_adjacent_container(con, D_LEFT) ? gaps.inner : gaps.left,
-            gaps_has_adjacent_container(con, D_UP) ? gaps.inner : gaps.top,
-            gaps_has_adjacent_container(con, D_RIGHT) ? -gaps.inner : -gaps.right,
-            gaps_has_adjacent_container(con, D_DOWN) ? -gaps.inner : -gaps.bottom};
+            gaps_has_adjacent_container(con, D_LEFT) ? gaps.inner / 2 : gaps.inner,
+            gaps_has_adjacent_container(con, D_UP) ? gaps.inner / 2 : gaps.inner,
+            gaps_has_adjacent_container(con, D_RIGHT) ? -(gaps.inner / 2) : -gaps.inner,
+            gaps_has_adjacent_container(con, D_DOWN) ? -(gaps.inner / 2) : -gaps.inner,
+        };
         inset.width -= inset.x;
         inset.height -= inset.y;
 


### PR DESCRIPTION
Hey @cameronleger, I have taken the liberty to rebase your fix against current i3 `next`, and also apply a small correction (compensating for the `gaps.inner / 2` calculation, keeping the `gaps_has_adjacent_container()` conditionals) so that the tests keep passing and the existing positions/gap sizes are kept as-is.

I tested that the windows still end up roughly same-sized when triggering the key binding `bindsym $mod+x gaps horizontal all toggle 264`

fixes https://github.com/Airblader/i3/issues/22

related to https://github.com/i3/i3/issues/3724