### PR TITLE
Start i3 with a systemd service, if systemd is running and the service is loaded.

### DIFF
--- a/libexec/i3-session-start
+++ b/libexec/i3-session-start
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# This script tries to start i3 via the i3-session systemd unit if it is loaded
+# and systemd is running, otherwise falls back to execing i3 directly.
+
+# Check if the i3-session systemd unit is loaded.
+UNIT_LOAD_STATE=$(systemctl show i3-session.service -P LoadState)
+if [[ $? != 0 || "${UNIT_LOAD_STATE}" != "loaded" ]]; then
+  # The unit is not loaded, or systemctl failed, so just start i3 normally.
+  exec i3
+fi
+
+# Start the i3 systemd session.
+systemctl start --user --wait i3-session.service

--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,9 @@ endif
 cdata.set('HAVE_STRNDUP', cc.has_function('strndup'))
 cdata.set('HAVE_MKDIRP', cc.has_function('mkdirp'))
 
+# Used in share/xsessions/i3.desktop.in to find i3-session-start.
+cdata.set('LIBEXECDIR', join_paths(get_option('prefix'), get_option('libexecdir')))
+
 # Instead of generating config.h directly, make vcs_tag generate it so that
 # @VCS_TAG@ is replaced.
 config_h_in = configure_file(
@@ -324,6 +327,8 @@ cairo_dep = dependency('cairo', version: '>=1.14.4', method: 'pkg-config')
 pangocairo_dep = dependency('pangocairo', method: 'pkg-config')
 glib_dep = dependency('glib-2.0', method: 'pkg-config')
 gobject_dep = dependency('gobject-2.0', method: 'pkg-config')
+
+systemd_dep = dependency('systemd', required: false)
 
 ev_dep = cc.find_library('ev')
 
@@ -597,11 +602,37 @@ install_subdir(
   install_dir: join_paths(get_option('sysconfdir'), 'i3'),
 )
 
-install_subdir(
-  'share/',
-  strip_directory: true,
+configure_file(
+  input: 'share/xsessions/i3.desktop.in',
+  output: 'i3.desktop',
+  configuration: cdata,
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'xsessions'),
+)
+
+install_data(
+  'share/applications/i3.desktop',
+  'share/xsessions/i3-with-shmlog.desktop',
+  rename: [
+    'applications/i3.desktop',
+    'xsessions/i3-with-shmlog.desktop',
+  ],
   install_dir: get_option('datadir'),
 )
+
+install_subdir(
+  'libexec/',
+  strip_directory: true,
+  install_dir: get_option('libexecdir'),
+)
+
+if systemd_dep.found()
+  install_subdir(
+    'systemd/',
+    strip_directory: true,
+    install_dir: systemd_dep.get_pkgconfig_variable('systemduserunitdir'),
+  )
+endif
 
 install_headers(
   'include/i3/ipc.h',

--- a/share/xsessions/i3.desktop.in
+++ b/share/xsessions/i3.desktop.in
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=i3
 Comment=improved dynamic tiling window manager
-Exec=i3
-TryExec=i3
+Exec=@LIBEXECDIR@/i3-session-start
+TryExec=@LIBEXECDIR@/i3-session-start
 Type=Application
 X-LightDM-DesktopName=i3
 DesktopNames=i3

--- a/systemd/i3-session.service
+++ b/systemd/i3-session.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=i3 Session
+
+Requires=graphical-session-pre.target
+After=graphical-session-pre.target
+BindsTo=graphical-session.target
+Before=graphical-session.target
+
+[Service]
+Type=exec
+ExecStart=i3


### PR DESCRIPTION
The systemd service activates `graphical-session.target` which in turn may activate other useful services such as the ssh-agent.

Fixes #5186 