### PR TITLE
Bugfix posix signals

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -252,7 +252,7 @@ static void setup_term_handlers(void) {
     ev_signal_init(&signal_watchers[2], handle_term_signal, SIGALRM);
     ev_signal_init(&signal_watchers[3], handle_term_signal, SIGTERM);
     ev_signal_init(&signal_watchers[4], handle_term_signal, SIGUSR1);
-    ev_signal_init(&signal_watchers[5], handle_term_signal, SIGUSR1);
+    ev_signal_init(&signal_watchers[5], handle_term_signal, SIGUSR2);
     for (size_t i = 0; i < num_watchers; i++) {
         ev_signal_start(main_loop, &signal_watchers[i]);
         /* The signal handlers should not block ev_run from returning

--- a/src/main.c
+++ b/src/main.c
@@ -239,7 +239,7 @@ static void handle_term_signal(struct ev_loop *loop, ev_signal *signal, int reve
  */
 static void setup_term_handlers(void) {
     static struct ev_signal signal_watchers[6];
-    size_t num_watchers = sizeof(signal_watchers) / sizeof(signal_watchers[0]);
+    const size_t num_watchers = sizeof(signal_watchers) / sizeof(signal_watchers[0]);
 
     /* We have to rely on libev functionality here and should not use
      * sigaction handlers because we need to invoke the exit handlers


### PR DESCRIPTION
Since there is no separate error handling the `SIGUSR2` signal is registered to get the write return code after exiting the program.

Additionally, the `num_watchers` variable is made const since it depends on a fixed array size and should not be modifyable after creation. Optimization can also benefit from const value.

Fixes #5958 