### PR TITLE
Improve documentation regarding tiling drag

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -202,7 +202,8 @@ Floating windows are always on top of tiling windows.
 Since i3 4.21, it's possible to drag tiling containers using the mouse. The
 drag can be initiated either by dragging the window's titlebar or by pressing
 the <<floating_modifier>> and dragging the container while holding the
-left-click button (depending on the <<config_tiling_drag>> option).
+left-click button. See the <<config_tiling_drag>> option for configuring which
+action triggers the tiling drag.
 
 Once the drag is initiated and the cursor has left the original container, drop
 indicators are created according to the position of the cursor relatively to
@@ -1438,7 +1439,7 @@ bindsym Mod1+F fullscreen toggle
 
 You can configure how to initiate the tiling drag feature (see <<tiling_drag>>).
 
-The default is modifier.
+The default is +modifier+.
 
 *Syntax*:
 --------------------------------

--- a/docs/userguide
+++ b/docs/userguide
@@ -202,7 +202,7 @@ Floating windows are always on top of tiling windows.
 Since i3 4.21, it's possible to drag tiling containers using the mouse. The
 drag can be initiated either by dragging the window's titlebar or by pressing
 the <<floating_modifier>> and dragging the container while holding the
-left-click button.
+left-click button (depending on the <<config_tiling_drag>> option).
 
 Once the drag is initiated and the cursor has left the original container, drop
 indicators are created according to the position of the cursor relatively to
@@ -1437,6 +1437,8 @@ bindsym Mod1+F fullscreen toggle
 === Tiling drag
 
 You can configure how to initiate the tiling drag feature (see <<tiling_drag>>).
+
+The default is modifier.
 
 *Syntax*:
 --------------------------------


### PR DESCRIPTION
I was confused by the documentation, as it stated that I could use tiling drag by dragging the title bar. Although that is the default in the example configuration, it's not the default if you already have a configuration file.

Only later I figured out there was an option to configure it. So I think it will be helpful to point to that configuration option at the documentation of the tiling drag feature. Also added the default of the `tiling_drag` option to the documentation (see https://github.com/i3/i3/blob/stable/src/config.c#L231).

See also #5538