### PR TITLE
Update meson setup command to remove warning

### DIFF
--- a/PACKAGE-MAINTAINER
+++ b/PACKAGE-MAINTAINER
@@ -27,7 +27,7 @@ https://mesonbuild.com/Quick-guide.html#compiling-a-meson-project
 In case you’re unfamiliar:
 
     $ mkdir -p build && cd build
-    $ meson ..
+    $ meson setup
     $ ninja
 
 Please make sure that i3-migrate-config-to-v4 and i3-config-wizard are

--- a/meson/meson-dist-script
+++ b/meson/meson-dist-script
@@ -28,7 +28,7 @@ rm -rf \
 
 mkdir build
 cd build
-meson .. -Dprefix=/usr -Ddocs=true -Dmans=true
+meson setup -Dprefix=/usr -Ddocs=true -Dmans=true
 ninja
 cp *.1 ../man/
 cp *.html ../docs/

--- a/release.sh
+++ b/release.sh
@@ -67,7 +67,7 @@ git commit -a -m "release i3 ${RELEASE_VERSION}"
 git tag "${RELEASE_VERSION}" -m "release i3 ${RELEASE_VERSION}" --sign --local-user=0x4AC8EE1D
 
 mkdir build
-(cd build && meson .. && ninja dist)
+(cd build && meson setup && ninja dist)
 cp build/meson-dist/i3-${RELEASE_VERSION}.tar.xz .
 
 echo "Differences in the release tarball file lists:"


### PR DESCRIPTION
This is a very easy fix, to remove the following warning:
```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```
The fix is to just run `meson setup` instead and it works like a charm.

Related PRs: i3/i3lock#365 and i3/i3status#538.