### PR TITLE
Limit IPC message size to prevent uncontrolled memory allocation

### DIFF
--- a/libi3/ipc_recv_message.c
+++ b/libi3/ipc_recv_message.c
@@ -65,6 +65,13 @@ int ipc_recv_message(int sockfd, uint32_t *message_type,
         memcpy(message_type, walk, sizeof(uint32_t));
     }
 
+    /* Limit IPC messages to 128 MiB to prevent uncontrolled memory allocation
+     * and denial-of-service attacks. */
+    const uint32_t max_message_size = 128 * 1024 * 1024;
+    if (*reply_length > max_message_size) {
+        ELOG("IPC: message too large (%" PRIu32 " bytes), disconnecting\n", *reply_length);
+        return -3;
+    }
     *reply = smalloc(*reply_length);
 
     read_bytes = 0;


### PR DESCRIPTION
Fixes #6620 a denial-of-service vulnerability (CWE-770) where an attacker could request a multi-gigabyte allocation via the IPC socket, causing i3 to exhaust memory and crash. A maximum message size of 128 MiB is now enforced before allocation.