### PR TITLE
Remove the double forking in start_application

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -579,7 +579,11 @@ int main(int argc, char *argv[]) {
 
     /* Initialize the libev event loop. This needs to be done before loading
      * the config file because the parser will install an ev_child watcher
-     * for the nagbar when config errors are found. */
+     * for the nagbar when config errors are found.
+     *
+     * Main loop must be ev's default loop because (at the moment of writing)
+     * only the default loop can handle ev_child events and reap zombies
+     * (the start_application routine relies on that too). */
     main_loop = EV_DEFAULT;
     if (main_loop == NULL)
         die("Could not initialize libev. Bad LIBEV_FLAGS?\n");


### PR DESCRIPTION
Having just a single fork is beneficial, as it preserves the approprate parent information for the children of i3, which is useful in some scenarious e.g. when a child wants to do something on the wm's exit (possible via `prctl(PR_SET_PDEATHSIG, ...)`).

Moreover, this is a zero-cost benefit: i3 is already using libev with the default loop, which automatically reaps all the zombie children even when there is no corresponding event set.

Quote from the `ev(3)` man page (emphasis mine):
> **Libev grabs "SIGCHLD" as soon as the default event loop is initialised.** This is necessary to guarantee proper behaviour even if the first child watcher is started after the child exits. The occurrence of "SIGCHLD" is recorded asynchronously, but child reaping is done synchronously as part of the event loop processing. **Libev always reaps all children, even ones not watched.**

Resolves #5506