### PR TITLE
Fix typos via codespell

### DIFF
--- a/docs/ipc
+++ b/docs/ipc
@@ -24,7 +24,7 @@ will print the path to the standard output (plus a newline) or by reading the
 +I3SOCK+ environmental variable.
 
 All i3 utilities, like +i3-msg+ and +i3-input+ will determine the path of the
-IPC socket frome the +I3SOCK+ environmental variable if it is set or the
+IPC socket from the +I3SOCK+ environmental variable if it is set or the
 +I3_SOCKET_PATH+ X11 property, stored on the X11 root window.
 
 [WARNING]

--- a/docs/userguide
+++ b/docs/userguide
@@ -1427,7 +1427,7 @@ The default is +modifier+.
 Since i3 4.24, you can configure a modifier key which, when pressed, will swap
 instead of moving containers when dropping directly onto another container.
 Defaults to +Shift+. Note that you have to be pressing both the floating
-modifer and the swap modifier before the drag is initiated.
+modifier and the swap modifier before the drag is initiated.
 
 *Syntax*:
 --------------------------------

--- a/src/commands.c
+++ b/src/commands.c
@@ -1802,7 +1802,7 @@ void cmd_focus_output(I3_CMD, const char *name) {
         return;
     }
 
-    /* Command critiera need to work for focus output left|right|up|down.
+    /* Command criteria need to work for focus output left|right|up|down.
      * We need to avoid using internal workspaces with get_output_for_con, so
      * we go through all matched windows until we find a non-internal one. If
      * there is no match, fall back to the focused one. */

