### PR TITLE
x_push_changes: change root event mask to avoid EnterNotify

### DIFF
--- a/src/x.c
+++ b/src/x.c
@@ -1297,6 +1297,10 @@ void x_push_changes(Con *con) {
             xcb_change_window_attributes(conn, state->id, XCB_CW_EVENT_MASK, values);
         }
     }
+    /* Change the event mask so that we do not receive EnterNotify events
+     * as a result of reconfiguring windows. */
+    xcb_change_window_attributes(conn, root, XCB_CW_EVENT_MASK, (uint32_t[]){ROOT_EVENT_MASK & ~XCB_EVENT_MASK_ENTER_WINDOW});
+
     bool order_changed = false;
     bool stacking_changed = false;
 
@@ -1393,6 +1397,7 @@ void x_push_changes(Con *con) {
             xcb_change_window_attributes(conn, state->id, XCB_CW_EVENT_MASK, values);
         }
     }
+    xcb_change_window_attributes(conn, root, XCB_CW_EVENT_MASK, (uint32_t[]){ROOT_EVENT_MASK});
 
     x_deco_recurse(con);
 

--- a/src/xcb.c
+++ b/src/xcb.c
@@ -105,14 +105,12 @@ void send_take_focus(xcb_window_t window, xcb_timestamp_t timestamp) {
  *
  */
 void xcb_set_window_rect(xcb_connection_t *conn, const xcb_window_t window, Rect r) {
-    xcb_void_cookie_t cookie = xcb_configure_window(conn, window,
-                                                    XCB_CONFIG_WINDOW_X |
-                                                        XCB_CONFIG_WINDOW_Y |
-                                                        XCB_CONFIG_WINDOW_WIDTH |
-                                                        XCB_CONFIG_WINDOW_HEIGHT,
-                                                    &(r.x));
-    /* ignore events which are generated because we configured a window */
-    add_ignore_event(cookie.sequence, -1);
+    xcb_configure_window(conn, window,
+                         XCB_CONFIG_WINDOW_X |
+                             XCB_CONFIG_WINDOW_Y |
+                             XCB_CONFIG_WINDOW_WIDTH |
+                             XCB_CONFIG_WINDOW_HEIGHT,
+                         &(r.x));
 }
 
 /*


### PR DESCRIPTION
Reconfiguring windows can cause EnterNotify events
when windows are mapped or configured under the mouse pointer.

To avoid handling such EnterNotify events like regular,
user-triggered EnterNotify events (through mouse movement),
we used to add the sequence to the ignore list, but under some
(unknown) circumstances, that does not seem to work reliably.

Instead of ignoring the events, we now change the event mask
of the root window to make the X server not send the events at all.

fixes https://github.com/i3/i3/issues/6372
