### PR TITLE
Added per-workspace smart_gaps configuration

### DIFF
--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -46,6 +46,7 @@ CFGFUN(for_window, const char *command);
 CFGFUN(gaps, const char *workspace, const char *type, const long value);
 CFGFUN(smart_borders, const char *enable);
 CFGFUN(smart_gaps, const char *enable);
+CFGFUN(smart_gaps_by_workspace, const char *workspace, const char *enable);
 CFGFUN(floating_minimum_size, const long width, const long height);
 CFGFUN(floating_maximum_size, const long width, const long height);
 CFGFUN(default_orientation, const char *orientation);

--- a/include/data.h
+++ b/include/data.h
@@ -241,6 +241,7 @@ struct Workspace_Assignment {
     char *output;
     gaps_t gaps;
     gaps_mask_t gaps_mask;
+    smart_gaps_t smart_gaps;
 
     TAILQ_ENTRY(Workspace_Assignment) ws_assignments;
 };
@@ -678,6 +679,7 @@ struct Con {
 
     /** Only applicable for containers of type CT_WORKSPACE. */
     gaps_t gaps;
+    smart_gaps_t smart_gaps;
 
     struct Con *parent;
 

--- a/include/gaps.h
+++ b/include/gaps.h
@@ -34,6 +34,12 @@ bool gaps_has_adjacent_container(Con *con, direction_t direction);
 gaps_t gaps_for_workspace(Con *ws);
 
 /**
+ * Returns the configured smart_gaps for this workspace based on the workspace name,
+ * number, and configured workspace gap assignments.
+ */
+smart_gaps_t smart_gaps_for_workspace(Con *ws);
+
+/**
  * Re-applies all workspace gap assignments to existing workspaces after
  * reloading the configuration file.
  *

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -333,6 +333,7 @@ state FOCUS_ON_WINDOW_ACTIVATION:
 
 # workspace <workspace> output <output>
 # workspace <workspace> gaps inner|outer <px>
+# workspace <workspace> smart_gaps on|off|inverse_outer
 state WORKSPACE:
   workspace = word
     -> WORKSPACE_COMMAND
@@ -342,6 +343,16 @@ state WORKSPACE_COMMAND:
       -> WORKSPACE_OUTPUT_WORD
   'gaps'
       -> GAPS
+  'smart_gaps'
+      -> SMART_GAPS_BY_WORKSPACE
+
+state SMART_GAPS_BY_WORKSPACE:
+  enabled = '1', 'yes', 'true', 'on', 'enable', 'active'
+      -> call cfg_smart_gaps_by_workspace($workspace, $enabled)
+  enabled = '0', 'no', 'false', 'off', 'disable', 'inactive'
+      -> call cfg_smart_gaps_by_workspace($workspace, $enabled)
+  enabled = 'inverse_outer'
+      -> call cfg_smart_gaps_by_workspace($workspace, $enabled)
 
 state WORKSPACE_OUTPUT_WORD:
   output = word

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -345,7 +345,6 @@ CFGFUN(smart_gaps_by_workspace, const char *workspace, const char *enable) {
 
     /* Assignment does not yet exist, let's create it. */
     if (!found) {
-        DLOG("assignment found");
         assignment = scalloc(1, sizeof(struct Workspace_Assignment));
         assignment->name = sstrdup(workspace);
         assignment->output = NULL;

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -320,11 +320,39 @@ CFGFUN(smart_borders, const char *enable) {
         config.smart_borders = boolstr(enable) ? SMART_BORDERS_ON : SMART_BORDERS_OFF;
 }
 
-CFGFUN(smart_gaps, const char *enable) {
+static smart_gaps_t smart_gaps_enable_to_type(const char *enable) {
     if (!strcmp(enable, "inverse_outer"))
-        config.smart_gaps = SMART_GAPS_INVERSE_OUTER;
+        return SMART_GAPS_INVERSE_OUTER;
     else
-        config.smart_gaps = boolstr(enable) ? SMART_GAPS_ON : SMART_GAPS_OFF;
+        return boolstr(enable) ? SMART_GAPS_ON : SMART_GAPS_OFF;
+}
+
+CFGFUN(smart_gaps, const char *enable) {
+    config.smart_gaps = smart_gaps_enable_to_type(enable);
+}
+
+CFGFUN(smart_gaps_by_workspace, const char *workspace, const char *enable) {
+    DLOG("Setting smart_gaps for workspace %s with %s...", workspace, enable);
+
+    bool found = false;
+    struct Workspace_Assignment *assignment;
+    TAILQ_FOREACH (assignment, &ws_assignments, ws_assignments) {
+        if (strcasecmp(assignment->name, workspace) == 0) {
+            found = true;
+            break;
+        }
+    }
+
+    /* Assignment does not yet exist, let's create it. */
+    if (!found) {
+        DLOG("assignment found");
+        assignment = scalloc(1, sizeof(struct Workspace_Assignment));
+        assignment->name = sstrdup(workspace);
+        assignment->output = NULL;
+        TAILQ_INSERT_TAIL(&ws_assignments, assignment, ws_assignments);
+    }
+
+    assignment->smart_gaps = smart_gaps_enable_to_type(enable);
 }
 
 CFGFUN(floating_minimum_size, const long width, const long height) {

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -160,6 +160,7 @@ Con *workspace_get(const char *num) {
     workspace->workspace_layout = config.default_layout;
     workspace->num = parsed_num;
     workspace->type = CT_WORKSPACE;
+    workspace->smart_gaps = smart_gaps_for_workspace(workspace);
     workspace->gaps = gaps_for_workspace(workspace);
 
     con_attach(workspace, output_get_content(output), false);
@@ -294,6 +295,7 @@ Con *create_workspace_on_output(Output *output, Con *content) {
     x_set_name(ws, name);
     free(name);
 
+    ws->smart_gaps = smart_gaps_for_workspace(ws);
     ws->gaps = gaps_for_workspace(ws);
 
     ws->fullscreen_mode = CF_OUTPUT;

--- a/testcases/t/319-gaps.t
+++ b/testcases/t/319-gaps.t
@@ -358,4 +358,63 @@ height => $left_rect->height,
 
 exit_gracefully($pid);
 
+################################################################################
+# Ensure per-workspace smart gaps works without default gaps
+################################################################################
+$config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+workspace 1 smart_gaps enable
+workspace 1 gaps outer 10
+workspace 1 gaps inner 10
+
+workspace 3 smart_gaps inverse_outer
+workspace 3 gaps inner 10
+workspace 3 gaps outer 20
+
+default_border pixel 0
+EOT
+
+$pid = launch_with_config($config);
+
+# One window
+cmd 'workspace 1';
+kill_all_windows;
+my $single_window = open_window;
+is($screen_width, $single_window->rect->width, "single window width");
+kill_all_windows;
+
+# Two windows enable
+$left = open_window;
+$right = open_window;
+$inner_gaps = 10;
+$total_gaps = 20;
+is_gaps();
+
+# Smart gaps not applied to other workspaces
+cmd 'workspace 2';
+$left = open_window;
+$right = open_window;
+$inner_gaps = 0;
+$total_gaps = 0;
+is_gaps();
+kill_all_windows;
+
+# Single window inverse_outer
+cmd 'workspace 3';
+my $single_window = open_window;
+$total_gaps = 30;
+is($screen_width - 2 * $total_gaps, $single_window->rect->width, "single window width");
+kill_all_windows;
+
+# Two windows inverse_outer
+$left = open_window;
+$right = open_window;
+$inner_gaps = 10;
+$total_gaps = 10;
+is_gaps();
+
+exit_gracefully($pid);
+
 done_testing;


### PR DESCRIPTION
Adds per-workspace smart_gaps configuration for #5356. First contribution here so any feedback appreciated!

Syntax is analogous to per-workspace gaps
```
workspace <ws> smart_gaps <on|inverse_outer>
```