### PR TITLE
Fix leak sanitizer memleaks

### DIFF
--- a/i3bar/src/ipc.c
+++ b/i3bar/src/ipc.c
@@ -283,7 +283,7 @@ static void got_data(struct ev_loop *loop, ev_io *watcher, int events) {
      * we have to expect */
     uint32_t rec = 0;
     while (rec < header_len) {
-        int n = read(fd, header + rec, header_len - rec);
+        const int n = read(fd, header + rec, header_len - rec);
         if (n == -1) {
             ELOG("read() failed: %s\n", strerror(errno));
             exit(EXIT_FAILURE);
@@ -292,10 +292,11 @@ static void got_data(struct ev_loop *loop, ev_io *watcher, int events) {
             /* EOF received. Since i3 will restart i3bar instances as appropriate,
              * we exit here. */
             DLOG("EOF received, exiting...\n");
+            clean_xcb();
+            free(header);
 #ifdef I3_ASAN_ENABLED
             __lsan_do_leak_check();
 #endif
-            clean_xcb();
             exit(EXIT_SUCCESS);
         }
         rec += n;

--- a/i3bar/src/xcb.c
+++ b/i3bar/src/xcb.c
@@ -1931,6 +1931,7 @@ void reconfig_windows(bool redraw_bars) {
                                                8,
                                                len,
                                                class);
+            free(class);
 
             char *name;
             sasprintf(&name, "i3bar for output %s", walk->name);

--- a/include/libi3.h
+++ b/include/libi3.h
@@ -240,12 +240,10 @@ void i3string_free(i3String *str);
  * to prevent accidentally using freed memory.
  *
  */
-#define I3STRING_FREE(str)      \
-    do {                        \
-        if (str != NULL) {      \
-            i3string_free(str); \
-            str = NULL;         \
-        }                       \
+#define I3STRING_FREE(str)  \
+    do {                    \
+        i3string_free(str); \
+        str = NULL;         \
     } while (0)
 
 /**

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -81,6 +81,7 @@ CFGFUN(include, const char *pattern) {
                 assert(false);
                 break;
         }
+        result->ctx->variables = ctx.variables; /* In case head was modified */
     }
     wordfree(&p);
 }

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -327,7 +327,7 @@ static int json_string(void *ctx, const unsigned char *val, size_t len) {
         sasprintf(&mark, "%.*s", (int)len, val);
 
         marks = srealloc(marks, (++num_marks) * sizeof(struct pending_marks));
-        marks[num_marks - 1].mark = sstrdup(mark);
+        marks[num_marks - 1].mark = mark;
         marks[num_marks - 1].con_to_be_marked = json_node;
     } else {
         if (strcasecmp(last_key, "name") == 0) {

--- a/src/restore_layout.c
+++ b/src/restore_layout.c
@@ -144,7 +144,9 @@ static void update_placeholder_contents(placeholder_state *state) {
 #define APPEND_REGEX(re_name)                                                                                                                        \
     do {                                                                                                                                             \
         if (swallows->re_name != NULL) {                                                                                                             \
+            char *old_serialized = serialized;                                                                                                       \
             sasprintf(&serialized, "%s%s" #re_name "=\"%s\"", (serialized ? serialized : "["), (serialized ? " " : ""), swallows->re_name->pattern); \
+            free(old_serialized);                                                                                                                    \
         }                                                                                                                                            \
     } while (0)
 
@@ -159,7 +161,9 @@ static void update_placeholder_contents(placeholder_state *state) {
             continue;
         }
 
+        char *old_serialized = serialized;
         sasprintf(&serialized, "%s]", serialized);
+        free(old_serialized);
         DLOG("con %p (placeholder 0x%08x) line %d: %s\n", state->con, state->window, n, serialized);
 
         i3String *str = i3string_from_utf8(serialized);


### PR DESCRIPTION
```sh
export LSAN_OPTIONS=suppressions=lsan.supp
echo leak:libxcb.so >suppressions=lsan.supp
```

Before:
```sh
rg -l LeakSanitizer latest/i3-log-for-*
latest/i3-log-for-308-focus_wrapping.t
latest/i3-log-for-313-include.t
latest/i3-log-for-316-drag-container.t
latest/i3-log-for-525-i3bar-mouse-bindings.t
latest/i3-log-for-529-net-wm-desktop.t
latest/i3-log-for-533-randr15.t
latest/i3-log-for-538-i3bar-primary-output.t
```

After:
```sh
rg -l LeakSanitizer latest/i3-log-for-*
```

Closes: #4087