### PR TITLE
Fix failing testcase when the font exists

### DIFF
--- a/testcases/complete-run.pl.in
+++ b/testcases/complete-run.pl.in
@@ -203,7 +203,7 @@ for my $display (@displays) {
 # Read previous timing information, if available. We will be able to roughly
 # predict the test duration and schedule a good order for the tests.
 my $timingsjson = slurp('.last_run_timings.json') if -e '.last_run_timings.json';
-%timings = %{decode_json($timingsjson)} if length($timingsjson) > 0;
+%timings = %{decode_json($timingsjson)} if length($timingsjson // '') > 0;
 
 # Re-order the files so that those which took the longest time in the previous
 # run will be started at the beginning to not delay the whole run longer than

--- a/testcases/t/317-bar-config-font-fallback.t
+++ b/testcases/t/317-bar-config-font-fallback.t
@@ -26,7 +26,8 @@ bar {
   # no font directive here, no i3-wide font configured (yet)
 }
 
-font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+# NOTE: iso99887 is invalid font specification, so it should always fallback
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso99887-9
 EOT
 
 my $i3 = i3(get_socket_path(0));
@@ -35,11 +36,7 @@ my $bars = $i3->get_bar_config()->recv;
 my $bar_id = shift @$bars;
 my $bar_config = $i3->get_bar_config($bar_id)->recv;
 
-# This should either load the font specified, or fallback to 'fixed'
-my %valid_fonts = map {; $_ => 1 } qw(
-    -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
-    fixed
-);
-is($valid_fonts{ $bar_config->{font} }, 1, 'font ok');
+# This should fallback to 'fixed' due to nonexistent font set in config
+is($bar_config->{font}, 'fixed', 'font fallback ok');
 
 done_testing;


### PR DESCRIPTION
When the font from testcase's config exists on the system, load_configuration() does not fallback to a 'fixed' one resulting in a fail of this case.

The details are under another project's PR: https://github.com/stapelberg/X11-XCB/pull/5