### PR TITLE
Ensure execl is followed by exit

### DIFF
--- a/i3-nagbar/main.c
+++ b/i3-nagbar/main.c
@@ -118,7 +118,7 @@ static void start_application(const char *command) {
         if (fork() == 0) {
             /* This is the child */
             execl(_PATH_BSHELL, _PATH_BSHELL, "-c", command, NULL);
-            /* not reached */
+            err(EXIT_FAILURE, "execl return"); /* only reached on error */
         }
         exit(0);
     }

--- a/i3bar/src/child.c
+++ b/i3bar/src/child.c
@@ -735,6 +735,7 @@ static void spipe(int pipedes[2]) {
 
 static void exec_shell(char *command) {
     execl(_PATH_BSHELL, _PATH_BSHELL, "-c", command, (char *)NULL);
+    err(EXIT_FAILURE, "execl return"); /* only reached on error */
 }
 
 static void setup_child_cb(i3bar_child *child) {
@@ -834,7 +835,6 @@ void start_ws_child(char *command) {
 
         setpgid(ws_child.pid, 0);
         exec_shell(command);
-        return;
     }
     /* Parent-process. Reroute streams */
     close(pipe_in[1]);

--- a/src/sighandler.c
+++ b/src/sighandler.c
@@ -112,8 +112,7 @@ static int sighandler_backtrace(void) {
             "-ex", "quit",
             NULL};
         execvp(args[0], args);
-        DLOG("Failed to exec GDB\n");
-        exit(EXIT_FAILURE);
+        err(EXIT_FAILURE, "execvp(gdb)");
     }
     int status = 0;
 

--- a/src/startup.c
+++ b/src/startup.c
@@ -196,7 +196,7 @@ void start_application(const char *command, bool no_startup_id) {
         setenv("I3SOCK", current_socketpath, 1);
 
         execl(_PATH_BSHELL, _PATH_BSHELL, "-c", command, NULL);
-        /* not reached */
+        err(EXIT_FAILURE, "execl return"); /* only reached on error */
     }
 
     if (!no_startup_id) {


### PR DESCRIPTION
exec* calls return when an error occurs, this is unexpected but would still leave the forked process in a broken state. This commit fixes that by ensuring they are followed by an immediate exit.