### PR TITLE
GitHub Actions: build Ubuntu packages using Ubuntu focal

### DIFF
--- a/travis/travis-base-ubuntu-386.Dockerfile
+++ b/travis/travis-base-ubuntu-386.Dockerfile
@@ -1,7 +1,7 @@
 # vim:ft=Dockerfile
 # Same as travis-base.Dockerfile, but without the test suite dependencies since
 # we only build Debian packages on Ubuntu i386, we don’t run the tests.
-FROM i386/ubuntu:bionic
+FROM i386/ubuntu:focal
 
 RUN echo force-unsafe-io > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup
 # Paper over occasional network flakiness of some mirrors.

--- a/travis/travis-base-ubuntu.Dockerfile
+++ b/travis/travis-base-ubuntu.Dockerfile
@@ -1,7 +1,7 @@
 # vim:ft=Dockerfile
 # Same as travis-base.Dockerfile, but without the test suite dependencies since
 # we only build Debian packages on Ubuntu, we don’t run the tests.
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 RUN echo force-unsafe-io > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup
 # Paper over occasional network flakiness of some mirrors.


### PR DESCRIPTION
This is required to satisfy our meson.build minimal Meson version.