### PR TITLE
Check if subscribe event type is supported in AnyEvent::I3

### DIFF
--- a/AnyEvent-I3/lib/AnyEvent/I3.pm
+++ b/AnyEvent-I3/lib/AnyEvent/I3.pm
@@ -315,6 +315,11 @@ sub subscribe {
 
     # Register callbacks for each message type
     for my $key (keys %{$callbacks}) {
+        if (!exists $events{$key}) {
+            warn "Could not subscribe to event type '$key'." .
+            " Supported events are " . join(" ", sort keys %events), $/;
+            next;
+        }
         my $type = $events{$key};
         $self->{callbacks}->{$type} = $callbacks->{$key};
     }


### PR DESCRIPTION
Add simple `if exists' construct in the subscribe function. This prevents a somewhat cryptic warnings such as these:

Use of uninitialized value $type in hash element at /usr/share/perl5/AnyEvent/I3.pm line 309.

We still warn the user, but it is much clearer as to what the cause is.

It now shows something like this:

Could not subscribe to event type 'foo'. Supported events are _error barconfig_update binding mode output shutdown tick window workspace