### PR TITLE
gaps: make workspace gap assignments order-independent

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -1476,8 +1476,7 @@ between a screen edge and a window (or split container) will be the sum of outer
 and inner gaps.
 
 You can define gaps either globally or per workspace using the following
-syntax. Note that the gaps configurations should be ordered from least specific
-to most specific as some directives can overwrite others.
+syntax.
 
 *Syntax*:
 -----------------------

--- a/release-notes/bugfixes/2-gaps-order
+++ b/release-notes/bugfixes/2-gaps-order
@@ -1,0 +1,1 @@
+gaps: workspace gaps assignments are no longer order-dependent

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -304,7 +304,7 @@ CFGFUN(gaps, const char *workspace, const char *scope, const long value) {
         if (workspace == NULL)
             config.gaps.inner = pixels;
         else {
-            gaps.inner = pixels - config.gaps.inner;
+            gaps.inner = pixels;
             create_gaps_assignment(workspace, scope, gaps);
         }
     } else if (!strcmp(scope, "outer")) {
@@ -314,10 +314,10 @@ CFGFUN(gaps, const char *workspace, const char *scope, const long value) {
             config.gaps.bottom = pixels;
             config.gaps.left = pixels;
         } else {
-            gaps.top = pixels - config.gaps.top;
-            gaps.right = pixels - config.gaps.right;
-            gaps.bottom = pixels - config.gaps.bottom;
-            gaps.left = pixels - config.gaps.left;
+            gaps.top = pixels;
+            gaps.right = pixels;
+            gaps.bottom = pixels;
+            gaps.left = pixels;
             create_gaps_assignment(workspace, scope, gaps);
         }
     } else if (!strcmp(scope, "vertical")) {
@@ -325,8 +325,8 @@ CFGFUN(gaps, const char *workspace, const char *scope, const long value) {
             config.gaps.top = pixels;
             config.gaps.bottom = pixels;
         } else {
-            gaps.top = pixels - config.gaps.top;
-            gaps.bottom = pixels - config.gaps.bottom;
+            gaps.top = pixels;
+            gaps.bottom = pixels;
             create_gaps_assignment(workspace, scope, gaps);
         }
     } else if (!strcmp(scope, "horizontal")) {
@@ -334,36 +334,36 @@ CFGFUN(gaps, const char *workspace, const char *scope, const long value) {
             config.gaps.right = pixels;
             config.gaps.left = pixels;
         } else {
-            gaps.right = pixels - config.gaps.right;
-            gaps.left = pixels - config.gaps.left;
+            gaps.right = pixels;
+            gaps.left = pixels;
             create_gaps_assignment(workspace, scope, gaps);
         }
     } else if (!strcmp(scope, "top")) {
         if (workspace == NULL)
             config.gaps.top = pixels;
         else {
-            gaps.top = pixels - config.gaps.top;
+            gaps.top = pixels;
             create_gaps_assignment(workspace, scope, gaps);
         }
     } else if (!strcmp(scope, "right")) {
         if (workspace == NULL)
             config.gaps.right = pixels;
         else {
-            gaps.right = pixels - config.gaps.right;
+            gaps.right = pixels;
             create_gaps_assignment(workspace, scope, gaps);
         }
     } else if (!strcmp(scope, "bottom")) {
         if (workspace == NULL)
             config.gaps.bottom = pixels;
         else {
-            gaps.bottom = pixels - config.gaps.bottom;
+            gaps.bottom = pixels;
             create_gaps_assignment(workspace, scope, gaps);
         }
     } else if (!strcmp(scope, "left")) {
         if (workspace == NULL)
             config.gaps.left = pixels;
         else {
-            gaps.left = pixels - config.gaps.left;
+            gaps.left = pixels;
             create_gaps_assignment(workspace, scope, gaps);
         }
     } else {

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -151,6 +151,22 @@ Con *workspace_get(const char *num) {
         }
     }
 
+    if (gaps.inner != 0) {
+        gaps.inner -= config.gaps.inner;
+    }
+    if (gaps.top != 0) {
+        gaps.top -= config.gaps.top;
+    }
+    if (gaps.right != 0) {
+        gaps.right -= config.gaps.right;
+    }
+    if (gaps.bottom != 0) {
+        gaps.bottom -= config.gaps.bottom;
+    }
+    if (gaps.left != 0) {
+        gaps.left -= config.gaps.left;
+    }
+
     Con *output = get_assigned_output(num, parsed_num);
     /* if an assignment is not found, we create this workspace on the current output */
     if (!output) {

--- a/testcases/t/319-gaps.t
+++ b/testcases/t/319-gaps.t
@@ -17,7 +17,9 @@
 # Basic gaps functionality test
 # Ticket: #3724
 
-use i3test i3_config => <<EOT;
+use i3test i3_autostart => 0;
+
+my $config = <<EOT;
 # i3 config file (v4)
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
@@ -26,6 +28,8 @@ gaps outer 20px
 
 default_border pixel 0
 EOT
+
+my $pid = launch_with_config($config);
 
 my $tmp = fresh_workspace;
 
@@ -125,5 +129,38 @@ $inner_gaps = 6;
 $total_gaps = $outer_gaps + $inner_gaps;
 sync_with_i3;
 is_gaps_in_between_only();
+
+exit_gracefully($pid);
+
+################################################################################
+# Ensure gaps configuration does not need to be ordered from least to most specific
+################################################################################
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+# This should result in a gap of 16px, not 26px
+workspace 2 gaps inner 16
+gaps inner 10
+
+default_border pixel 0
+EOT
+
+$pid = launch_with_config($config);
+
+cmd 'workspace 2';
+
+$left = open_window;
+$right = open_window;
+sync_with_i3;
+
+$inner_gaps = 16;
+$outer_gaps = 0;
+$total_gaps = $outer_gaps + $inner_gaps;
+
+is_gaps();
+
+exit_gracefully($pid);
 
 done_testing;


### PR DESCRIPTION
This commit moves subtracting the global gaps from the workspace gaps: previously, this calculation was done while parsing the configuration (order dependent), now it’s done at workspace assignment evaluation time.

related to https://github.com/i3/i3/issues/3724

fixes https://github.com/i3/i3/issues/5253