### PR TITLE
i3-sensible-terminal: add ghostty

### DIFF
--- a/i3-sensible-terminal
+++ b/i3-sensible-terminal
@@ -14,7 +14,7 @@
 # 2. Distribution-specific mechanisms come next, e.g. x-terminal-emulator
 # 3. The terminal emulator with best accessibility comes first.
 # 4. No order is guaranteed/desired for the remaining terminal emulators.
-for terminal in "$TERMINAL" x-terminal-emulator mate-terminal gnome-terminal terminator xfce4-terminal urxvt rxvt termit Eterm aterm uxterm xterm roxterm termite lxterminal terminology st qterminal lilyterm tilix terminix konsole kitty guake tilda alacritty hyper wezterm rio; do
+for terminal in "$TERMINAL" x-terminal-emulator mate-terminal gnome-terminal terminator xfce4-terminal urxvt rxvt termit Eterm aterm uxterm xterm roxterm termite lxterminal terminology st qterminal lilyterm tilix terminix konsole kitty guake tilda alacritty hyper wezterm rio ghostty; do
     if command -v "$terminal" > /dev/null 2>&1; then
         exec "$terminal" "$@"
     fi

--- a/man/i3-sensible-terminal.man
+++ b/man/i3-sensible-terminal.man
@@ -49,6 +49,9 @@ It tries to start one of the following (in that order):
 * tilda
 * alacritty
 * hyper
+* wezterm
+* rio
+* ghostty
 
 Please don’t complain about the order: If the user has any preference, they will
 have $TERMINAL set or modified their i3 configuration file.


### PR DESCRIPTION
[Ghostty](https://ghostty.org) is a relatively newer terminal emulator. Appending it to the existing sensible terminals list.

The man pages seem to be missing the previous two terminal additions. Adding those as well.