### PR TITLE
randr: Fix memleak

### DIFF
--- a/src/randr.c
+++ b/src/randr.c
@@ -660,9 +660,8 @@ static bool randr_query_outputs_15(void) {
                         struct output_name *output_name = scalloc(1, sizeof(struct output_name));
                         output_name->name = sstrdup(oname);
                         SLIST_INSERT_HEAD(&new->names_head, output_name, names);
-                    } else {
-                        free(oname);
                     }
+                    free(oname);
                 }
                 FREE(info);
             }


### PR DESCRIPTION
`sasprintf` always allocates `oname` but it is only conditionally freed.

Note: Found with [bugfinder](https://github.com/stanek-michal/bugfinder)