### PR TITLE
meson: use sh

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -610,15 +610,15 @@ install_headers(
 # because configure_file strips the backslash in e.g. \@display,
 # resulting in @display, breaking our Perl code:
 # https://github.com/mesonbuild/meson/issues/7165
-bash = find_program('bash')
+sh = find_program('sh')
 replace_dirs = [
-  bash, '-c',  # Use bash to capture output and mark as executable
+  sh, '-c',  # Use sh to capture output and mark as executable
   'sed -e \'s,@abs_top_builddir@,'
   + meson.current_build_dir()
   + ',g;s,@abs_top_srcdir@,'
   + meson.current_source_dir()+',g\''
   # Only mark files ending in .pl as executables
-  + ' "$0" > "$1" && { [[ "${1##*.}" == pl ]] && chmod +x "$1" || true; }',
+  + ' "$0" > "$1" && { [ "${1##*.}" = pl ] && chmod +x "$1" || true; }',
   '@INPUT0@',   # $0
   '@OUTPUT0@',  # $1
 ]


### PR DESCRIPTION
This pr will remove the need on `bash` shell for systems that do not need it, as this is only checked at build time for a *very* simple task and not needed at run time