### PR TITLE
Fix paragraph separators cutting off titles

### DIFF
--- a/libi3/font.c
+++ b/libi3/font.c
@@ -95,6 +95,7 @@ static void draw_text_pango(const char *text, size_t text_len,
     pango_layout_set_width(layout, max_width * PANGO_SCALE);
     pango_layout_set_wrap(layout, PANGO_WRAP_CHAR);
     pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
+    pango_layout_set_single_paragraph_mode(layout, true);
 
     if (pango_markup) {
         pango_layout_set_markup(layout, text, text_len);

--- a/release-notes/bugfixes/6337-paragraph-separators-cutting-off-titles
+++ b/release-notes/bugfixes/6337-paragraph-separators-cutting-off-titles
@@ -1,0 +1,1 @@
+fix paragraph separators cutting off titles


### PR DESCRIPTION
Pango has the option to render paragraph separators and other special characters as glyphs, which fixes the cutting off described in #5391.

https://docs.gtk.org/Pango/method.Layout.set_single_paragraph_mode.html