### PR TITLE
Add "mode" field in binding event

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -1099,6 +1099,8 @@ binding that ran a command because of user input. The +change (string)+ field
 indicates what sort of binding event was triggered (right now it will always be
 +"run"+ but may be expanded in the future).
 
+The +mode (string)+ field contains the name of the mode the binding was run in.
+
 The +binding (object)+ field contains details about the binding that was run:
 
 command (string)::

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -133,7 +133,7 @@ void ipc_send_barconfig_update_event(Barconfig *barconfig);
 /**
  * For the binding events, we send the serialized binding struct.
  */
-void ipc_send_binding_event(const char *event_type, Binding *bind);
+void ipc_send_binding_event(const char *event_type, Binding *bind, const char *modename);
 
 /**
  * Set the maximum duration that we allow for a connection with an unwriteable

--- a/release-notes/changes/4-mode-in-binding-event
+++ b/release-notes/changes/4-mode-in-binding-event
@@ -1,0 +1,1 @@
+add "mode" field in binding event

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -843,6 +843,10 @@ CommandResult *run_binding(Binding *bind, Con *con) {
         sasprintf(&command, "[con_id=\"%p\"] %s", con, bind->command);
 
     Binding *bind_cp = binding_copy(bind);
+    /* The "mode" command might change the current mode, so back it up to
+     * correctly produce an event later. */
+    const char *modename = current_binding_mode;
+
     CommandResult *result = parse_command(command, NULL, NULL);
     free(command);
 
@@ -868,7 +872,7 @@ CommandResult *run_binding(Binding *bind, Con *con) {
         free(pageraction);
     }
 
-    ipc_send_binding_event("run", bind_cp);
+    ipc_send_binding_event("run", bind_cp, modename);
     binding_free(bind_cp);
 
     return result;

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1678,7 +1678,7 @@ void ipc_send_barconfig_update_event(Barconfig *barconfig) {
 /*
  * For the binding events, we send the serialized binding struct.
  */
-void ipc_send_binding_event(const char *event_type, Binding *bind) {
+void ipc_send_binding_event(const char *event_type, Binding *bind, const char *modename) {
     DLOG("Issue IPC binding %s event (sym = %s, code = %d)\n", event_type, bind->symbol, bind->keycode);
 
     setlocale(LC_NUMERIC, "C");
@@ -1689,6 +1689,13 @@ void ipc_send_binding_event(const char *event_type, Binding *bind) {
 
     ystr("change");
     ystr(event_type);
+
+    ystr("mode");
+    if (modename == NULL) {
+        ystr("default");
+    } else {
+        ystr(modename);
+    }
 
     ystr("binding");
     dump_binding(gen, bind);

--- a/testcases/t/238-ipc-binding-event.t
+++ b/testcases/t/238-ipc-binding-event.t
@@ -16,6 +16,7 @@
 #
 # Test that the binding event works properly
 # Ticket: #1210
+# Ticket: #5323
 use i3test i3_autostart => 0;
 
 my $keysym = 't';
@@ -28,6 +29,12 @@ my $config = <<EOT;
 font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
 
 bindsym $binding_symbol $command
+
+bindsym m mode some-mode
+mode some-mode {
+    bindsym a nop
+    bindsym b mode default
+}
 EOT
 
 SKIP: {
@@ -46,11 +53,12 @@ SKIP: {
 	    qx(xdotool key $binding_symbol);
 	},
 	'binding');
-
     is(scalar @events, 1, 'Received 1 event');
 
     is($events[0]->{change}, 'run',
         'the `change` field should indicate this binding has run');
+
+    is($events[0]->{mode}, 'default', 'the `mode` field should be "default"');
 
     ok($events[0]->{binding},
         'the `binding` field should be a hash that contains information about the binding');
@@ -68,6 +76,21 @@ SKIP: {
 
     is($events[0]->{binding}->{input_code}, 0,
         'the input_code should be the specified code if the key was bound with bindcode, and otherwise zero');
+
+    # Test that the mode field is correct
+    # See #5323.
+    @events = events_for(
+	sub {
+	    qx(xdotool key m);
+	    qx(xdotool key a);
+	    qx(xdotool key b);
+	},
+	'binding');
+    is(scalar @events, 3, 'Received 3 events');
+
+    is($events[0]->{mode}, 'default', 'Event for binding to enter new mode is atributed to default mode');
+    is($events[1]->{mode}, 'some-mode', 'Event for binding while in mode is attributed to the non-default mode');
+    is($events[2]->{mode}, 'some-mode', 'Event for binding exiting mode is attributed to the non-default mode');
 
     exit_gracefully($pid);
 


### PR DESCRIPTION
This does *not* go in the binding object to reflect the same hierarchy of the config file: a mode is a collection of bindings.

Fixes #5323