### PR TITLE
fix xss-lock in i3-session: import and specify $XDG_SESSION_ID

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -26,7 +26,7 @@ exec --no-startup-id dex --autostart --environment i3
 
 # xss-lock grabs a logind suspend inhibit lock and will use i3lock to lock the
 # screen before suspend. Use loginctl lock-session to lock your screen.
-exec --no-startup-id xss-lock --transfer-sleep-lock -- i3lock --nofork
+exec --no-startup-id xss-lock --transfer-sleep-lock --session=$XDG_SESSION_ID -- i3lock --nofork
 
 # NetworkManager is the most popular way to manage wireless networks on Linux,
 # and nm-applet is a desktop environment-independent system tray GUI for it.

--- a/etc/config.keycodes
+++ b/etc/config.keycodes
@@ -27,7 +27,7 @@ exec --no-startup-id dex --autostart --environment i3
 
 # xss-lock grabs a logind suspend inhibit lock and will use i3lock to lock the
 # screen before suspend. Use loginctl lock-session to lock your screen.
-exec --no-startup-id xss-lock --transfer-sleep-lock -- i3lock --nofork
+exec --no-startup-id xss-lock --transfer-sleep-lock --session=$XDG_SESSION_ID -- i3lock --nofork
 
 # NetworkManager is the most popular way to manage wireless networks on Linux,
 # and nm-applet is a desktop environment-independent system tray GUI for it.

--- a/libexec/i3-session.in
+++ b/libexec/i3-session.in
@@ -6,10 +6,10 @@ if [ "$(systemctl --user show -P CanStart @UNIT@ 2>/dev/null)" = "yes" ]
 then
   # Ensure the X11 environment variables are available
   # to the systemd user session (required on some distros).
-  systemctl --user import-environment DISPLAY XAUTHORITY
+  systemctl --user import-environment DISPLAY XAUTHORITY XDG_SESSION_ID
 
   if command -v dbus-update-activation-environment >/dev/null 2>&1; then
-    dbus-update-activation-environment DISPLAY XAUTHORITY
+    dbus-update-activation-environment DISPLAY XAUTHORITY XDG_SESSION_ID
   fi
 
   systemctl --user --wait start @UNIT@

--- a/libexec/xss-lock
+++ b/libexec/xss-lock
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# This wrapper script ensures that xss-lock receives the XDG session ID,
+# which logind could auto-detect before we started using systemd user
+# services with i3 v4.25. See https://github.com/i3/i3/issues/5186
+
+# Find the real xss-lock in $PATH, skipping this wrapper script.
+IFS=:
+for dir in $PATH
+do
+  [ -z "$dir" ] && dir="."
+  [ -x "$dir/xss-lock" ] || continue
+  [ "$dir/xss-lock" -ef "$0" ] && continue
+  exec "$dir/xss-lock" --session=$XDG_SESSION_ID "$@"
+done
+
+echo "real xss-lock binary not found in \$PATH" >&2
+exit 1

--- a/meson.build
+++ b/meson.build
@@ -610,7 +610,7 @@ xsessions = join_paths(get_option('datadir'), 'xsessions')
 xsession_cdata = configuration_data()
 xsession_cdata.set('NAME', 'i3')
 xsession_cdata.set('UNIT', 'i3.service')
-xsession_cdata.set('EXEC', join_paths(get_option('prefix'), get_option('libexecdir'), 'i3-session'))
+xsession_cdata.set('EXEC', join_paths(get_option('prefix'), get_option('libexecdir'), 'i3', 'i3-session'))
 configure_file(
   input: 'share/xsessions/i3.desktop.in',
   output: 'i3.desktop',
@@ -623,12 +623,12 @@ configure_file(
   output: 'i3-session',
   configuration: xsession_cdata,
   install: true,
-  install_dir: get_option('libexecdir'),
+  install_dir: join_paths(get_option('libexecdir'), 'i3'),
 )
 xsession_log_cdata = configuration_data()
 xsession_log_cdata.set('NAME', 'i3-with-shmlog')
 xsession_log_cdata.set('UNIT', 'i3-with-shmlog.service')
-xsession_log_cdata.set('EXEC', join_paths(get_option('prefix'), get_option('libexecdir'), 'i3-session-with-shmlog'))
+xsession_log_cdata.set('EXEC', join_paths(get_option('prefix'), get_option('libexecdir'), 'i3', 'i3-session-with-shmlog'))
 configure_file(
   input: 'share/xsessions/i3.desktop.in',
   output: 'i3-with-shmlog.desktop',
@@ -641,7 +641,15 @@ configure_file(
   output: 'i3-session-with-shmlog',
   configuration: xsession_log_cdata,
   install: true,
-  install_dir: get_option('libexecdir'),
+  install_dir: join_paths(get_option('libexecdir'), 'i3'),
+)
+
+configure_file(
+  input: 'libexec/xss-lock',
+  output: 'xss-lock',
+  configuration: cdata,
+  install: true,
+  install_dir: join_paths(get_option('libexecdir'), 'i3'),
 )
 
 if systemd_dep.found()
@@ -651,6 +659,7 @@ if systemd_dep.found()
   # but for systemd unit files, we must not use quoting.
   systemd_cdata = configuration_data()
   systemd_cdata.set('BINDIR', join_paths(get_option('prefix'), get_option('bindir')))
+  systemd_cdata.set('LIBEXECDIR', join_paths(get_option('prefix'), get_option('libexecdir')))
   systemd_cdata.set('EXECSTART', join_paths(get_option('prefix'), get_option('bindir'), 'i3'))
   configure_file(
     input: 'systemd/i3.service.in',

--- a/systemd/i3.service.in
+++ b/systemd/i3.service.in
@@ -21,5 +21,5 @@ Before=graphical-session.target
 
 [Service]
 Type=notify
-ExecStart=@EXECSTART@
+ExecStart=/bin/sh -c "PATH=@LIBEXECDIR@/i3:$PATH @EXECSTART@"
 ExecReload=@BINDIR@/i3-msg reload


### PR DESCRIPTION
I noticed that 'loginctl lock-session' no longer worked after switching to the i3.service user unit. xss-lock said: org.freedesktop.login1.NoSessionForPID: PID 26414 does not belong to any known session.

See also:
https://gitlab.archlinux.org/archlinux/packaging/packages/xss-lock/-/issues/1