### PR TITLE
 complete-run.pl: Un-set I3SOCK

### DIFF
--- a/testcases/complete-run.pl.in
+++ b/testcases/complete-run.pl.in
@@ -106,6 +106,8 @@ $ENV{PATH} = join(':',
     '@abs_top_builddir@',
     '@abs_top_srcdir@',
     $ENV{PATH});
+# Make sure we don't re-use the existing (developer's) i3 connection
+delete $ENV{I3SOCK};
 
 qx(Xephyr -help 2>&1);
 die "Xephyr was not found in your path. Please install Xephyr (xserver-xephyr on Debian)." if $?;


### PR DESCRIPTION
This causes test breakage when the developer/tester is running the tests in i3, as the actual active instance socket is used instead of the test instance.

Besides breaking tests, this is quite dangerous as tests like 319-gaps.t will replace the **actual** config of the user (i.e. ~/.config/i3/config) instead of the current test config.

Broken after #5987