### PR TITLE
motif hints: respect maximum border style in append_layout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,8 +84,8 @@ jobs:
       run: ./release-notes/generator.pl
     - name: Install dependencies
       run: |
-        sudo apt-get install -y clang-format-14
+        sudo apt-get install -y clang-format-15
     - name: Check formatting
-      run: clang-format-14 --dry-run --Werror $(git ls-files '*.c' '*.h')
+      run: clang-format-15 --dry-run --Werror $(git ls-files '*.c' '*.h')
     - name: Verify safe wrapper functions are used
       run: ./travis/check-safe-wrappers.sh

--- a/release-notes/bugfixes/6-motif-append_layout
+++ b/release-notes/bugfixes/6-motif-append_layout
@@ -1,0 +1,1 @@
+motif hints: respect maximum border style in append_layout

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -40,7 +40,7 @@ static int num_marks;
 struct pending_marks {
     char *mark;
     Con *con_to_be_marked;
-} * marks;
+} *marks;
 
 /* This list is used for reordering the focus stack after parsing the 'focus'
  * array. */

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -351,17 +351,18 @@ static int json_string(void *ctx, const unsigned char *val, size_t len) {
         } else if (strcasecmp(last_key, "border") == 0) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);
-            if (strcasecmp(buf, "none") == 0)
-                json_node->border_style = BS_NONE;
-            else if (strcasecmp(buf, "1pixel") == 0) {
-                json_node->border_style = BS_PIXEL;
+            if (strcasecmp(buf, "none") == 0) {
+                json_node->max_user_border_style = json_node->border_style = BS_NONE;
+            } else if (strcasecmp(buf, "1pixel") == 0) {
+                json_node->max_user_border_style = json_node->border_style = BS_PIXEL;
                 json_node->current_border_width = 1;
-            } else if (strcasecmp(buf, "pixel") == 0)
-                json_node->border_style = BS_PIXEL;
-            else if (strcasecmp(buf, "normal") == 0)
-                json_node->border_style = BS_NORMAL;
-            else
+            } else if (strcasecmp(buf, "pixel") == 0) {
+                json_node->max_user_border_style = json_node->border_style = BS_PIXEL;
+            } else if (strcasecmp(buf, "normal") == 0) {
+                json_node->max_user_border_style = json_node->border_style = BS_NORMAL;
+            } else {
                 LOG("Unhandled \"border\": %s\n", buf);
+            }
             free(buf);
         } else if (strcasecmp(last_key, "type") == 0) {
             char *buf = NULL;

--- a/testcases/t/548-motif-hints.t
+++ b/testcases/t/548-motif-hints.t
@@ -18,10 +18,12 @@
 # accordingly, respecting user configuration.
 # Ticket: #3678
 # Ticket: #5149
+# Ticket: #5438
 # Bug still in: 4.21
+use File::Temp qw(tempfile);
 use List::Util qw(first);
-use i3test i3_autostart => 0;
 use X11::XCB qw(:all);
+use i3test i3_autostart => 0;
 
 my $use_floating;
 sub subtest_with_config {
@@ -71,10 +73,12 @@ sub _change_motif_property {
 }
 
 sub open_window_with_motifs {
-    my $value = shift;
+    my ($value, %args) = @_;
+
+    $args{kill_all} //= 1;
 
     # we don't need other windows anymore, simplifies get_border_style
-    kill_all_windows;
+    kill_all_windows if $args{kill_all};
 
     my $open = \&open_window;
     if ($use_floating) {
@@ -82,6 +86,7 @@ sub open_window_with_motifs {
     }
 
     my $window = $open->(
+        %args,
         before_map => sub {
             my ($window) = @_;
             _change_motif_property($window, $value);
@@ -117,7 +122,7 @@ sub is_border_style {
     }
 
     local $Test::Builder::Level = $Test::Builder::Level + 1;
-    is(get_border_style($window), $expected, $msg);
+    is(get_border_style, $expected, $msg);
 }
 
 ###############################################################################
@@ -201,5 +206,45 @@ is_border_style('none');
 change_motif_property(1);
 is_border_style('pixel', 'because of user maximum=pixel');
 };
+
+###############################################################################
+# Test with append_layout
+# See #5438
+###############################################################################
+
+$use_floating = 0;
+
+my $config = <<EOT;
+# i3 config file (v4)
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+EOT
+my $pid = launch_with_config($config);
+
+my ($fh, $filename) = tempfile(UNLINK => 1);
+print $fh <<'EOT';
+{
+	"nodes": [
+		{
+			"border": "none",
+			"swallows": [
+				{
+					"class": "^Special$"
+				}
+			],
+			"type": "con"
+		}
+	],
+	"type": "con"
+}
+EOT
+$fh->flush;
+cmd "append_layout $filename";
+
+# can't use get_border_style because append_layout creates a parent container
+is(@{get_ws(focused_ws)->{nodes}}[0]->{nodes}[0]->{border}, 'none', 'placeholder has border style none');
+
+$window = open_window_with_motifs(1, wm_class => 'Special', instance => 'Special', kill_all => 0);
+is(@{get_ws(focused_ws)->{nodes}}[0]->{nodes}[0]->{border}, 'none', 'window has border style none');
 
 done_testing;


### PR DESCRIPTION
Alternative approach to #5663 that just uses the existing `max_user_border_style` mechanism to ensure consistency with #5158.

@njhanley to answer your https://github.com/i3/i3/pull/5663#issuecomment-1724536318
> Could you give an example use case? I can't imagine wanting to restore a layout and not caring about the style.
> 
> There's currently no such thing as a placeholder with no border style; placeholders are containers and take the default style on creation. We could add the concept of implicit default style with a new `border_style_t` variant (`BS_UNDEFINED = -1` for example) or a placeholder-specific flag on `Con`, but I'm not convinced it's worth it.

A use case example would be:
```json
{
	"layout": "splith",
	"nodes": [
		{
			"swallows": [
				{
					"class": "^Chromium$"
				}
			],
			"type": "con"
		},
		{
			"border": "none",
			"swallows": [
				{
					"class": "^URxvt$"
				}
			],
			"type": "con"
		}
	],
	"type": "con"
}
```

where the user has not specified any border style for chromium, they merely said they want chromium left of urxvt. Forcing a different border style on Chromium compared to what the user would get if they launched chromium regularly is inconsistent.

Fixes #5438
Closes #5663 