### PR TITLE
GitHub Actions: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 -e CC ${{ env.BASENAME }} ./travis/run-tests.sh
     - name: Archive test logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test-logs
         path: build/testsuite-*

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -1515,7 +1515,9 @@ static void send_tray_clientmessage(void) {
 static void init_tray(void) {
     DLOG("Initializing system tray functionality\n");
     /* request the tray manager atom for the X11 display we are running on */
-    char atomname[strlen("_NET_SYSTEM_TRAY_S") + 11];
+    /* The following line cannot use strlen as that makes compilation fail with
+     * some versions of clang (-Wgnu-folding-constant): */
+    char atomname[18 /* strlen("_NET_SYSTEM_TRAY_S") */ + 11];
     snprintf(atomname, strlen("_NET_SYSTEM_TRAY_S") + 11, "_NET_SYSTEM_TRAY_S%d", screen);
     xcb_intern_atom_cookie_t tray_cookie;
     if (tray_reply == NULL) {


### PR DESCRIPTION
The older versions are now deprecated and result in failing GitHub Actions runs.