--- a/src/main.c
+++ b/src/main.c
@@ -1221,7 +1221,7 @@ int main(int argc, char *argv[]) {
      *
      * Note that there is no race condition between raising the signal below and
      * entering the event loop later: the signal is just to notify libev that
-     * zombies might already be there. Actuall reaping will take place in the
+     * zombies might already be there. Actual reaping will take place in the
      * event loop anyway. */
     (void)raise(SIGCHLD);
 

--- a/src/x.c
+++ b/src/x.c
@@ -1114,7 +1114,7 @@ void x_push_node(Con *con) {
         fake_notify = true;
     }
 
-    /* dito, but for child windows */
+    /* ditto, but for child windows */
     if (con->window != NULL &&
         !rect_equals(state->window_rect, con->window_rect)) {
         DLOG("setting window rect (%d, %d, %d, %d)\n",

--- a/testcases/complete-run.pl.in
+++ b/testcases/complete-run.pl.in
@@ -379,7 +379,7 @@ sub take_job {
             }
 
             # count lines before stripping eof-marker otherwise we might
-            # end up with for (1 .. 0) { } which would effectivly skip the loop
+            # end up with for (1 .. 0) { } which would effectively skip the loop
             my $lines = $buf =~ tr/\n//;
             my $t_eof = $buf =~ s/^$TestWorker::EOF$//m;
 

--- a/testcases/t/210-mark-unmark.t
+++ b/testcases/t/210-mark-unmark.t
@@ -140,7 +140,7 @@ cmd 'focus left';
 cmd 'mark --toggle important';
 
 is_deeply(get_mark_for_window_on_workspace($tmp, $first), [ 'important' ], 'left container has the mark now');
-is_deeply(get_mark_for_window_on_workspace($tmp, $second), [], 'second containr no longer has the mark');
+is_deeply(get_mark_for_window_on_workspace($tmp, $second), [], 'second container no longer has the mark');
 
 ##############################################################
 # 9: try to mark two cons with the same mark and check that
@@ -155,7 +155,7 @@ my $result = cmd "[instance=iamnotunique] mark important";
 is($result->[0]->{success}, 0, 'command was unsuccessful');
 is($result->[0]->{error}, 'A mark must not be put onto more than one window', 'correct error is returned');
 is_deeply(get_mark_for_window_on_workspace($tmp, $first), [], 'first container is not marked');
-is_deeply(get_mark_for_window_on_workspace($tmp, $second), [], 'second containr is not marked');
+is_deeply(get_mark_for_window_on_workspace($tmp, $second), [], 'second container is not marked');
 
 ##############################################################
 

--- a/testcases/t/238-ipc-binding-event.t
+++ b/testcases/t/238-ipc-binding-event.t
@@ -87,7 +87,7 @@ SKIP: {
 	'binding');
     is(scalar @events, 3, 'Received 3 events');
 
-    is($events[0]->{mode}, 'default', 'Event for binding to enter new mode is atributed to default mode');
+    is($events[0]->{mode}, 'default', 'Event for binding to enter new mode is attributed to default mode');
     is($events[1]->{mode}, 'some-mode', 'Event for binding while in mode is attributed to the non-default mode');
     is($events[2]->{mode}, 'some-mode', 'Event for binding exiting mode is attributed to the non-default mode');
 

--- a/testcases/t/316-drag-container.t
+++ b/testcases/t/316-drag-container.t
@@ -91,7 +91,7 @@ is($ws2, focused_ws, 'Empty workspace focused after floating window dragged to i
 # Drag tiling container onto an empty workspace.
 ###############################################################################
 
-subtest "Draging tiling container onto an empty workspace produces move event", \&move_subtest,
+subtest "Dragging tiling container onto an empty workspace produces move event", \&move_subtest,
 sub {
 
 $ws2 = fresh_workspace(output => 1);
@@ -155,7 +155,7 @@ is(@{get_ws_content($ws1)}, 1, 'One container left in ws1');
 # Drag tiling container onto a tiling container on an other workspace.
 ###############################################################################
 
-subtest "Draging tiling container onto a tiling container on an other workspace produces move event", \&move_subtest,
+subtest "Dragging tiling container onto a tiling container on an other workspace produces move event", \&move_subtest,
 sub {
 
 $ws2 = fresh_workspace(output => 1);
@@ -205,7 +205,7 @@ is($ws1->{focus}[0], $B_id, 'B now in first workspace');
 # Drag tiling container onto a floating container on an other workspace.
 ###############################################################################
 
-subtest "Draging tiling container onto a floating container on an other workspace produces move event", \&move_subtest,
+subtest "Dragging tiling container onto a floating container on an other workspace produces move event", \&move_subtest,
 sub {
 
 $ws2 = fresh_workspace(output => 1);
@@ -229,7 +229,7 @@ is($ws2->{floating_nodes}[0]->{nodes}[0]->{id}, $B_id, 'B exists & floating');
 # Drag tiling container onto a bar.
 ###############################################################################
 
-subtest "Draging tiling container onto a bar produces move event", \&move_subtest,
+subtest "Dragging tiling container onto a bar produces move event", \&move_subtest,
 sub {
 
 $ws1 = fresh_workspace(output => 0);
@@ -270,7 +270,7 @@ is($ws1->{focus}[1], $A_id, 'A focused second, unfocused dragged container didn\
 # Drag an unfocused tiling container onto an occupied workspace.
 ###############################################################################
 
-subtest "Draging unfocused tiling container onto an occupied workspace produces move event", \&move_subtest,
+subtest "Dragging unfocused tiling container onto an occupied workspace produces move event", \&move_subtest,
 sub {
 
 $ws1 = fresh_workspace(output => 0);
@@ -310,7 +310,7 @@ is($x->input_focus, $A->id, 'Fullscreen container still focused');
 # Drag unfocused fullscreen container onto window in other workspace.
 ###############################################################################
 
-subtest "Draging unfocused fullscreen container onto window in other workspace produces move event", \&move_subtest,
+subtest "Dragging unfocused fullscreen container onto window in other workspace produces move event", \&move_subtest,
 sub {
 
 $ws1 = fresh_workspace(output => 0);
@@ -333,13 +333,13 @@ is($ws2->{nodes}->[0]->{window}, $A->id, 'Fullscreen container now leftmost wind
 };
 
 ###############################################################################
-# Drag unfocused fullscreen container onto left outter region of window in
+# Drag unfocused fullscreen container onto left outer region of window in
 # other workspace. The container shouldn't end up in $ws2 because it was
-# dragged onto the outter region of the leftmost window. We must also check
+# dragged onto the outer region of the leftmost window. We must also check
 # that the focus remains on the other window.
 ###############################################################################
 
-subtest "Draging unfocused fullscreen container onto left outter region of window in other workspace produces move event", \&move_subtest,
+subtest "Dragging unfocused fullscreen container onto left outer region of window in other workspace produces move event", \&move_subtest,
 sub {
 
 $ws1 = fresh_workspace(output => 0);
@@ -351,7 +351,7 @@ $ws2 = fresh_workspace(output => 1);
 $B = open_window;
 
 start_drag(990, 100);  # rightmost of $ws1
-end_drag(1004, 100);  # outter region of window of $ws2
+end_drag(1004, 100);  # outer region of window of $ws2
 
 is($ws2, focused_ws, 'Workspace still focused after dragging fullscreen container to it');
 is_num_fullscreen($ws1, 1, 'Fullscreen container still in first workspace');

--- a/testcases/t/524-move.t
+++ b/testcases/t/524-move.t
@@ -69,7 +69,7 @@ cmd '[class="first"] move down';
 is_num_children('right-top', 0, 'no children on right-top');
 is_num_children('right-bottom', 2, 'two children on right-bottom');
 
-# Move the second windo onto the lower left workspace.
+# Move the second window onto the lower left workspace.
 cmd '[class="second"] move left, move left';
 is_num_children('right-bottom', 1, 'one child on right-bottom');
 is_num_children('left-bottom', 1, 'one on left-bottom');


### PR DESCRIPTION
There are some typos in the documentation, messages, etc.
Fix them via codespell.