### PR TITLE
cmd_floating: Fix crash when running empty workspace

### DIFF
--- a/release-notes/bugfixes/1-floating-crash-empty-workspace
+++ b/release-notes/bugfixes/1-floating-crash-empty-workspace
@@ -1,0 +1,1 @@
+fix crash when running floating command on empty workspace

--- a/src/assignments.c
+++ b/src/assignments.c
@@ -15,6 +15,10 @@
  *
  */
 void run_assignments(i3Window *window) {
+    if (!window) {
+        return;
+    }
+
     DLOG("Checking if any assignments match this window\n");
 
     bool needs_tree_render = false;

--- a/testcases/t/554-crash-floating-enable.t
+++ b/testcases/t/554-crash-floating-enable.t
@@ -1,0 +1,28 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • https://i3wm.org/downloads/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Verify that i3 does not crash when a floating command is run and for_window
+# rule exists.
+# Ticket: #6561
+# Bug still in: 4.25-6-g0e2e8290
+use i3test i3_config => <<EOT;
+for_window [class=xxx] nop
+EOT
+
+cmd 'floating toggle';
+does_i3_live;
+
+done_testing;


### PR DESCRIPTION
When running 'floating toggle' (or enable/disable) on an empty workspace, the focused container is the workspace itself, which has window=NULL. The command would call run_assignments(workspace->window), which would pass NULL to match_matches_window(), causing a crash when trying to access window->id.

Add a NULL check at the beginning of `run_assignments` to immediately skip assignments for that case.

Fixes: #6561