### PR TITLE
Remove focus workaround

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1578,7 +1578,6 @@ void cmd_move_direction(I3_CMD, const char *direction_str, long amount, const ch
     owindow *current;
     HANDLE_EMPTY_MATCH;
 
-    Con *initially_focused = focused;
     direction_t direction = parse_direction(direction_str);
 
     const bool is_ppt = mode && strcmp(mode, "ppt") == 0;
@@ -1610,12 +1609,6 @@ void cmd_move_direction(I3_CMD, const char *direction_str, long amount, const ch
             tree_move(current->con, direction);
             cmd_output->needs_tree_render = true;
         }
-    }
-
-    /* The move command should not disturb focus. con_exists is called because
-     * tree_move calls tree_flatten. */
-    if (focused != initially_focused && con_exists(initially_focused)) {
-        con_activate(initially_focused);
     }
 
     // XXX: default reply for now, make this a better reply

--- a/src/move.c
+++ b/src/move.c
@@ -241,6 +241,7 @@ static void move_to_output_directed(Con *con, direction_t direction) {
         con_focus(con);
         focused = old_ws;
         workspace_show(ws);
+        con_focus(con);
     }
 
     /* force re-painting the indicators */


### PR DESCRIPTION
The way `cmd_move_direction` currently preserves focus is by saving it beforehand, and applying it after. As far as I can tell, the only reason this is required is because `move_to_output_directed` has unexpected behavior in the case of moving multiple windows otherwise. Since it uses `workspace_show` in an unusual way(That is, with focus on the other workspace), it ends up focusing on one of the internal windows of the container, instead of the container itself.

I kept `workspace_show` because the comment before it seems to indicate that it does some important work, even though it doesn't update focus correctly in this case. I'd like this to be looked at from a more experienced eye to tell me whether I'm essentially undoing that work using `con_focus`, or if the `workspace_show` is necessary there versus some alternative method of getting those things done. I'll come back on that if nobody else does for a while.

This pull request is a precursor to https://github.com/i3/i3/pull/5521, since that needs to change focus in `tree_move` to work as expected.