### PR TITLE
Fix top border resizing registered on tiled windows

### DIFF
--- a/release-notes/bugfixes/1-top-border-resize
+++ b/release-notes/bugfixes/1-top-border-resize
@@ -1,0 +1,1 @@
+fix top border resizing on tiling windows

--- a/src/click.c
+++ b/src/click.c
@@ -128,8 +128,11 @@ static bool tiling_resize(Con *con, xcb_button_press_event_t *event, const click
     DLOG("checks for right >= %d\n", con->window_rect.x + con->window_rect.width);
     if (dest == CLICK_DECORATION) {
         return tiling_resize_for_border(con, BORDER_TOP, event, use_threshold);
+    } else if (dest == CLICK_BORDER) {
+        if (event->event_y >= 0 && event->event_y <= (int32_t)bsr.y &&
+            event->event_x >= (int32_t)bsr.x && event->event_x <= (int32_t)(con->rect.width + bsr.width))
+            return tiling_resize_for_border(con, BORDER_TOP, event, false);
     }
-
     if (event->event_x >= 0 && event->event_x <= (int32_t)bsr.x &&
         event->event_y >= (int32_t)bsr.y && event->event_y <= (int32_t)(con->rect.height + bsr.height))
         return tiling_resize_for_border(con, BORDER_LEFT, event, false);


### PR DESCRIPTION
I noticed click+drag resize wasn't working on the top border of my tiled windows.
Unlike the other checks for where the mouse is clicked, it reference decoration. This commit makes it reference the borders like the other ones.

Thanks.