### PR TITLE
Fix multiple window movement issue

### DIFF
--- a/release-notes/bugfixes/3-moving-multiple
+++ b/release-notes/bugfixes/3-moving-multiple
@@ -1,0 +1,1 @@
+Fixed the multiple window movement issue from #5382

--- a/src/move.c
+++ b/src/move.c
@@ -265,8 +265,20 @@ void tree_move(Con *con, direction_t direction) {
     /* 1: get the first parent with the same orientation */
 
     if (con->type == CT_WORKSPACE) {
-        DLOG("Not moving workspace\n");
-        return;
+        /* If there is already a split container for the windows in the workspace, use that. */
+        /* Otherwise, make a split container for them and move that split container. This way, moving multiple windows at a time from a workspace works as expected. */
+        const bool moves_focus = (focused == con);
+        Con *first_child = TAILQ_FIRST(&(con->nodes_head));
+        if (first_child != NULL && !con_is_leaf(first_child) && con_num_children(con) == 1) {
+            con = first_child;
+        } else {
+            if ((con = workspace_encapsulate(con)) == NULL) {
+                return;
+            }
+        }
+        if (moves_focus) {
+            con_focus(con);
+        }
     }
 
     if (con->fullscreen_mode == CF_GLOBAL) {


### PR DESCRIPTION
This solves #5382. The issue is caused because there's no container between the workspace and the windows, and when focus is moved up to the workspace, `tree_move` will refuse to move workspaces.

I was planning on making a change elsewhere(Making the split container if they'd otherwise attach to the workspace at all), but as I mentioned in my comment on the issue, the windows attaching directly to the workspace seems specifically intentional based on comments in code. For this reason, making the change at `tree_move` instead of earlier seems needed to respect that intention. If I'm mistaken in any way, or making the earlier change seems like a good idea anyways, let me know.

Thanks.