### PR TITLE
assignments: Avoid crash when using for_window reload

### DIFF
--- a/release-notes/bugfixes/6-for_window-reload
+++ b/release-notes/bugfixes/6-for_window-reload
@@ -1,0 +1,1 @@
+fix crash when using for_window [...] reload

--- a/src/assignments.c
+++ b/src/assignments.c
@@ -18,6 +18,7 @@ void run_assignments(i3Window *window) {
     DLOG("Checking if any assignments match this window\n");
 
     bool needs_tree_render = false;
+    const Assignment *old_first_assignment = TAILQ_FIRST(&assignments);
 
     /* Check if any assignments match */
     Assignment *current;
@@ -59,6 +60,14 @@ void run_assignments(i3Window *window) {
         }
 
         command_result_free(result);
+
+        /* Prevent crash: if the assigned command included a reload, the
+         * assignments array was re-initialized, which will lead to a SEGFAULT
+         * if we continue.
+         */
+        if (old_first_assignment != TAILQ_FIRST(&assignments)) {
+            break;
+        }
     }
 
     /* If any of the commands required re-rendering, we will do that now. */

--- a/testcases/t/324-for-window-reload-crash.t
+++ b/testcases/t/324-for-window-reload-crash.t
@@ -1,0 +1,33 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • https://i3wm.org/downloads/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# This test ensures that i3 does not crash when a for_window rule triggers a
+# 'reload' command.
+# Bug still in: 4.24-12-gab6a75a6
+
+use i3test i3_config => <<'EOT';
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+for_window [class="special"] reload
+EOT
+
+my $window = open_window(
+    wm_class => 'special',
+);
+
+does_i3_live;
+
+done_testing;


### PR DESCRIPTION
Note: Found with [bugfinder](https://github.com/stanek-michal/bugfinder)