### PR TITLE
Reap zombie children on i3 start

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1220,6 +1220,17 @@ int main(int argc, char *argv[]) {
      * when calling exit() */
     atexit(i3_exit);
 
+    /* There might be children who died before we initialized the event loop,
+     * e.g., when restarting i3 (see #5756).
+     * To not carry zombie children around, raise the signal to invite libev to
+     * reap them.
+     *
+     * Note that there is no race condition between raising the signal below and
+     * entering the event loop later: the signal is just to notify libev that
+     * zombies might already be there. Actuall reaping will take place in the
+     * event loop anyway. */
+    (void)raise(SIGCHLD);
+
     sd_notify(1, "READY=1");
     ev_loop(main_loop, 0);
 


### PR DESCRIPTION
One case when this might be useful is when i3 is restarted and there are children that terminate after the previous i3 instance shut down but before the new one set things up.

Fixes #5756