### PR TITLE
smart_borders: Deprecate option

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -789,6 +789,10 @@ The "smart_no_gaps" setting hides edge-specific borders of a container if the
 container is the only container on its workspace and the gaps to the screen edge
 are +0+.
 
+[[_smart_borders]]
++hide_edge_borders+ has replaced the old +smart_borders+ syntax. Use the former
+instead of the latter.
+
 *Syntax*:
 -----------------------------------------------
 hide_edge_borders none|vertical|horizontal|both|smart|smart_no_gaps
@@ -797,27 +801,6 @@ hide_edge_borders none|vertical|horizontal|both|smart|smart_no_gaps
 *Example*:
 ----------------------
 hide_edge_borders vertical
-----------------------
-
-[[_smart_borders]]
-=== Smart borders
-
-Smart borders will draw borders on windows only if there is more than one window
-in a workspace. This feature can also be enabled only if the gap size between
-window and screen edge is +0+.
-
-*Syntax*:
------------------------------------------------
-smart_borders on|off|no_gaps
------------------------------------------------
-
-*Example*:
-----------------------
-# Activate smart borders (always)
-smart_borders on
-
-# Activate smart borders (only when there are effectively no gaps)
-smart_borders no_gaps
 ----------------------
 
 [[for_window]]

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -272,9 +272,6 @@ struct Config {
     /* Gap sizes */
     gaps_t gaps;
 
-    /* Should single containers on a workspace receive a border? */
-    smart_borders_t smart_borders;
-
     /* Disable gaps if there is only one container on the workspace */
     smart_gaps_t smart_gaps;
 };

--- a/include/data.h
+++ b/include/data.h
@@ -81,10 +81,6 @@ typedef enum { ADJ_NONE = 0,
                ADJ_UPPER_SCREEN_EDGE = (1 << 2),
                ADJ_LOWER_SCREEN_EDGE = (1 << 4) } adjacent_t;
 
-typedef enum { SMART_BORDERS_OFF,
-               SMART_BORDERS_ON,
-               SMART_BORDERS_NO_GAPS } smart_borders_t;
-
 typedef enum { SMART_GAPS_OFF,
                SMART_GAPS_ON,
                SMART_GAPS_INVERSE_OUTER } smart_gaps_t;

--- a/release-notes/changes/3-deprecate-smart-borders
+++ b/release-notes/changes/3-deprecate-smart-borders
@@ -1,0 +1,1 @@
+deprecate smart_borders in favour of hide_edge_borders smart/smart_no_gaps

--- a/src/con.c
+++ b/src/con.c
@@ -1824,9 +1824,7 @@ bool con_draw_decoration_into_frame(Con *con) {
 }
 
 static Rect con_border_style_rect_without_title(Con *con) {
-    if ((config.smart_borders == SMART_BORDERS_ON && con_num_visible_children(con_get_workspace(con)) <= 1) ||
-        (config.smart_borders == SMART_BORDERS_NO_GAPS && !has_outer_gaps(calculate_effective_gaps(con))) ||
-        (config.hide_edge_borders == HEBM_SMART && con_num_visible_children(con_get_workspace(con)) <= 1) ||
+    if ((config.hide_edge_borders == HEBM_SMART && con_num_visible_children(con_get_workspace(con)) <= 1) ||
         (config.hide_edge_borders == HEBM_SMART_NO_GAPS && con_num_visible_children(con_get_workspace(con)) <= 1 && !has_outer_gaps(calculate_effective_gaps(con)))) {
         if (!con_is_floating(con)) {
             return (Rect){0, 0, 0, 0};

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -327,9 +327,15 @@ CFGFUN(gaps, const char *workspace, const char *scope, const long value) {
 
 CFGFUN(smart_borders, const char *enable) {
     if (!strcmp(enable, "no_gaps")) {
-        config.smart_borders = SMART_BORDERS_NO_GAPS;
-    } else {
-        config.smart_borders = boolstr(enable) ? SMART_BORDERS_ON : SMART_BORDERS_OFF;
+        config.hide_edge_borders = HEBM_SMART_NO_GAPS;
+    } else if (boolstr(enable)) {
+        if (config.hide_edge_borders == HEBM_NONE) {
+            /* Only enable this if hide_edge_borders is at the default value as it otherwise takes precedence */
+            config.hide_edge_borders = HEBM_SMART;
+        } else {
+            ELOG("Both hide_edge_borders and smart_borders was used. "
+                 "Ignoring smart_borders as it is deprecated.\n");
+        }
     }
 }
 
@@ -808,12 +814,12 @@ static void bar_configure_binding(const char *button, const char *release, const
 }
 
 CFGFUN(bar_wheel_up_cmd, const char *command) {
-    ELOG("'wheel_up_cmd' is deprecated. Please us 'bindsym button4 %s' instead.\n", command);
+    ELOG("'wheel_up_cmd' is deprecated. Please use 'bindsym button4 %s' instead.\n", command);
     bar_configure_binding("button4", NULL, command);
 }
 
 CFGFUN(bar_wheel_down_cmd, const char *command) {
-    ELOG("'wheel_down_cmd' is deprecated. Please us 'bindsym button5 %s' instead.\n", command);
+    ELOG("'wheel_down_cmd' is deprecated. Please use 'bindsym button5 %s' instead.\n", command);
     bar_configure_binding("button5", NULL, command);
 }
 


### PR DESCRIPTION
This had pretty much identical behaviour to hide_edge_borders which made it confusing. The `hide_edge_borders smart_no_gaps` implementation has an extra check which fixes #5406.