### PR TITLE
use con_border_style() to fix titles in stacked/tabbed containers

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -1700,7 +1700,7 @@ static bool has_outer_gaps(gaps_t gaps) {
  */
 bool con_draw_decoration_into_frame(Con *con) {
     return con_is_leaf(con) &&
-           con->border_style == BS_NORMAL &&
+           con_border_style(con) == BS_NORMAL &&
            (con->parent == NULL ||
             (con->parent->layout != L_TABBED &&
              con->parent->layout != L_STACKED));
@@ -1817,14 +1817,19 @@ int con_border_style(Con *con) {
         return BS_NONE;
     }
 
-    if (con->parent->layout == L_STACKED)
-        return (con_num_children(con->parent) == 1 ? con->border_style : BS_NORMAL);
+    if (con->parent != NULL) {
+        if (con->parent->layout == L_STACKED) {
+            return (con_num_children(con->parent) == 1 ? con->border_style : BS_NORMAL);
+        }
 
-    if (con->parent->layout == L_TABBED && con->border_style != BS_NORMAL)
-        return (con_num_children(con->parent) == 1 ? con->border_style : BS_NORMAL);
+        if (con->parent->layout == L_TABBED && con->border_style != BS_NORMAL) {
+            return (con_num_children(con->parent) == 1 ? con->border_style : BS_NORMAL);
+        }
 
-    if (con->parent->type == CT_DOCKAREA)
-        return BS_NONE;
+        if (con->parent->type == CT_DOCKAREA) {
+            return BS_NONE;
+        }
+    }
 
     return con->border_style;
 }

--- a/src/x.c
+++ b/src/x.c
@@ -618,8 +618,8 @@ void x_draw_decoration(Con *con) {
         goto copy_pixmaps;
 
     /* 4: paint the bar */
-    DLOG("con->deco_rect = (x=%d, y=%d, w=%d, h=%d)\n",
-         con->deco_rect.x, con->deco_rect.y, con->deco_rect.width, con->deco_rect.height);
+    DLOG("con->deco_rect = (x=%d, y=%d, w=%d, h=%d) for con->name=%s\n",
+         con->deco_rect.x, con->deco_rect.y, con->deco_rect.width, con->deco_rect.height, con->name);
     draw_util_rectangle(dest_surface, p->color->background,
                         con->deco_rect.x, con->deco_rect.y, con->deco_rect.width, con->deco_rect.height);
 
@@ -960,7 +960,7 @@ void x_push_node(Con *con) {
 
     /* The pixmap of a borderless leaf container will not be used except
      * for the titlebar in a stack or tabs (issue #1013). */
-    bool is_pixmap_needed = ((con_is_leaf(con) && con->border_style != BS_NONE) ||
+    bool is_pixmap_needed = ((con_is_leaf(con) && con_border_style(con) != BS_NONE) ||
                              con->layout == L_STACKED ||
                              con->layout == L_TABBED);
     DLOG("Con %p (layout %d), is_pixmap_needed = %s, rect.height = %d\n",


### PR DESCRIPTION
Previously, the code was directly accessing con->border_style, which circumvents the special-casing for stacked/tabbed containers that forces window titles even for title-less containers.

Fixes https://github.com/i3/i3/issues/5269