### PR TITLE
Fix AdressSanitizer failures in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         docker pull ${{ env.BASENAME_UBUNTU }} || ./travis/docker-build-and-push.sh ${{ env.BASENAME_UBUNTU }} travis/travis-base-ubuntu.Dockerfile
     - name: build i3
       run: |
-        docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 -e CC ${{ env.BASENAME }} /bin/sh -c 'rm -rf build; mkdir -p build && cd build && CFLAGS="-Wformat -Wformat-security -Wextra -Wno-unused-parameter -Wstrict-prototypes -Wmissing-prototypes -Werror -fno-common -D_FORTIFY_SOURCE=3" meson setup .. -Ddocs=true -Dmans=true -Db_sanitize=address --buildtype=debugoptimized && ninja -v'
+        docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 -e CC ${{ env.BASENAME }} /bin/sh -c 'rm -rf build; mkdir -p build && cd build && CFLAGS="-Wformat -Wformat-security -Wextra -Wno-unused-parameter -Wstrict-prototypes -Wmissing-prototypes -Werror -fno-common -D_FORTIFY_SOURCE=3" meson setup .. -Ddocs=true -Dmans=true -Db_sanitize='address,undefined' --buildtype=debugoptimized && ninja -v'
     - name: Upload docs html for manual inspection
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         docker pull ${{ env.BASENAME_UBUNTU }} || ./travis/docker-build-and-push.sh ${{ env.BASENAME_UBUNTU }} travis/travis-base-ubuntu.Dockerfile
     - name: build i3
       run: |
-        docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 -e CC ${{ env.BASENAME }} /bin/sh -c 'rm -rf build; mkdir -p build && cd build && CFLAGS="-Wformat -Wformat-security -Wextra -Wno-unused-parameter -Wstrict-prototypes -Wmissing-prototypes -Werror -fno-common -D_FORTIFY_SOURCE=3" meson setup .. -Ddocs=true -Dmans=true -Db_sanitize='address,undefined' --buildtype=debugoptimized && ninja -v'
+        docker run -v $PWD:/usr/src/i3/ -w /usr/src/i3 -e CC ${{ env.BASENAME }} /bin/sh -c 'rm -rf build; mkdir -p build && cd build && CFLAGS="-Wformat -Wformat-security -Wextra -Wno-unused-parameter -Wstrict-prototypes -Wmissing-prototypes -Werror -fno-common -D_FORTIFY_SOURCE=3" meson setup .. -Ddocs=true -Dmans=true -Db_sanitize="address,undefined" --buildtype=debugoptimized && ninja -v'
     - name: Upload docs html for manual inspection
       uses: actions/upload-artifact@v4
       with:

