### PR TITLE
GitHub Actions: install libcrypt-dev in travis-base.Dockerfile

### DIFF
--- a/travis/travis-base.Dockerfile
+++ b/travis/travis-base.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     dpkg-dev devscripts git equivs \
     build-essential clang libclang-rt-dev \
     lintian \
-    libmodule-install-perl libanyevent-perl libextutils-pkgconfig-perl xcb-proto cpanminus xvfb xserver-xephyr xauth libinline-perl libinline-c-perl libxml-simple-perl libmouse-perl libmousex-nativetraits-perl libextutils-depends-perl perl libtest-deep-perl libtest-exception-perl libxml-parser-perl libtest-simple-perl libtest-fatal-perl libdata-dump-perl libtest-differences-perl libxml-tokeparser-perl libipc-run-perl libxcb-xtest0-dev libx11-xcb-perl libjson-xs-perl x11-xserver-utils && \
+    libmodule-install-perl libanyevent-perl libextutils-pkgconfig-perl xcb-proto cpanminus xvfb xserver-xephyr xauth libinline-perl libinline-c-perl libxml-simple-perl libmouse-perl libmousex-nativetraits-perl libextutils-depends-perl perl libtest-deep-perl libtest-exception-perl libxml-parser-perl libtest-simple-perl libtest-fatal-perl libdata-dump-perl libtest-differences-perl libxml-tokeparser-perl libipc-run-perl libxcb-xtest0-dev libx11-xcb-perl libjson-xs-perl x11-xserver-utils libcrypt-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Install i3 build dependencies.


### PR DESCRIPTION
This package used to be included transitively, but no longer is. Test cases like t/555-i3bar-workspace-output-assignment.t which use XTEST need crypt.h available (via Inline::C).