### PR TITLE
AnyEvent::I3: rip out taint mode compatibility

### DIFF
--- a/AnyEvent-I3/t/00-load.t
+++ b/AnyEvent-I3/t/00-load.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl
 
 use Test::More tests => 1;
 

--- a/AnyEvent-I3/t/01-workspaces.t
+++ b/AnyEvent-I3/t/01-workspaces.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl
 # vim:ts=4:sw=4:expandtab
 
 use Test::More tests => 3;

--- a/AnyEvent-I3/t/02-sugar.t
+++ b/AnyEvent-I3/t/02-sugar.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl
 # vim:ts=4:sw=4:expandtab
 
 use Test::More tests => 3;

--- a/AnyEvent-I3/t/boilerplate.t
+++ b/AnyEvent-I3/t/boilerplate.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl
 
 use strict;
 use warnings;

--- a/AnyEvent-I3/t/manifest.t
+++ b/AnyEvent-I3/t/manifest.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl
 
 use strict;
 use warnings;

--- a/AnyEvent-I3/t/pod.t
+++ b/AnyEvent-I3/t/pod.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
I suspect nobody actually uses Perl’s taint mode with AnyEvent::I3.

See https://github.com/i3/i3/pull/5987 for discussion.