### PR TITLE
Make floating_from and tiling_from criterion work in commands, too

### DIFF
--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -57,12 +57,30 @@ state CRITERIA:
   ctype = 'urgent'      -> CRITERION
   ctype = 'workspace'   -> CRITERION
   ctype = 'machine'     -> CRITERION
+  ctype = 'floating_from' -> CRITERION_FROM
+  ctype = 'tiling_from'   -> CRITERION_FROM
   ctype = 'tiling', 'floating', 'all'
       -> call cmd_criteria_add($ctype, NULL); CRITERIA
   ']' -> call cmd_criteria_match_windows(); INITIAL
 
 state CRITERION:
   '=' -> CRITERION_STR
+
+state CRITERION_FROM:
+  '=' -> CRITERION_FROM_STR_START
+
+state CRITERION_FROM_STR_START:
+  '"' -> CRITERION_FROM_STR
+  kind = 'auto', 'user'
+    -> call cmd_criteria_add($ctype, $kind); CRITERIA
+
+state CRITERION_FROM_STR:
+  kind = 'auto', 'user'
+    -> CRITERION_FROM_STR_END
+
+state CRITERION_FROM_STR_END:
+  '"'
+    -> call cmd_criteria_add($ctype, $kind); CRITERIA
 
 state CRITERION_STR:
   cvalue = word

--- a/release-notes/bugfixes/3-floating-from-tiling-from
+++ b/release-notes/bugfixes/3-floating-from-tiling-from
@@ -1,0 +1,1 @@
+The floating_from and tiling_from criteria now also work in commands


### PR DESCRIPTION
These criteria were hooked up only to the config parser (for directives like `for_window`), but not to the commands parser.

Fixes https://github.com/i3/i3/issues/5258