### PR TITLE
fix: prevent gaps inside floating split containers

### DIFF
--- a/src/con.c
+++ b/src/con.c
@@ -618,7 +618,10 @@ bool con_is_docked(Con *con) {
  *
  */
 Con *con_inside_floating(Con *con) {
-    assert(con != NULL);
+    if (con == NULL) {
+        return NULL;
+    }
+
     if (con->type == CT_FLOATING_CON)
         return con;
 

--- a/src/gaps.c
+++ b/src/gaps.c
@@ -52,6 +52,11 @@ bool gaps_should_inset_con(Con *con, int children) {
         return false;
     }
 
+    /* Floating split containers should never have gaps inside them. */
+    if (con_inside_floating(con)) {
+        return false;
+    }
+
     const bool leaf_or_stacked_tabbed =
         con_is_leaf(con) ||
         (con->layout == L_STACKED || con->layout == L_TABBED);

--- a/testcases/t/319-gaps.t
+++ b/testcases/t/319-gaps.t
@@ -202,4 +202,35 @@ is_gaps();
 
 exit_gracefully($pid);
 
+################################################################################
+# Ensure floating split containers don’t get gaps (issue #5272).
+################################################################################
+
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+gaps inner 10
+
+default_border pixel 0
+EOT
+
+$pid = launch_with_config($config);
+
+fresh_workspace;
+
+my $floating = open_floating_window;
+sync_with_i3;
+
+my $orig_rect = $floating->rect;
+cmd 'border pixel 0';
+sync_with_i3;
+is_deeply(scalar $floating->rect, $orig_rect, 'floating window position unchanged after border pixel 0');
+
+cmd 'layout stacking';
+sync_with_i3;
+is_deeply(scalar $floating->rect, $orig_rect, 'floating window position unchanged after border pixel 0');
+
+exit_gracefully($pid);
+
 done_testing;


### PR DESCRIPTION
Fixes https://github.com/i3/i3/issues/5272