--- a/libi3/get_colorpixel.c
+++ b/libi3/get_colorpixel.c
@@ -50,7 +50,7 @@ uint32_t get_colorpixel(const char *hex) {
 
     /* Shortcut: if our screen is true color, no need to do a roundtrip to X11 */
     if (root_screen == NULL || root_screen->root_depth == 24 || root_screen->root_depth == 32) {
-        return (a << 24) | (r << 16 | g << 8 | b);
+        return ((uint32_t)a << 24) | ((uint32_t)r << 16) | ((uint32_t)g << 8) | b;
     }
 
     /* Lookup this colorpixel in the cache */

--- a/src/commands.c
+++ b/src/commands.c
@@ -1178,19 +1178,18 @@ void cmd_move_con_to_mark(I3_CMD, const char *mark) {
  *
  */
 void cmd_floating(I3_CMD, const char *floating_mode) {
-    owindow *current;
-
+    assert(floating_mode != NULL); /* Compiler complains */
     DLOG("floating_mode=%s\n", floating_mode);
 
     HANDLE_EMPTY_MATCH;
 
+    owindow *current;
     TAILQ_FOREACH (current, &owindows, owindows) {
         DLOG("matching: %p / %s\n", current->con, current->con->name);
         if (strcmp(floating_mode, "toggle") == 0) {
             DLOG("should toggle mode\n");
             toggle_floating_mode(current->con, false);
         } else {
-            assert(floating_mode != NULL); /* Compiler complains */
             DLOG("should switch mode to %s\n", floating_mode);
             if (strcmp(floating_mode, "enable") == 0) {
                 floating_enable(current->con, false);

--- a/src/commands.c
+++ b/src/commands.c
@@ -1190,6 +1190,7 @@ void cmd_floating(I3_CMD, const char *floating_mode) {
             DLOG("should toggle mode\n");
             toggle_floating_mode(current->con, false);
         } else {
+            assert(floating_mode != NULL); /* Compiler complains */
             DLOG("should switch mode to %s\n", floating_mode);
             if (strcmp(floating_mode, "enable") == 0) {
                 floating_enable(current->con, false);

--- a/src/x.c
+++ b/src/x.c
@@ -624,7 +624,7 @@ void x_draw_decoration(Con *con) {
 
     /* if this is a borderless/1pixel window, we don’t need to render the
      * decoration. */
-    if (p->border_style != BS_NORMAL) {
+    if (p->border_style != BS_NORMAL || con->deco_rect.width == 0 || con->deco_rect.height == 0) {
         goto copy_pixmaps;
     }
 

--- a/travis/run-tests.sh
+++ b/travis/run-tests.sh
@@ -1,28 +1,8 @@
 #!/bin/sh
 
-set -e
-set -x
+set -euxo pipefail
 
 cd build
-
-# TODO: remove this workaround once https://bugs.debian.org/836723 is fixed
-# Found at https://llvm.org/bugs/show_bug.cgi?id=27310#c8:
-if [ "$CC" = "clang" ]
-then
-	cat >fixasan.c <<EOT
-void __isoc99_printf() {}
-void __isoc99_sprintf() {}
-void __isoc99_snprintf() {}
-void __isoc99_fprintf() {}
-void __isoc99_vprintf() {}
-void __isoc99_vsprintf() {}
-void __isoc99_vsnprintf() {}
-void __isoc99_vfprintf() {}
-void __cxa_throw() {} // NEW
-EOT
-	gcc fixasan.c -o fixasan.so -fPIC -shared -nostdlib
-	export LD_PRELOAD=$PWD/fixasan.so
-fi
 
 # Try running the tests in parallel so that the common case (tests pass) is
 # quick, but fall back to running them in sequence to make debugging easier.

--- a/travis/travis-base-ubuntu.Dockerfile
+++ b/travis/travis-base-ubuntu.Dockerfile
@@ -1,7 +1,7 @@
 # vim:ft=Dockerfile
 # Same as travis-base.Dockerfile, but without the test suite dependencies since
 # we only build Debian packages on Ubuntu, we don’t run the tests.
-FROM ubuntu:jammy
+FROM ubuntu:24.04
 
 RUN echo force-unsafe-io > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup
 # Paper over occasional network flakiness of some mirrors.


### PR DESCRIPTION
Example in https://github.com/i3/i3/actions/runs/18260895234/job/51988635887?pr=6502
`i3-log-for-124-move.t`:
```
../libi3/font.c:332:9: runtime error: signed integer overflow: 2147483641 + 11 cannot be represented in type 'int'
    #0 0x5611ce962d65 in draw_text_xcb ../libi3/font.c:332
    #1 0x5611ce962d65 in draw_text ../libi3/font.c:376
    #2 0x5611ce95de20 in draw_util_text ../libi3/draw_util.c:219
    #3 0x5611ce947e7a in x_draw_decoration ../src/x.c:751
    #4 0x5611ce94f93a in x_push_node ../src/x.c:1097
    #5 0x5611ce94e9d8 in x_push_node ../src/x.c:1204
    #6 0x5611ce94e9d8 in x_push_node ../src/x.c:1204
    #7 0x5611ce94e9d8 in x_push_node ../src/x.c:1204
    #8 0x5611ce952e9b in x_push_changes ../src/x.c:1373
    #9 0x5611ce922d1f in tree_render ../src/tree.c:468
    #10 0x5611ce8d1bbb in handle_run_command ../src/ipc.c:220
    #11 0x5611ce8c87fe in ipc_receive_message ../src/ipc.c:1481
    #12 0x7effc262b64a in ev_invoke_pending (/lib/x86_64-linux-gnu/libev.so.4+0x564a) (BuildId: cfcffb10ff16734dcc7d31d002a90940abff0323)
    #13 0x7effc262f22e in ev_run (/lib/x86_64-linux-gnu/libev.so.4+0x922e) (BuildId: cfcffb10ff16734dcc7d31d002a90940abff0323)
    #14 0x5611ce809d48 in ev_loop /usr/include/ev.h:841
    #15 0x5611ce809d48 in main ../src/main.c:1229
    #16 0x7effc1e41ca7  (/lib/x86_64-linux-gnu/libc.so.6+0x29ca7) (BuildId: def5460e3cee00bfee25b429c97bcc4853e5b3a8)
    #17 0x7effc1e41d64 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29d64) (BuildId: def5460e3cee00bfee25b429c97bcc4853e5b3a8)
    #18 0x5611ce80e770 in _start (/usr/src/i3/build/i3+0x230770) (BuildId: 181abde9a3dd28a8a4be68b90b9b710c8e280633)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../libi3/font.c:332:9 
```

Unrelated but I fixed the build fails in `next` because of a false-positive:
```
In file included from ../include/all.h:40,
                 from ../src/commands.c:10:
../src/commands.c: In function ‘cmd_floating’:
../include/log.h:30:33: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
   30 | #define DLOG(fmt, ...) debuglog("%s:%s:%d - " fmt, __FILE__, __FUNCTION__, __LINE__, ##__VA_ARGS__)
      |                                 ^~~~~~~~~~~~~
../src/commands.c:1193:13: note: in expansion of macro ‘DLOG’
 1193 |             DLOG("should switch mode to %s\n", floating_mode);
      |             ^~~~
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```