### PR TITLE
318-i3-dmenu-desktop: Use $^X for generated script shebang

### DIFF
--- a/testcases/t/318-i3-dmenu-desktop.t
+++ b/testcases/t/318-i3-dmenu-desktop.t
@@ -39,7 +39,7 @@ mkfifo("$tmpdir/fifo", 0600) or BAIL_OUT "Could not create FIFO: $!";
 
 open(my $i3msg_dump, '>', "$tmpdir/i3-msg");
 say $i3msg_dump <<EOT;
-#!/usr/bin/env perl
+#!/usr/bin/env $^X
 use strict;
 use warnings;
 use JSON::XS qw(encode_json);


### PR DESCRIPTION
The test creates a fake i3-msg Perl script at runtime. Previously it used `#!/usr/bin/env perl` as the shebang, but this can fail in certain build environments (e.g., Nix sandboxed builds) where the `perl` found via `/usr/bin/env` may not have the same module paths as the `perl` running the test suite.

Use `$^X` instead, which contains the path to the Perl interpreter currently running the test. This ensures the generated script uses the same Perl with the same `PERL5LIB` environment, guaranteeing that `JSON::XS` and other required modules are available.
