### PR TITLE
tiling_drag: Fix crash when performing tree_move

### DIFF
--- a/release-notes/bugfixes/10-tiling-drag-focused-parent
+++ b/release-notes/bugfixes/10-tiling-drag-focused-parent
@@ -1,0 +1,1 @@
+fix crash when a container parent is focused and a tiling drag causes it to be killed

--- a/src/tiling_drag.c
+++ b/src/tiling_drag.c
@@ -389,7 +389,7 @@ void tiling_drag(Con *con, xcb_button_press_event_t *event, bool use_threshold) 
             /* tree_move can change the focus */
             Con *old_focus = focused;
             tree_move(con, direction);
-            if (focused != old_focus) {
+            if (focused != old_focus && con_exists(old_focus)) {
                 con_activate(old_focus);
             }
             break;


### PR DESCRIPTION
tree_move calls tree_flatten which can destroy redundant containers.

An example reproduction would be V[H[a V[b]]] where V[b] is focused (parent of b) and a is moved away using the DT_PARENT target.

Note: Found with [bugfinder](https://github.com/stanek-michal/bugfinder)