### PR TITLE
ui: allow stacked view to have title bars vertical

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -731,6 +731,46 @@ Default is +left+
 title_align left|center|right
 ---------------------------------------------
 
+=== Stacked title column width
+
+The title bars of a +stacking+ container can optionally be laid out as a
+vertical column on the left-hand side of the container (similar to the vertical
+tabs found in some web browsers) instead of the classic horizontal bars across
+the top. This is toggled at runtime, per container, with the
++stack_title_position+ command (see <<stack_title_position>>).
+
+This option only controls how wide that column is: each title is clipped to
+roughly the given number of characters, while the focused window fills the
+remaining space to the right of the column. It has no effect while a container
+uses the default top title bars. When unset, a default width of 20 characters
+is used.
+
+*Syntax*:
+---------------------------------------------
+stack_title_width <characters>
+---------------------------------------------
+
+*Example*:
+---------------------------------------------
+stack_title_width 20
+---------------------------------------------
+
+The default title bar position for newly created stacked containers can be set
+with +stack_title_position+. It accepts +top+ (classic horizontal bars, the
+default) or +left+ (vertical column). Existing containers are not affected; use
+the +stack_title_position+ command (see <<stack_title_position>>) to change them
+at runtime, which also overrides this default per container.
+
+*Syntax*:
+---------------------------------------------
+stack_title_position top|left
+---------------------------------------------
+
+*Example*:
+---------------------------------------------
+stack_title_position left
+---------------------------------------------
+
 [[default_border]]
 === Default border style for new windows
 
@@ -2414,6 +2454,31 @@ bindsym $mod+f fullscreen toggle
 
 # Toggle floating/tiling
 bindsym $mod+t floating toggle
+--------------
+
+[[stack_title_position]]
+=== Stacked title bar position
+
+For containers in the +stacking+ layout, the title bars are normally drawn as a
+horizontal strip across the top of the container. The +stack_title_position+
+command switches the enclosing stacked container between those top title bars
+and a vertical column of title bars on the left-hand side (similar to the
+vertical tabs found in some web browsers). The choice is stored per container
+and preserved across an in-place restart. The width of the left column is
+configured with +stack_title_width+ (see <<_stacked_title_column_width>>).
+
+*Syntax*:
+--------------------------------------------
+stack_title_position top|left|toggle
+--------------------------------------------
+
+*Examples*:
+--------------
+# Toggle the focused stack between top and left title bars
+bindsym $mod+Shift+s stack_title_position toggle
+
+# Force the left (vertical) title column
+bindsym $mod+Shift+v stack_title_position left
 --------------
 
 [[_focusing_moving_containers]]

