### PR TITLE
Fix crash when reloading config with invalid criteria

### DIFF
--- a/release-notes/bugfixes/5-reload-match-criteria
+++ b/release-notes/bugfixes/5-reload-match-criteria
@@ -1,0 +1,1 @@
+fix crash when reloading config with invalid criteria

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -231,6 +231,10 @@ CFGFUN(exec, const char *exectype, const char *no_startup_id, const char *comman
 }
 
 CFGFUN(for_window, const char *command) {
+    if (current_match->error != NULL) {
+        ELOG("match has error: %s\n", current_match->error);
+        return;
+    }
     if (match_is_empty(current_match)) {
         ELOG("Match is empty, ignoring this for_window statement\n");
         return;
@@ -631,6 +635,10 @@ CFGFUN(color, const char *colorclass, const char *border, const char *background
 }
 
 CFGFUN(assign_output, const char *output) {
+    if (current_match->error != NULL) {
+        ELOG("match has error: %s\n", current_match->error);
+        return;
+    }
     if (match_is_empty(current_match)) {
         ELOG("Match is empty, ignoring this assignment\n");
         return;
@@ -650,6 +658,10 @@ CFGFUN(assign_output, const char *output) {
 }
 
 CFGFUN(assign, const char *workspace, bool is_number) {
+    if (current_match->error != NULL) {
+        ELOG("match has error: %s\n", current_match->error);
+        return;
+    }
     if (match_is_empty(current_match)) {
         ELOG("Match is empty, ignoring this assignment\n");
         return;
@@ -674,6 +686,10 @@ CFGFUN(assign, const char *workspace, bool is_number) {
 }
 
 CFGFUN(no_focus) {
+    if (current_match->error != NULL) {
+        ELOG("match has error: %s\n", current_match->error);
+        return;
+    }
     if (match_is_empty(current_match)) {
         ELOG("Match is empty, ignoring this assignment\n");
         return;

--- a/testcases/t/322-match-error-crash.t
+++ b/testcases/t/322-match-error-crash.t
@@ -1,0 +1,34 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • https://i3wm.org/downloads/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Verify i3 does not crash when reloading configuration with invalid match
+# criteria.
+# Ticket: #6141
+# Bug still in: 4.23-47-gbe840af4
+use i3test i3_config => <<EOT;
+# i3 config file (v4)
+assign [class="class" window_type="some_type"] workspace 1
+assign [class="class" window_type="some_type"] output 1
+for_window [class="class" window_type="some_type"] workspace 1
+no_focus [class="class" window_type="some_type"] workspace 1
+EOT
+
+does_i3_live;
+
+cmd 'reload';
+does_i3_live;
+
+done_testing;


### PR DESCRIPTION
Came up in https://github.com/i3/i3/discussions/6141