### PR TITLE
Restore floating floating geometry after fullscreen

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -688,6 +688,9 @@ struct Con {
     struct Rect deco_rect;
     /** the geometry this window requested when getting mapped */
     struct Rect geometry;
+    /** saved geometry used to restore floating containers after fullscreen */
+    struct Rect saved_floating_rect;
+    bool saved_floating_rect_valid;
 
     char *name;
 

--- a/src/con.c
+++ b/src/con.c
@@ -1284,6 +1284,13 @@ void con_enable_fullscreen(Con *con, fullscreen_mode_t fullscreen_mode) {
         con_activate(old_focused);
     }
 
+    /* Preserve the floating geometry so we can restore it after leaving fullscreen. */
+    Con *floating_con = con_inside_floating(con);
+    if (floating_con != NULL) {
+        floating_con->saved_floating_rect = floating_con->rect;
+        floating_con->saved_floating_rect_valid = true;
+    }
+
     con_set_fullscreen_mode(con, fullscreen_mode);
 }
 
@@ -1306,6 +1313,14 @@ void con_disable_fullscreen(Con *con) {
     }
 
     con_set_fullscreen_mode(con, CF_NONE);
+
+    /* Restore floating geometry if we previously saved it. */
+    Con *floating_con = con_inside_floating(con);
+    if (floating_con != NULL && floating_con->saved_floating_rect_valid) {
+        DLOG("Restoring floating geometry for %p / %s\n", floating_con, floating_con->name);
+        floating_reposition(floating_con, floating_con->saved_floating_rect);
+        floating_con->saved_floating_rect_valid = false;
+    }
 }
 
 static bool _con_move_to_con(Con *con, Con *target, bool behind_focused, bool fix_coordinates, bool dont_warp, bool ignore_focus, bool fix_percentage) {

--- a/testcases/t/556-floating-fullscreen-restore.t
+++ b/testcases/t/556-floating-fullscreen-restore.t
@@ -1,0 +1,38 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • https://i3wm.org/downloads/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Regression test: ensure floating containers restore their pre-fullscreen
+# geometry/position after leaving fullscreen.
+
+use i3test;
+
+my $ws = fresh_workspace;
+my $win = open_floating_window(rect => [120, 160, 320, 180]);
+
+sub floating_rect {
+    my ($nodes) = get_ws($ws);
+    my $floating_con = $nodes->{floating_nodes}->[0];
+    return $floating_con->{rect};
+}
+
+my $original_rect = floating_rect();
+
+cmd 'fullscreen enable';
+cmd 'fullscreen disable';
+
+is_deeply(floating_rect(), $original_rect, 'floating rect restored after fullscreen toggle');
+
+done_testing;


### PR DESCRIPTION
Hi,

I create floating contaners and apply position and geometry manually, to set up a workspace for work. When making a floating window fullscreen and returning it to focus, the  geometry and postion is not restored when leaving fullscreen.

This patch preserves the original floating rectangle so it comes back exactly where it started.

The change saves the floating rect when entering fullscreen and restores it via floating_reposition() when leaving, so geometry and coordinates are both recovered.

I'm opening this as it seems (to me) an improvement to core i3 functionality. Is there a reason this functionaity is not the default in i3?

Kind regards.