### PR TITLE
doc: update meson build instruction

### DIFF
--- a/docs/hacking-howto
+++ b/docs/hacking-howto
@@ -31,8 +31,6 @@ Guide → Compiling a Meson project]. In case you’re unfamiliar:
     mkdir -p build
     meson setup build
     meson compile -C build
-    meson install -C build
-
 
 === Build system features
 

--- a/docs/hacking-howto
+++ b/docs/hacking-howto
@@ -28,9 +28,11 @@ https://mesonbuild.com/[The Meson Build system]; see
 https://mesonbuild.com/Quick-guide.html#compiling-a-meson-project[Quickstart
 Guide → Compiling a Meson project]. In case you’re unfamiliar:
 
-    $ mkdir -p build && cd build
-    $ meson ..
-    $ ninja
+    mkdir -p build
+    meson setup build
+    meson compile -C build
+    meson install -C build
+
 
 === Build system features
 


### PR DESCRIPTION
The [official build instruction][1] are deprecated on Meson 1.3.1.
These command:

    mkdir -p build && cd build
    meson ..
    ninja

... work but will yield the following warning:

> WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.

Here's the correct way, according to the [meson documentation][2]:

    mkdir -p build
    meson setup build
    meson compile -C build
    meson install -C build


[1]: https://i3wm.org/docs/hacking-howto.html#_building_i3
[2]: https://mesonbuild.com/Quick-guide.html#compiling-a-meson-project