--- a/include/commands.h
+++ b/include/commands.h
@@ -225,6 +225,14 @@ void cmd_move_direction(I3_CMD, const char *direction_str, long amount, const ch
 void cmd_layout(I3_CMD, const char *layout_str);
 
 /**
+ * Implementation of 'stack_title_position top|left|toggle'. Switches the
+ * enclosing stacked container between horizontal title bars on top and a
+ * vertical title column on the left.
+ *
+ */
+void cmd_stack_title_position(I3_CMD, const char *position_str);
+
+/**
  * Implementation of 'layout toggle [all|split]'.
  *
  */

--- a/include/config_directives.h
+++ b/include/config_directives.h
@@ -61,6 +61,8 @@ CFGFUN(fake_outputs, const char *outputs);
 CFGFUN(force_display_urgency_hint, const long duration_ms);
 CFGFUN(focus_on_window_activation, const char *mode);
 CFGFUN(title_align, const char *alignment);
+CFGFUN(stack_title_width, const long width);
+CFGFUN(stack_title_position, const char *position);
 CFGFUN(show_marks, const char *value);
 CFGFUN(hide_edge_borders, const char *borders);
 CFGFUN(assign_output, const char *output);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -218,6 +218,17 @@ struct Config {
         ALIGN_RIGHT
     } title_align;
 
+    /** Width, in characters, of the title column drawn on the left-hand side
+     * of stacked containers when they use the left/vertical title bars (see
+     * stack_title_position). When unset, a default of 20 characters is used. */
+    int stack_title_width;
+
+    /** Default title bar position for newly created stacked containers: classic
+     * horizontal bars on top (STACK_TITLE_TOP, the default) or a vertical column
+     * on the left (STACK_TITLE_LEFT). Can be overridden per container at runtime
+     * with the stack_title_position command. */
+    stack_title_position_t default_stack_title_position;
+
     /** The default border style for new windows. */
     border_style_t default_border;
 

--- a/include/data.h
+++ b/include/data.h
@@ -109,6 +109,18 @@ typedef enum {
 } layout_t;
 
 /**
+ * Where the title bars of an L_STACKED container are drawn. See
+ * Con::stack_title_position.
+ */
+typedef enum {
+    /* Classic horizontal title bars stacked across the top. */
+    STACK_TITLE_TOP = 0,
+    /* Vertical column of title bars on the left (Firefox-style vertical tabs).
+     * The column width is configured by stack_title_width. */
+    STACK_TITLE_LEFT = 1,
+} stack_title_position_t;
+
+/**
  * Binding input types. See Binding::input_type.
  */
 typedef enum {
@@ -753,6 +765,11 @@ struct Con {
      * layout in workspace_layout and creates a new split container with that
      * layout whenever a new container is attached to the workspace. */
     layout_t layout, last_split_layout, workspace_layout;
+
+    /* For L_STACKED containers: whether the title bars are drawn as the classic
+     * horizontal strip on top or as a vertical column on the left. Toggled at
+     * runtime with the stack_title_position command and saved across restarts. */
+    stack_title_position_t stack_title_position;
 
     border_style_t border_style;
     /* When the border style of a con changes because of motif hints, we don't

--- a/parser-specs/commands.spec
+++ b/parser-specs/commands.spec
@@ -23,6 +23,7 @@ state INITIAL:
   'debuglog' -> DEBUGLOG
   'border' -> BORDER
   'layout' -> LAYOUT
+  'stack_title_position' -> STACK_TITLE_POSITION
   'append_layout' -> APPEND_LAYOUT
   'workspace' -> WORKSPACE
   'focus' -> FOCUS
@@ -150,6 +151,11 @@ state LAYOUT:
       -> call cmd_layout($layout_mode)
   'toggle'
       -> LAYOUT_TOGGLE
+
+# stack_title_position top|left|toggle
+state STACK_TITLE_POSITION:
+  position = 'top', 'left', 'toggle'
+      -> call cmd_stack_title_position($position)
 
 # layout toggle [split|all]
 state LAYOUT_TOGGLE:

--- a/parser-specs/config.spec
+++ b/parser-specs/config.spec
@@ -50,6 +50,8 @@ state INITIAL:
   'force_display_urgency_hint'             -> FORCE_DISPLAY_URGENCY_HINT
   'focus_on_window_activation'             -> FOCUS_ON_WINDOW_ACTIVATION
   'title_align'                            -> TITLE_ALIGN
+  'stack_title_width'                    -> STACK_TITLE_WIDTH
+  'stack_title_position'                 -> STACK_TITLE_POSITION
   'show_marks'                             -> SHOW_MARKS
   'workspace'                              -> WORKSPACE
   'ipc_socket', 'ipc-socket'               -> IPC_SOCKET
@@ -323,6 +325,16 @@ state FORCE_DISPLAY_URGENCY_HINT:
 state TITLE_ALIGN:
   alignment = 'left', 'center', 'right'
       -> call cfg_title_align($alignment)
+
+# stack_title_width <number>
+state STACK_TITLE_WIDTH:
+  width = number
+      -> call cfg_stack_title_width(&width)
+
+# stack_title_position top|left
+state STACK_TITLE_POSITION:
+  position = 'top', 'left'
+      -> call cfg_stack_title_position($position)
 
 # show_marks
 state SHOW_MARKS:

--- a/src/commands.c
+++ b/src/commands.c
@@ -1624,6 +1624,47 @@ void cmd_layout(I3_CMD, const char *layout_str) {
 }
 
 /*
+ * Implementation of 'stack_title_position top|left|toggle'.
+ *
+ */
+void cmd_stack_title_position(I3_CMD, const char *position_str) {
+    HANDLE_EMPTY_MATCH;
+
+    owindow *current;
+    TAILQ_FOREACH (current, &OWINDOWS, owindows) {
+        /* Find the nearest enclosing stacked container (including the matched
+         * container itself), mirroring how the user thinks of "the stack". */
+        Con *stack = current->con;
+        while (stack != NULL && stack->layout != L_STACKED) {
+            stack = stack->parent;
+        }
+        if (stack == NULL) {
+            DLOG("con %p is not inside a stacked container, skipping it.\n", current->con);
+            continue;
+        }
+
+        stack_title_position_t pos;
+        if (strcmp(position_str, "top") == 0) {
+            pos = STACK_TITLE_TOP;
+        } else if (strcmp(position_str, "left") == 0) {
+            pos = STACK_TITLE_LEFT;
+        } else {
+            /* "toggle" */
+            pos = (stack->stack_title_position == STACK_TITLE_LEFT)
+                      ? STACK_TITLE_TOP
+                      : STACK_TITLE_LEFT;
+        }
+
+        DLOG("setting stack_title_position of con %p to %d\n", stack, pos);
+        stack->stack_title_position = pos;
+    }
+
+    cmd_output->needs_tree_render = true;
+    // XXX: default reply for now, make this a better reply
+    ysuccess(true);
+}
+
+/*
  * Implementation of 'layout toggle [all|split]'.
  *
  */

--- a/src/con.c
+++ b/src/con.c
@@ -42,6 +42,7 @@ Con *con_new_skeleton(Con *parent, i3Window *window) {
     new->type = CT_CON;
     new->window = window;
     new->border_style = new->max_user_border_style = config.default_border;
+    new->stack_title_position = config.default_stack_title_position;
     new->current_border_width = -1;
     new->window_icon_padding = -1;
     if (window) {

--- a/src/config_directives.c
+++ b/src/config_directives.c
@@ -535,6 +535,28 @@ CFGFUN(show_marks, const char *value) {
     config.show_marks = boolstr(value);
 }
 
+CFGFUN(stack_title_width, const long width) {
+    /* The value is a per-character column width that gets turned into a pixel
+     * buffer, so clamp it to a sane range: a typo must not request a gigantic
+     * allocation, and we avoid the implementation-defined (int) cast of values
+     * above INT_MAX. */
+    if (width <= 0) {
+        config.stack_title_width = 0;
+    } else if (width > 200) {
+        config.stack_title_width = 200;
+    } else {
+        config.stack_title_width = (int)width;
+    }
+}
+
+CFGFUN(stack_title_position, const char *position) {
+    if (strcmp(position, "left") == 0) {
+        config.default_stack_title_position = STACK_TITLE_LEFT;
+    } else {
+        config.default_stack_title_position = STACK_TITLE_TOP;
+    }
+}
+
 static char *current_workspace = NULL;
 
 CFGFUN(workspace, const char *workspace, const char *output) {

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -462,6 +462,17 @@ void dump_node(yajl_gen gen, Con *con, bool inplace_restart) {
             break;
     }
 
+    ystr("stack_title_position");
+    switch (con->stack_title_position) {
+        case STACK_TITLE_LEFT:
+            ystr("left");
+            break;
+        case STACK_TITLE_TOP:
+        default:
+            ystr("top");
+            break;
+    }
+
     ystr("workspace_layout");
     switch (con->workspace_layout) {
         case L_DEFAULT:

--- a/src/load_layout.c
+++ b/src/load_layout.c
@@ -415,6 +415,17 @@ static int json_string(void *ctx, const unsigned char *val, size_t len) {
                 LOG("Unhandled \"layout\": %s\n", buf);
             }
             free(buf);
+        } else if (strcasecmp(last_key, "stack_title_position") == 0) {
+            char *buf = NULL;
+            sasprintf(&buf, "%.*s", (int)len, val);
+            if (strcasecmp(buf, "left") == 0) {
+                json_node->stack_title_position = STACK_TITLE_LEFT;
+            } else if (strcasecmp(buf, "top") == 0) {
+                json_node->stack_title_position = STACK_TITLE_TOP;
+            } else {
+                LOG("Unhandled \"stack_title_position\": %s\n", buf);
+            }
+            free(buf);
         } else if (strcasecmp(last_key, "workspace_layout") == 0) {
             char *buf = NULL;
             sasprintf(&buf, "%.*s", (int)len, val);

--- a/src/render.c
+++ b/src/render.c
@@ -32,6 +32,51 @@ int render_deco_height(void) {
     return deco_height;
 }
 
+/* Default width (in characters) of the vertical title column when the user
+ * enabled left title bars but did not configure stack_title_width. */
+#define STACK_TITLE_WIDTH_DEFAULT 20
+
+/*
+ * Returns the width, in pixels, of the vertical title column drawn on the
+ * left-hand side of stacked containers in STACK_TITLE_LEFT mode, derived from
+ * config.stack_title_width (a character count, defaulting to
+ * STACK_TITLE_WIDTH_DEFAULT when unset).
+ *
+ * The result is cached because translating the character count into pixels
+ * requires measuring a sample string, which would otherwise happen once per
+ * child on every render.
+ *
+ */
+static int render_stack_title_width(void) {
+    static int cached_chars = -1;
+    static int cached_font_height = -1;
+    static int cached_width = 0;
+
+    const int chars = config.stack_title_width > 0
+                          ? config.stack_title_width
+                          : STACK_TITLE_WIDTH_DEFAULT;
+
+    if (chars == cached_chars && config.font.height == cached_font_height) {
+        return cached_width;
+    }
+
+    /* Measure a representative run of characters to translate the configured
+     * character count into pixels. '0' is used because its advance width is
+     * close to the average for most fonts. */
+    char *buf = smalloc(chars + 1);
+    memset(buf, '0', chars);
+    buf[chars] = '\0';
+    i3String *sample = i3string_from_utf8(buf);
+    /* Add the padding draw_util_text() leaves on both sides of the title. */
+    cached_width = predict_text_width(sample) + 2 * logical_px(2);
+    I3STRING_FREE(sample);
+    free(buf);
+
+    cached_chars = chars;
+    cached_font_height = config.font.height;
+    return cached_width;
+}
+
 /*
  * "Renders" the given container (and its children), meaning that all rects are
  * updated correctly. Note that this function does not call any xcb_*
@@ -437,10 +482,31 @@ static void render_con_split(Con *con, Con *child, render_params *p, int i) {
 static void render_con_stacked(Con *con, Con *child, render_params *p, int i) {
     assert(con->layout == L_STACKED);
 
+    const int title_width = (con->stack_title_position == STACK_TITLE_LEFT)
+                                ? render_stack_title_width()
+                                : 0;
+
     child->rect.x = p->x;
     child->rect.y = p->y;
     child->rect.width = p->rect.width;
     child->rect.height = p->rect.height;
+
+    if (title_width > 0) {
+        /* Vertical title column on the left, à la Firefox' vertical tabs. Each
+         * title bar is stacked below the previous one in a fixed-width column,
+         * and the (focused) window fills the remaining space to its right. The
+         * title text is clipped to the column width by x_draw_decoration(). */
+        child->deco_rect.x = p->x - con->rect.x;
+        child->deco_rect.y = p->y - con->rect.y + (i * p->deco_height);
+        child->deco_rect.width = min(title_width, (int)p->rect.width);
+        child->deco_rect.height = p->deco_height;
+
+        if (p->children > 1 || (child->border_style != BS_PIXEL && child->border_style != BS_NONE)) {
+            child->rect.x += child->deco_rect.width;
+            child->rect.width -= child->deco_rect.width;
+        }
+        return;
+    }
 
     child->deco_rect.x = p->x - con->rect.x;
     child->deco_rect.y = p->y - con->rect.y + (i * p->deco_height);

--- a/src/x.c
+++ b/src/x.c
@@ -950,7 +950,27 @@ void x_push_node(Con *con) {
         FREE(state->name);
     }
 
-    if (con->window == NULL && (con->layout == L_STACKED || con->layout == L_TABBED)) {
+    if (con->layout == L_STACKED && con->stack_title_position == STACK_TITLE_LEFT && con->window == NULL) {
+        /* The title bars are laid out as a vertical column on the left-hand
+         * side. Everything below the last title is left uncovered so the desktop
+         * wallpaper shows through. */
+        uint32_t max_y = 0, max_height = 0, max_width = 0;
+        TAILQ_FOREACH (current, &(con->nodes_head), nodes) {
+            Rect *dr = &(current->deco_rect);
+            if (dr->y >= max_y && dr->height >= max_height) {
+                max_y = dr->y;
+                max_height = dr->height;
+            }
+            if (dr->width > max_width) {
+                max_width = dr->width;
+            }
+        }
+        rect.width = max_width;
+        rect.height = max_y + max_height;
+        if (rect.height == 0) {
+            con->mapped = false;
+        }
+    } else if (con->window == NULL && (con->layout == L_STACKED || con->layout == L_TABBED)) {
         /* Calculate the height of all window decorations which will be drawn on to
          * this frame. */
         uint32_t max_y = 0, max_height = 0;


### PR DESCRIPTION
Title says it all. I mostly use the stack view but it wastes a lot of space when I have 15 different windows stacked. 
This patch adds a toggle to switch the titlebars between horizontal (the default) and vertical:

<img width="2559" height="1439" alt="a" src="https://github.com/user-attachments/assets/82b53066-d1b6-4542-b6d4-05c4cd15eba6" />

vs

<img width="2559" height="1438" alt="b" src="https://github.com/user-attachments/assets/f4cfa973-fb13-4407-a67c-4d81a93ac686" />

