### PR TITLE
Shrinking on a per-block basis

### DIFF
--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -46,8 +46,6 @@ struct status_block {
     i3String *full_text;
     i3String *short_text;
 
-    bool use_short_text;
-
     char *color;
     char *background;
     char *border;

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -46,6 +46,8 @@ struct status_block {
     i3String *full_text;
     i3String *short_text;
 
+    uint32_t length_priority;
+
     char *color;
     char *background;
     char *border;

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -47,6 +47,7 @@ struct status_block {
     i3String *short_text;
 
     bool use_short;
+    uint32_t render_length;
 
     char *color;
     char *background;

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -47,6 +47,7 @@ struct status_block {
     i3String *short_text;
 
     uint32_t length_priority;
+    bool use_short;
 
     char *color;
     char *background;

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -82,7 +82,7 @@ struct status_block {
     TAILQ_ENTRY(status_block) blocks;
 };
 
-extern TAILQ_HEAD(statusline_head, status_block) statusline_head;
+extern TAILQ_HEAD(statusline_head, status_block) statusline_head, statusline_sorted;
 
 #include "child.h"
 #include "ipc.h"

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -84,7 +84,6 @@ struct status_block {
 };
 
 extern TAILQ_HEAD(statusline_head, status_block) statusline_head;
-extern size_t block_count;
 
 #include "child.h"
 #include "ipc.h"

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -46,7 +46,6 @@ struct status_block {
     i3String *full_text;
     i3String *short_text;
 
-    uint32_t length_priority;
     bool use_short;
 
     char *color;
@@ -85,7 +84,6 @@ struct status_block {
 
 extern TAILQ_HEAD(statusline_head, status_block) statusline_head;
 extern size_t block_count;
-extern struct status_block **statusline_sorted;
 
 #include "child.h"
 #include "ipc.h"

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -46,6 +46,8 @@ struct status_block {
     i3String *full_text;
     i3String *short_text;
 
+    bool use_short_text;
+
     char *color;
     char *background;
     char *border;

--- a/i3bar/include/common.h
+++ b/i3bar/include/common.h
@@ -83,7 +83,9 @@ struct status_block {
     TAILQ_ENTRY(status_block) blocks;
 };
 
-extern TAILQ_HEAD(statusline_head, status_block) statusline_head, statusline_sorted;
+extern TAILQ_HEAD(statusline_head, status_block) statusline_head;
+extern size_t block_count;
+extern struct status_block **statusline_sorted;
 
 #include "child.h"
 #include "ipc.h"

--- a/i3bar/include/outputs.h
+++ b/i3bar/include/outputs.h
@@ -65,8 +65,6 @@ struct i3_output {
     surface_t statusline_buffer;
     /* How much of statusline_buffer's horizontal space was used on last statusline render. */
     int statusline_width;
-    /* Whether statusline block short texts were used on last statusline render. */
-    bool statusline_short_text;
     /* The actual window on which we draw. */
     surface_t bar;
 

--- a/i3bar/include/outputs.h
+++ b/i3bar/include/outputs.h
@@ -66,8 +66,7 @@ struct i3_output {
     /* How much of statusline_buffer's horizontal space was used on last statusline render. */
     int statusline_width;
     /* Whether statusline block short texts were used on last statusline render. */
-    bool* statusline_short_text;
-    size_t block_count;
+    bool statusline_short_text;
     /* The actual window on which we draw. */
     surface_t bar;
 

--- a/i3bar/include/outputs.h
+++ b/i3bar/include/outputs.h
@@ -65,8 +65,9 @@ struct i3_output {
     surface_t statusline_buffer;
     /* How much of statusline_buffer's horizontal space was used on last statusline render. */
     int statusline_width;
-    /* Whether statusline block short texts where used on last statusline render. */
-    bool statusline_short_text;
+    /* Whether statusline block short texts were used on last statusline render. */
+    bool* statusline_short_text;
+    size_t block_count;
     /* The actual window on which we draw. */
     surface_t bar;
 

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -211,6 +212,9 @@ static int stdin_start_map(void *context) {
     ctx->block.border_bottom = 1;
     ctx->block.border_left = 1;
 
+    /* By default, no block takes priority for short mode */
+    ctx->block.length_priority = 0;
+
     return 1;
 }
 
@@ -326,6 +330,10 @@ static int stdin_integer(void *context, long long val) {
     }
     if (strcasecmp(ctx->last_map_key, "border_left") == 0) {
         ctx->block.border_left = (uint32_t)val;
+        return 1;
+    }
+    if (strcasecmp(ctx->last_map_key, "length_priority") == 0) {
+        ctx->block.length_priority = (uint32_t)val;
         return 1;
     }
 

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -379,7 +379,7 @@ static int stdin_end_map(void *context) {
     return 1;
 }
 
-int descending_length_priority(const void *a, const void *b) {
+static int descending_length_priority(const void *a, const void *b) {
     return (*(struct status_block **)b)->length_priority - (*(struct status_block **)a)->length_priority;
 }
 

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -379,8 +379,8 @@ static int stdin_end_map(void *context) {
     return 1;
 }
 
-int compare_length_priority(const void *a, const void *b) {
-    return (*(struct status_block **)a)->length_priority - (*(struct status_block **)b)->length_priority;
+int descending_length_priority(const void *a, const void *b) {
+    return (*(struct status_block **)b)->length_priority - (*(struct status_block **)a)->length_priority;
 }
 
 /*
@@ -405,7 +405,7 @@ static int stdin_end_array(void *context) {
         *dst = current;
         dst++;
     }
-    qsort(statusline_sorted, block_count, sizeof(struct status_block *), compare_length_priority);
+    qsort(statusline_sorted, block_count, sizeof(struct status_block *), descending_length_priority);
     TAILQ_FOREACH (current, &statusline_head, blocks) {
         DLOG("full_text = %s\n", i3string_as_utf8(current->full_text));
         DLOG("short_text = %s\n", (current->short_text == NULL ? NULL : i3string_as_utf8(current->short_text)));

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -377,12 +377,12 @@ static int stdin_end_map(void *context) {
 
     TAILQ_INSERT_TAIL(&statusline_buffer, new_block, blocks);
 
-    if (new_block->length_priority > TAILQ_FIRST(&statusline_sorted)->length_priority) {
+    if (TAILQ_FIRST(&statusline_sorted) == NULL || new_block->length_priority > TAILQ_FIRST(&statusline_sorted)->length_priority) {
         TAILQ_INSERT_HEAD(&statusline_sorted, new_block, blocks);
     } else {
         struct status_block *block;
         TAILQ_FOREACH (block, &statusline_sorted, blocks) {
-            if (new_block->length_priority > TAILQ_NEXT(block, blocks)->length_priority) {
+            if (TAILQ_NEXT(block, blocks) == NULL || new_block->length_priority > TAILQ_NEXT(block, blocks)->length_priority) {
                 TAILQ_INSERT_AFTER(&statusline_sorted, block, new_block, blocks);
                 break;
             }

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -370,6 +370,7 @@ static int stdin_end_map(void *context) {
 
     i3string_set_markup(new_block->full_text, new_block->pango_markup);
 
+    new_block->use_short = false;
     if (new_block->short_text != NULL) {
         i3string_set_markup(new_block->short_text, new_block->pango_markup);
     }
@@ -380,7 +381,7 @@ static int stdin_end_map(void *context) {
         TAILQ_INSERT_HEAD(&statusline_sorted, new_block, blocks);
     } else {
         struct status_block *block;
-        TAILQ_FOREACH(block, &statusline_sorted, blocks) {
+        TAILQ_FOREACH (block, &statusline_sorted, blocks) {
             if (new_block->length_priority > TAILQ_NEXT(block, blocks)->length_priority) {
                 TAILQ_INSERT_AFTER(&statusline_sorted, block, new_block, blocks);
                 break;

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -78,7 +78,6 @@ parser_ctx parser_context;
 struct statusline_head statusline_head = TAILQ_HEAD_INITIALIZER(statusline_head);
 /* Used temporarily while reading a statusline */
 struct statusline_head statusline_buffer = TAILQ_HEAD_INITIALIZER(statusline_buffer);
-size_t block_count = 0;
 
 int child_stdin;
 
@@ -106,16 +105,13 @@ void clear_statusline(struct statusline_head *head, bool free_resources) {
     }
 }
 
-static size_t copy_statusline(struct statusline_head *from, struct statusline_head *to) {
+static void copy_statusline(struct statusline_head *from, struct statusline_head *to) {
     struct status_block *current;
-    size_t count = 0;
     TAILQ_FOREACH (current, from, blocks) {
         struct status_block *new_block = smalloc(sizeof(struct status_block));
         memcpy(new_block, current, sizeof(struct status_block));
         TAILQ_INSERT_TAIL(to, new_block, blocks);
-        count++;
     }
-    return count;
 }
 
 /*
@@ -377,7 +373,7 @@ static int stdin_end_map(void *context) {
 static int stdin_end_array(void *context) {
     DLOG("copying statusline_buffer to statusline_head\n");
     clear_statusline(&statusline_head, true);
-    block_count = copy_statusline(&statusline_buffer, &statusline_head);
+    copy_statusline(&statusline_buffer, &statusline_head);
 
     DLOG("dumping statusline:\n");
     struct status_block *current;

--- a/i3bar/src/outputs.c
+++ b/i3bar/src/outputs.c
@@ -147,7 +147,6 @@ static int outputs_start_map_cb(void *params_) {
         new_output->visible = false;
         new_output->ws = 0,
         new_output->statusline_width = 0;
-        new_output->statusline_short_text = false;
         memset(&new_output->rect, 0, sizeof(rect));
         memset(&new_output->bar, 0, sizeof(surface_t));
         memset(&new_output->buffer, 0, sizeof(surface_t));

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -188,7 +188,7 @@ static void draw_separator(i3_output *output, uint32_t x, struct status_block *b
     }
 }
 
-static uint32_t predict_statusline_length(bool* used_short_text) {
+static uint32_t predict_statusline_length(void) {
     uint32_t width = 0;
     struct status_block *block;
 
@@ -238,6 +238,10 @@ static uint32_t predict_statusline_length(bool* used_short_text) {
     }
 
     return width;
+}
+
+static uint32_t adjust_statusline_length(bool* used_short_text, uint32_t max_length) {
+    return predict_statusline_length();
 }
 
 /*
@@ -2055,9 +2059,6 @@ static void draw_button(surface_t *surface, color_t fg_color, color_t bg_color, 
 void draw_bars(bool unhide) {
     DLOG("Drawing bars...\n");
 
-    bool used_short_text;
-    uint32_t statusline_width = predict_statusline_length(&used_short_text);
-
     i3_output *outputs_walk;
     SLIST_FOREACH (outputs_walk, outputs, slist) {
         int workspace_width = logical_px(config.padding.x);
@@ -2132,6 +2133,9 @@ void draw_bars(bool unhide) {
             uint32_t hoff = logical_px(((workspace_width > 0) + (tray_width > 0)) * sb_hoff_px);
             uint32_t max_statusline_width = outputs_walk->rect.w - workspace_width - tray_width - hoff;
             uint32_t clip_left = 0;
+
+            bool used_short_text;
+            uint32_t statusline_width = adjust_statusline_length(&used_short_text, max_statusline_width);
 
             if (statusline_width > max_statusline_width) {
                 clip_left = statusline_width - max_statusline_width;

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -240,15 +240,15 @@ static uint32_t predict_statusline_length(void) {
     return width;
 }
 
-static uint32_t adjust_statusline_length(bool* used_short_text, uint32_t max_length) {
-    uint32_t width = -1;
+static uint32_t adjust_statusline_length(bool *used_short_text, uint32_t max_length) {
+    uint32_t width = 0;
     struct status_block *block;
 
     // Switch the blocks to short mode in order of their length priority
     TAILQ_FOREACH (block, &statusline_sorted, blocks) {
         // If this block has no short form, there is no point in checking if we need to switch;
         // however, we do have to compute the width at least once
-        if (block->short_text == NULL && width != -1) {
+        if (block->short_text == NULL && width > 0) {
             continue;
         }
         width = predict_statusline_length();
@@ -2155,7 +2155,7 @@ void draw_bars(bool unhide) {
 
             /* Reset short mode between outputs */
             struct status_block *block;
-            TAILQ_FOREACH(block, &statusline_head, blocks) {
+            TAILQ_FOREACH (block, &statusline_head, blocks) {
                 block->use_short = false;
             }
 

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -242,20 +242,20 @@ static uint32_t predict_statusline_length(void) {
 
 static uint32_t adjust_statusline_length(bool *used_short_text, uint32_t max_length) {
     uint32_t width = 0;
-    struct status_block *block;
 
     // Switch the blocks to short mode in order of their length priority
-    TAILQ_FOREACH (block, &statusline_sorted, blocks) {
+    size_t idx = 0;
+    for (struct status_block **block = statusline_sorted; idx < block_count; idx++, block++) {
         // If this block has no short form, there is no point in checking if we need to switch;
         // however, we do have to compute the width at least once
-        if (block->short_text == NULL && width > 0) {
+        if ((*block)->short_text == NULL && width > 0) {
             continue;
         }
         width = predict_statusline_length();
         if (width < max_length) {
             break;
         } else {
-            block->use_short = true;
+            (*block)->use_short = true;
             *used_short_text = true;
         }
     }

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -270,6 +270,9 @@ static uint32_t adjust_statusline_length(uint32_t max_length) {
             uint32_t diff = full - block->render_length;
             width -= diff;
 
+            /* Provide support for representing a single logical block using multiple JSON blocks:
+               if one block is shortened, ensure that all other blocks with the same name are also
+               shortened such that the entire logical block uses the short form text. */
             if (block->name) {
                 struct status_block *other;
                 TAILQ_FOREACH (other, &statusline_head, blocks) {

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -241,7 +241,20 @@ static uint32_t predict_statusline_length(void) {
 }
 
 static uint32_t adjust_statusline_length(bool* used_short_text, uint32_t max_length) {
-    return predict_statusline_length();
+    uint32_t width;
+    struct status_block *block;
+
+    TAILQ_FOREACH (block, &statusline_head, blocks) {
+        width = predict_statusline_length();
+        if (width < max_length) {
+            break;
+        } else if (block->short_text != NULL) {
+            block->use_short_text = true;
+            *used_short_text = true;
+        }
+    }
+
+    return width;
 }
 
 /*

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -2153,6 +2153,12 @@ void draw_bars(bool unhide) {
             uint32_t max_statusline_width = outputs_walk->rect.w - workspace_width - tray_width - hoff;
             uint32_t clip_left = 0;
 
+            /* Reset short mode between outputs */
+            struct status_block *block;
+            TAILQ_FOREACH(block, &statusline_head, blocks) {
+                block->use_short = false;
+            }
+
             bool used_short_text;
             uint32_t statusline_width = adjust_statusline_length(&used_short_text, max_statusline_width);
 

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -241,7 +241,7 @@ static uint32_t predict_statusline_length(void) {
     return width;
 }
 
-static uint32_t adjust_statusline_length(bool *used_short_text, uint32_t max_length) {
+static uint32_t adjust_statusline_length(uint32_t max_length) {
     uint32_t width = 0;
 
     /* Switch the blocks to short mode */
@@ -257,7 +257,6 @@ static uint32_t adjust_statusline_length(bool *used_short_text, uint32_t max_len
             break;
         } else if (!block->use_short) {
             block->use_short = true;
-            *used_short_text = true;
 
             if (block->name) {
                 struct status_block *other;
@@ -2169,8 +2168,7 @@ void draw_bars(bool unhide) {
                 block->use_short = false;
             }
 
-            bool used_short_text;
-            uint32_t statusline_width = adjust_statusline_length(&used_short_text, max_statusline_width);
+            uint32_t statusline_width = adjust_statusline_length(max_statusline_width);
 
             if (statusline_width > max_statusline_width) {
                 clip_left = statusline_width - max_statusline_width;
@@ -2185,7 +2183,6 @@ void draw_bars(bool unhide) {
                                    x_dest, 0, visible_statusline_width, (int16_t)bar_height);
 
             outputs_walk->statusline_width = statusline_width;
-            outputs_walk->statusline_short_text = used_short_text;
         }
     }
 

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -258,31 +258,31 @@ static uint32_t adjust_statusline_length(uint32_t max_length) {
     /* Progressively switch the blocks to short mode */
     struct status_block *block;
     TAILQ_FOREACH (block, &statusline_head, blocks) {
-        if (block->short_text == NULL) {
-            continue;
-        }
         if (width < max_length) {
             break;
-        } else if (!block->use_short) {
-            uint32_t full = block->render_length;
-            block->use_short = true;
-            predict_block_length(block);
-            uint32_t diff = full - block->render_length;
-            width -= diff;
+        }
+        /* Skip blocks that have no short form or are already in short form */
+        if (block->short_text == NULL || block->use_short) {
+            continue;
+        }
+        uint32_t full = block->render_length;
+        block->use_short = true;
+        predict_block_length(block);
+        uint32_t diff = full - block->render_length;
+        width -= diff;
 
-            /* Provide support for representing a single logical block using multiple JSON blocks:
-               if one block is shortened, ensure that all other blocks with the same name are also
-               shortened such that the entire logical block uses the short form text. */
-            if (block->name) {
-                struct status_block *other;
-                TAILQ_FOREACH (other, &statusline_head, blocks) {
-                    if (other->name && !strcmp(other->name, block->name)) {
-                        uint32_t full = other->render_length;
-                        other->use_short = true;
-                        predict_block_length(other);
-                        uint32_t diff = full - other->render_length;
-                        width -= diff;
-                    }
+        /* Provide support for representing a single logical block using multiple JSON blocks:
+           if one block is shortened, ensure that all other blocks with the same name are also
+           shortened such that the entire logical block uses the short form text. */
+        if (block->name) {
+            struct status_block *other;
+            TAILQ_FOREACH (other, &statusline_head, blocks) {
+                if (other->name && !strcmp(other->name, block->name)) {
+                    uint32_t full = other->render_length;
+                    other->use_short = true;
+                    predict_block_length(other);
+                    uint32_t diff = full - other->render_length;
+                    width -= diff;
                 }
             }
         }

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -243,18 +243,18 @@ static uint32_t predict_statusline_length(void) {
 static uint32_t adjust_statusline_length(bool *used_short_text, uint32_t max_length) {
     uint32_t width = 0;
 
-    // Switch the blocks to short mode in order of their length priority
+    /* Switch the blocks to short mode in order of their length priority */
     size_t idx = 0;
     for (struct status_block **block = statusline_sorted; idx < block_count; idx++, block++) {
-        // If this block has no short form, there is no point in checking if we need to switch;
-        // however, we do have to compute the width at least once
+        /* If this block has no short form, there is no point in checking if we need to switch;
+         * however, we do have to compute the width at least once */
         if ((*block)->short_text == NULL && width > 0) {
             continue;
         }
         width = predict_statusline_length();
         if (width < max_length) {
             break;
-        } else {
+        } else if (!(*block)->use_short) {
             (*block)->use_short = true;
             *used_short_text = true;
 

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -188,14 +188,14 @@ static void draw_separator(i3_output *output, uint32_t x, struct status_block *b
     }
 }
 
-static uint32_t predict_statusline_length(bool* use_short_text) {
+static uint32_t predict_statusline_length(void) {
     uint32_t width = 0;
     struct status_block *block;
 
     TAILQ_FOREACH (block, &statusline_head, blocks) {
         i3String *text = block->full_text;
         struct status_block_render_desc *render = &block->full_render;
-        if (*use_short_text++ && block->short_text != NULL) {
+        if (block->use_short && block->short_text != NULL) {
             text = block->short_text;
             render = &block->short_render;
         }
@@ -240,16 +240,17 @@ static uint32_t predict_statusline_length(bool* use_short_text) {
     return width;
 }
 
-static uint32_t adjust_statusline_length(bool* use_short_text, uint32_t max_length) {
+static uint32_t adjust_statusline_length(bool* used_short_text, uint32_t max_length) {
     uint32_t width;
     struct status_block *block;
 
     TAILQ_FOREACH (block, &statusline_sorted, blocks) {
-        width = predict_statusline_length(use_short_text);
+        width = predict_statusline_length();
         if (width < max_length) {
             break;
         } else if (block->short_text != NULL) {
-            *use_short_text++ = true;
+            block->use_short = true;
+            *used_short_text = true;
         }
     }
 
@@ -274,11 +275,10 @@ static void draw_statusline(i3_output *output, uint32_t clip_left, bool use_focu
     uint32_t x = 0 - clip_left;
 
     /* Draw the text of each block */
-    bool* use_short_text = output->statusline_short_text;
     TAILQ_FOREACH (block, &statusline_head, blocks) {
         i3String *text = block->full_text;
         struct status_block_render_desc *render = &block->full_render;
-        if (*use_short_text++ && block->short_text != NULL) {
+        if (block->use_short && block->short_text != NULL) {
             text = block->short_text;
             render = &block->short_render;
         }
@@ -480,11 +480,10 @@ static void child_handle_button(xcb_button_press_event_t *event, i3_output *outp
     /* x of the start of the current block relative to the statusline. */
     uint32_t last_block_x = 0;
     struct status_block *block;
-    bool* use_short_text = output->statusline_short_text;
     TAILQ_FOREACH (block, &statusline_head, blocks) {
         i3String *text;
         struct status_block_render_desc *render;
-        if (*use_short_text++ && block->short_text != NULL) {
+        if (block->use_short && block->short_text != NULL) {
             text = block->short_text;
             render = &block->short_render;
         } else {
@@ -2148,12 +2147,8 @@ void draw_bars(bool unhide) {
             uint32_t max_statusline_width = outputs_walk->rect.w - workspace_width - tray_width - hoff;
             uint32_t clip_left = 0;
 
-            extern size_t block_count;
-            if (outputs_walk->block_count < block_count) {
-                outputs_walk->statusline_short_text = srealloc(outputs_walk->statusline_short_text, block_count * sizeof(bool));
-                outputs_walk->block_count = block_count;
-            }
-            uint32_t statusline_width = adjust_statusline_length(outputs_walk->statusline_short_text, max_statusline_width);
+            bool used_short_text;
+            uint32_t statusline_width = adjust_statusline_length(&used_short_text, max_statusline_width);
 
             if (statusline_width > max_statusline_width) {
                 clip_left = statusline_width - max_statusline_width;
@@ -2168,6 +2163,7 @@ void draw_bars(bool unhide) {
                                    x_dest, 0, visible_statusline_width, (int16_t)bar_height);
 
             outputs_walk->statusline_width = statusline_width;
+            outputs_walk->statusline_short_text = used_short_text;
         }
     }
 

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -244,7 +244,7 @@ static uint32_t adjust_statusline_length(bool* use_short_text, uint32_t max_leng
     uint32_t width;
     struct status_block *block;
 
-    TAILQ_FOREACH (block, &statusline_head, blocks) {
+    TAILQ_FOREACH (block, &statusline_sorted, blocks) {
         width = predict_statusline_length(use_short_text);
         if (width < max_length) {
             break;

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -241,14 +241,20 @@ static uint32_t predict_statusline_length(void) {
 }
 
 static uint32_t adjust_statusline_length(bool* used_short_text, uint32_t max_length) {
-    uint32_t width;
+    uint32_t width = -1;
     struct status_block *block;
 
+    // Switch the blocks to short mode in order of their length priority
     TAILQ_FOREACH (block, &statusline_sorted, blocks) {
+        // If this block has no short form, there is no point in checking if we need to switch;
+        // however, we do have to compute the width at least once
+        if (block->short_text == NULL && width != -1) {
+            continue;
+        }
         width = predict_statusline_length();
         if (width < max_length) {
             break;
-        } else if (block->short_text != NULL) {
+        } else {
             block->use_short = true;
             *used_short_text = true;
         }

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -243,6 +243,9 @@ static uint32_t predict_statusline_length(void) {
 static uint32_t adjust_statusline_length(bool *used_short_text, uint32_t max_length) {
     uint32_t width = 0;
 
+    // Track the priority levels of shortened blocks
+    uint32_t min_shortened = UINT32_MAX;
+
     // Switch the blocks to short mode in order of their length priority
     size_t idx = 0;
     for (struct status_block **block = statusline_sorted; idx < block_count; idx++, block++) {
@@ -255,9 +258,26 @@ static uint32_t adjust_statusline_length(bool *used_short_text, uint32_t max_len
         if (width < max_length) {
             break;
         } else {
+            if ((*block)->length_priority < min_shortened) {
+                min_shortened = (*block)->length_priority;
+            }
             (*block)->use_short = true;
             *used_short_text = true;
         }
+    }
+
+    // Shorten all blocks with equal or lesser priority than a previously shortened block
+    // If no priorities are set, this is equivalent to an all-or-nothing approach to block shortening
+    idx = 0;
+    bool changed = false;
+    for (struct status_block **block = statusline_sorted; idx < block_count; idx++, block++) {
+        if ((*block)->length_priority >= min_shortened) {
+            changed = !(*block)->use_short;
+            (*block)->use_short = true;
+        }
+    }
+    if (changed) {
+        width = predict_statusline_length();
     }
 
     return width;

--- a/release-notes/changes/4-shrink-i3bar-blocks
+++ b/release-notes/changes/4-shrink-i3bar-blocks
@@ -1,0 +1,1 @@
+i3bar: use short-form text on a per-block basis


### PR DESCRIPTION
Closes #4113.

This is a prototype implementation of the feature described in #4113. Instead of a global "use short mode" flag, individual blocks can be shortened to fit the content of the status bar. The user can assign priority values to the blocks such that certain blocks are shrunk before others, i.e. prioritizing that certain other blocks retain their full length where possible.

When blocks are shrunk, all blocks of equal or higher priority[^1] are also shrunk. The default priority value is 0. This means that a config with no priority values results in the same behavior as before, i.e. either all blocks are shortened or none of them are.

The feature described in #4113 can be more faithfully implemented using the same strategy by assigning ascending priority values if none are provided by the user in the config. This behavior may be implemented either in `i3bar` itself, or in the bar generators.

This PR serves as a RFC of sorts such that the feature itself and its possible implementations can be discussed. Further cleanup and testing (and possibly optimizations) are required before any possibility of merging, but the idea is to provide a concrete implementation to discuss.

[^1]: This design choice is due to the fact that some bar generators do not create a single JSON object for each logical block, in order to provide features such as clickable icons in blocks. This implementation uses the priority value as a proxy for block names in order to identify logical blocks and ensure that the same logical block is either all in full form or all in short form, even if multiple JSON objects are output to represent the same block. An alternative is to use the `name` property, but this is optional at protocol level.