### PR TITLE
t/318-i3-dmenu-desktop.t: use $Config{perlpath} (absolute) over $^X

### DIFF
--- a/testcases/t/318-i3-dmenu-desktop.t
+++ b/testcases/t/318-i3-dmenu-desktop.t
@@ -23,6 +23,7 @@ use i3test::Util qw(slurp);
 use File::Temp qw(tempfile tempdir);
 use POSIX qw(mkfifo);
 use JSON::XS qw(decode_json);
+use Config;
 
 my $desktopdir = tempdir(CLEANUP => 1);
 
@@ -39,7 +40,7 @@ mkfifo("$tmpdir/fifo", 0600) or BAIL_OUT "Could not create FIFO: $!";
 
 open(my $i3msg_dump, '>', "$tmpdir/i3-msg");
 say $i3msg_dump <<EOT;
-#!/usr/bin/env $^X
+#!$Config{perlpath}
 use strict;
 use warnings;
 use JSON::XS qw(encode_json);


### PR DESCRIPTION
I noticed that the Nix build does not actually work when using the “#!/usr/bin/env $^X” shebang because /usr/bin/env is not present in the Nix build sandbox.

$Config{perlpath} is always absolute, so let’s prefer that.

Tested both inside and outside a Nix build sandbox.

related to https://github.com/i3/i3/pull/6537