### PR TITLE
Remove pledge() support for OpenBSD

### DIFF
--- a/i3-msg/main.c
+++ b/i3-msg/main.c
@@ -148,11 +148,6 @@ static yajl_callbacks config_callbacks = {
 };
 
 int main(int argc, char *argv[]) {
-#if defined(__OpenBSD__)
-    if (pledge("stdio rpath unix", NULL) == -1) {
-        err(EXIT_FAILURE, "pledge");
-    }
-#endif
     char *socket_path = NULL;
     int o, option_index = 0;
     uint32_t message_type = I3_IPC_MESSAGE_TYPE_RUN_COMMAND;

--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -513,12 +513,6 @@ int main(int argc, char *argv[]) {
     font = load_font(pattern, true);
     set_font(&font);
 
-#if defined(__OpenBSD__)
-    if (pledge("stdio rpath wpath cpath getpw proc exec", NULL) == -1) {
-        err(EXIT_FAILURE, "pledge");
-    }
-#endif
-
     /* Default values if we cannot determine the preferred window position. */
     xcb_rectangle_t win_pos = (xcb_rectangle_t){50, 50, 500, font.height + 2 * MSG_PADDING + BAR_BORDER};
     if (position_on_primary) {

--- a/src/main.c
+++ b/src/main.c
@@ -1147,12 +1147,6 @@ int main(int argc, char *argv[]) {
         }
     }
 
-#if defined(__OpenBSD__)
-    if (pledge("stdio rpath wpath cpath proc exec unix", NULL) == -1) {
-        err(EXIT_FAILURE, "pledge");
-    }
-#endif
-
     if (!disable_signalhandler) {
         setup_signal_handler();
     } else {


### PR DESCRIPTION
While this initially worked fine, at some point these patches broke because libcairo started calling shmget(2) - a syscall not covered by any pledge promise - and a common pitfall when using pledge with graphics-oriented applications.

Various attempts were made to fix them, but at some time they were simply disabled in the OpenBSD port:

https://github.com/openbsd/ports/commit/a4a9f41dd79f8e9db6d58fb946d2a0c7151cde00 https://github.com/openbsd/ports/commit/5a03c386bab19dcc8e8d7a618693d557840068d1

This seems pointless and creates needless friction both for the i3 team who was willing to carry ugly code and for the OpenBSD ports maintainers who had to disable that code again.

Let's abandon this experiment.