### PR TITLE
flake.nix: disable fortify hardening (results in compiler warnings)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
         {
           default = pkgs.mkShell {
             inputsFrom = [ pkgs.i3 ];
+            hardeningDisable = [ "fortify" ];
           };
         }
       );


### PR DESCRIPTION
Without this change, I see the following (harmless but annoying) compiler warnings when building i3 after `meson setup build`:

    [3/106] Compiling C object libi3.a.p/libi3_g_utf8_make_valid.c.o
    In file included from /nix/store/gi4cz4ir3zlwhf1azqfgxqdnczfrwsr7-glibc-2.40-66-dev/include/bits/libc-header-start.h:33,
                     from /nix/store/gi4cz4ir3zlwhf1azqfgxqdnczfrwsr7-glibc-2.40-66-dev/include/stdio.h:28,
                     from ../include/libi3.h:17,
                     from ../libi3/g_utf8_make_valid.c:20:
    /nix/store/gi4cz4ir3zlwhf1azqfgxqdnczfrwsr7-glibc-2.40-66-dev/include/features.h:422:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
      422 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
          |    ^~~~~~~