### PR TITLE
Fix size_t format specifiers on 32 bit systems

### DIFF
--- a/i3-input/main.c
+++ b/i3-input/main.c
@@ -170,7 +170,7 @@ static void finish_input(void) {
             cnt++;
         }
     }
-    printf("occurrences = %ld\n", cnt);
+    printf("occurrences = %zu\n", cnt);
 
     /* allocate space for the output */
     const size_t input_len = strlen(command);

--- a/src/regex.c
+++ b/src/regex.c
@@ -32,8 +32,8 @@ struct regex *regex_new(const char *pattern) {
     if (!(re->regex = pcre2_compile((PCRE2_SPTR)pattern, PCRE2_ZERO_TERMINATED, options, &errorcode, &offset, NULL))) {
         PCRE2_UCHAR buffer[256];
         pcre2_get_error_message(errorcode, buffer, sizeof(buffer));
-        ELOG("PCRE regular expression compilation failed at %lu: %s\n",
-             offset, buffer);
+        ELOG("PCRE regular expression compilation failed at %zu: %s\n",
+             (size_t)offset, buffer);
         regex_free(re);
         return NULL;
     }


### PR DESCRIPTION
This fixes the following warnings on 32 bit systems

```
[60/108] Compiling C object i3.p/src_regex.c.o
In file included from ../include/all.h:40,
                 from ../src/regex.c:10:
../src/regex.c: In function ‘regex_new’:
../include/log.h:29:33: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
   29 | #define ELOG(fmt, ...) errorlog("ERROR: " fmt, ##__VA_ARGS__)
      |                                 ^~~~~~~~~
../src/regex.c:35:9: note: in expansion of macro ‘ELOG’
   35 |         ELOG("PCRE regular expression compilation failed at %lu: %s\n",
      |         ^~~~
[93/108] Compiling C object i3-input.p/i3-input_main.c.o
../i3-input/main.c: In function ‘finish_input’:
../i3-input/main.c:173:29: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 2 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
  173 |     printf("occurrences = %ld\n", cnt);
      |                           ~~^     ~~~
      |                             |     |
      |                             |     size_t {aka unsigned int}
      |                             long int
      |                           %d 
```