### PR TITLE
i3test: Add require statements before pragma imports

### DIFF
--- a/testcases/lib/i3test.pm.in
+++ b/testcases/lib/i3test.pm.in
@@ -173,6 +173,9 @@ use Time::HiRes qw(sleep);
 use i3test::Test;
 __
     $tester->BAIL_OUT("$@") if $@;
+    require feature;
+    require strict;
+    require warnings;
     feature->import(":5.10");
     strict->import;
     warnings->import;


### PR DESCRIPTION
In the dynamically eval'd import code, `feature->import()`, `strict->import()`, and `warnings->import()` are called without first loading these modules. While these pragma modules may be coincidentally loaded by other modules in some Perl environments, this is not guaranteed.

Add explicit `require` statements before calling the import methods to ensure the modules are loaded. This follows correct Perl practice where a module must be loaded before calling its `->import` method.

Without this fix, tests may fail in some environments with:

```
Attempt to call undefined import method with arguments (":5.10") via package "feature"
```
