### PR TITLE
fix switching to/restoring from LC_NUMERIC

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -10,6 +10,9 @@
 #pragma once
 
 #include <config.h>
+#include <locale.h>
+
+extern locale_t numericC;
 
 /**
  * Enable or disable the main X11 event handling function.

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -909,10 +909,10 @@ static void dump_bar_config(yajl_gen gen, Barconfig *config) {
 }
 
 IPC_HANDLER(tree) {
-    setlocale(LC_NUMERIC, "C");
+    locale_t prev_locale = uselocale(numericC);
     yajl_gen gen = ygenalloc();
     dump_node(gen, croot, false);
-    setlocale(LC_NUMERIC, "");
+    uselocale(prev_locale);
 
     const unsigned char *payload;
     ylength length;
@@ -1585,7 +1585,7 @@ ipc_client *ipc_new_client_on_fd(EV_P_ int fd) {
  * generator. Free with yajl_gen_free().
  */
 yajl_gen ipc_marshal_workspace_event(const char *change, Con *current, Con *old) {
-    setlocale(LC_NUMERIC, "C");
+    locale_t prev_locale = uselocale(numericC);
     yajl_gen gen = ygenalloc();
 
     y(map_open);
@@ -1609,7 +1609,7 @@ yajl_gen ipc_marshal_workspace_event(const char *change, Con *current, Con *old)
 
     y(map_close);
 
-    setlocale(LC_NUMERIC, "");
+    uselocale(prev_locale);
 
     return gen;
 }
