### PR TITLE
declare a development shell in flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1765838191,
+        "narHash": "sha256-m5KWt1nOm76ILk/JSCxBM4MfK3rYY7Wq9/TZIIeGnT8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6f52ebd45e5925c188d1a20119978aa4ffd5ef6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "i3 window manager development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            inputsFrom = [ pkgs.i3 ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
This makes it possible to build i3 (for development) on any system on which Nix can be installed (= most Linux systems).

For example, I start Emacs using `nix develop --command emacs` and that Emacs process is in an environment with all i3 build deps.

See also:
https://michael.stapelberg.ch/posts/2025-07-27-dev-shells-with-nix-4-quick-examples/

This file is provided best-effort, but PRs are welcome.

While users can already run `nix develop nixpkgs#i3`, for nix-direnv integration it is required to declare a flake.nix in the project directory (otherwise direnv cannot find it).

similar to https://github.com/i3/i3lock/pull/372

related to https://github.com/i3/i3/pull/6549