@@ -1639,7 +1639,7 @@ void ipc_send_window_event(const char *property, Con *con) {
     DLOG("Issue IPC window %s event (con = %p, window = 0x%08x)\n",
          property, con, (con->window ? con->window->id : XCB_WINDOW_NONE));
 
-    setlocale(LC_NUMERIC, "C");
+    locale_t prev_locale = uselocale(numericC);
     yajl_gen gen = ygenalloc();
 
     y(map_open);
@@ -1658,7 +1658,7 @@ void ipc_send_window_event(const char *property, Con *con) {
 
     ipc_send_event("window", I3_IPC_EVENT_WINDOW, (const char *)payload);
     y(free);
-    setlocale(LC_NUMERIC, "");
+    uselocale(prev_locale);
 }
 
 /*
@@ -1666,7 +1666,7 @@ void ipc_send_window_event(const char *property, Con *con) {
  */
 void ipc_send_barconfig_update_event(Barconfig *barconfig) {
     DLOG("Issue barconfig_update event for id = %s\n", barconfig->id);
-    setlocale(LC_NUMERIC, "C");
+    locale_t prev_locale = uselocale(numericC);
     yajl_gen gen = ygenalloc();
 
     dump_bar_config(gen, barconfig);
@@ -1677,7 +1677,7 @@ void ipc_send_barconfig_update_event(Barconfig *barconfig) {
 
     ipc_send_event("barconfig_update", I3_IPC_EVENT_BARCONFIG_UPDATE, (const char *)payload);
     y(free);
-    setlocale(LC_NUMERIC, "");
+    uselocale(prev_locale);
 }
 
 /*
@@ -1686,7 +1686,7 @@ void ipc_send_barconfig_update_event(Barconfig *barconfig) {
 void ipc_send_binding_event(const char *event_type, Binding *bind, const char *modename) {
     DLOG("Issue IPC binding %s event (sym = %s, code = %d)\n", event_type, bind->symbol, bind->keycode);
 
-    setlocale(LC_NUMERIC, "C");
+    locale_t prev_locale = uselocale(numericC);
 
     yajl_gen gen = ygenalloc();
 
@@ -1714,7 +1714,7 @@ void ipc_send_binding_event(const char *event_type, Binding *bind, const char *m
     ipc_send_event("binding", I3_IPC_EVENT_BINDING, (const char *)payload);
 
     y(free);
-    setlocale(LC_NUMERIC, "");
+    uselocale(prev_locale);
 }
 
 /*

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -634,14 +634,14 @@ bool json_validate(const char *buf, const size_t len) {
     /* Allow multiple values, i.e. multiple nodes to attach */
     yajl_config(hand, yajl_allow_multiple_values, true);
 
-    setlocale(LC_NUMERIC, "C");
+    locale_t prev_locale = uselocale(numericC);
     if (yajl_parse(hand, (const unsigned char *)buf, len) != yajl_status_ok) {
         unsigned char *str = yajl_get_error(hand, 1, (const unsigned char *)buf, len);
         ELOG("JSON parsing error: %s\n", str);
         yajl_free_error(hand, str);
         valid = false;
     }
-    setlocale(LC_NUMERIC, "");
+    uselocale(prev_locale);
 
     yajl_complete_parse(hand);
     yajl_free(hand);
@@ -671,7 +671,7 @@ json_content_t json_determine_content(const char *buf, const size_t len) {
     yajl_config(hand, yajl_allow_comments, true);
     /* Allow multiple values, i.e. multiple nodes to attach */
     yajl_config(hand, yajl_allow_multiple_values, true);
-    setlocale(LC_NUMERIC, "C");
+    locale_t prev_locale = uselocale(numericC);
     const yajl_status stat = yajl_parse(hand, (const unsigned char *)buf, len);
     if (stat != yajl_status_ok && stat != yajl_status_client_canceled) {
         unsigned char *str = yajl_get_error(hand, 1, (const unsigned char *)buf, len);
@@ -679,7 +679,7 @@ json_content_t json_determine_content(const char *buf, const size_t len) {
         yajl_free_error(hand, str);
     }
 
-    setlocale(LC_NUMERIC, "");
+    uselocale(prev_locale);
     yajl_complete_parse(hand);
     yajl_free(hand);
 
@@ -725,7 +725,7 @@ void tree_append_json(Con *con, const char *buf, const size_t len, char **errorm
     parsing_geometry = false;
     parsing_focus = false;
     parsing_marks = false;
-    setlocale(LC_NUMERIC, "C");
+    locale_t prev_locale = uselocale(numericC);
     const yajl_status stat = yajl_parse(hand, (const unsigned char *)buf, len);
     if (stat != yajl_status_ok) {
         unsigned char *str = yajl_get_error(hand, 1, (const unsigned char *)buf, len);
@@ -750,7 +750,7 @@ void tree_append_json(Con *con, const char *buf, const size_t len, char **errorm
      * next time. */
     con_fix_percent(con);
 
-    setlocale(LC_NUMERIC, "");
+    uselocale(prev_locale);
     yajl_complete_parse(hand);
     yajl_free(hand);
 

--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,8 @@
 #include "i3-atoms_NET_SUPPORTED.xmacro.h"
 #include "i3-atoms_rest.xmacro.h"
 
+locale_t numericC;
+
 /* The original value of RLIMIT_CORE when i3 was started. We need to restore
  * this before starting any other process, since we set RLIMIT_CORE to
  * RLIM_INFINITY for i3 debugging versions. */
@@ -314,6 +316,7 @@ int main(int argc, char *argv[]) {
     int option_index = 0, opt;
 
     setlocale(LC_ALL, "");
+    numericC = newlocale(LC_NUMERIC_MASK, "C", 0);
 
     /* Get the RLIMIT_CORE limit at startup time to restore this before
      * starting processes. */

--- a/src/util.c
+++ b/src/util.c
@@ -221,12 +221,12 @@ static char **add_argument(char **original, char *opt_char, char *opt_arg, char 
 #define ystr(str) yajl_gen_string(gen, (unsigned char *)str, strlen(str))
 
 static char *store_restart_layout(void) {
-    setlocale(LC_NUMERIC, "C");
+    locale_t prev_locale = uselocale(numericC);
     yajl_gen gen = yajl_gen_alloc(NULL);
 
     dump_node(gen, croot, true);
 
-    setlocale(LC_NUMERIC, "");
+    uselocale(prev_locale);
 
     const unsigned char *payload;
     size_t length;

--- a/testcases/t/325-layout-percent-and-marks.t
+++ b/testcases/t/325-layout-percent-and-marks.t
@@ -1,0 +1,61 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Tests that container percentages are correctly preserved when restoring
+# layouts containing marks.
+# See: https://github.com/i3/i3/issues/6391
+#
+use i3test;
+use File::Temp qw(tempfile);
+use IO::Handle;
+
+################################################################################
+# Test 1: Layout with marks should preserve percent values
+################################################################################
+
+my $ws = fresh_workspace;
+
+my @content = @{get_ws_content($ws)};
+is(@content, 0, 'no nodes on the new workspace yet');
+
+my ($fh, $filename) = tempfile(UNLINK => 1);
+print $fh <<'EOT';
+{
+    "layout": "splith",
+    "nodes": [
+        {
+            "percent": 0.2,
+            "marks": ["left_mark"],
+            "swallows": [
+                { "class": "^left$" }
+            ]
+        },
+        {
+            "percent": 0.8,
+            "swallows": [
+                { "class": "^right$" }
+            ]
+        }
+    ]
+}
+EOT
+$fh->flush;
+cmd "append_layout $filename";
+close($fh);
+
+does_i3_live;
+
+@content = @{get_ws_content($ws)};
+is(@content, 1, 'one node on the workspace now');
+
+my @nodes = @{$content[0]->{nodes}};
+is(@nodes, 2, 'split container has two children');
+
+cmp_float($nodes[0]->{percent}, 0.2, 'first container (with mark) got 20%');
+cmp_float($nodes[1]->{percent}, 0.8, 'second container got 80%');
+
+my @marks = @{$nodes[0]->{marks}};
+is(@marks, 1, 'first container has one mark');
+is($marks[0], 'left_mark', 'mark is correctly applied');
+
+done_testing;


### PR DESCRIPTION
Before this commit, we used setlocale(LC_NUMERIC, "");,
but that is not correct because it doesn’t nest:
load_layout.c (sets LC_NUMERIC=C) calls con_mark(),
which calls ipc_send_window_event() (sets LC_NUMERIC=C),
which calls setlocale(LC_NUMERIC, ""); when returning,
but now load_layout has LC_NUMERIC set per the environment,
whereas the function expects to remain in LC_NUMERIC=C.

Using newlocale and uselocale just swaps handles,
which is a little cleaner than querying the locale with
strdup(setlocale(LC_NUMERIC, NULL)); and restoring it later.

The test only fails with certain locales, e.g. LC_NUMERIC=de_DE.
I don’t think it’s important to set a locale in our test runner,
(which locales are available is very system-dependent),
as I am personally regularly testing with LC_NUMERIC=de_DE ;)

fixes https://github.com/i3/i3/issues/6391
