### PR TITLE
docs: align reload binding with config file

### DIFF
--- a/docs/userguide
+++ b/docs/userguide
@@ -3096,7 +3096,7 @@ however you don’t need to (simply killing your X session is fine as well).
 *Examples*:
 ----------------------------
 bindsym $mod+Shift+r restart
-bindsym $mod+Shift+w reload
+bindsym $mod+Shift+c reload
 bindsym $mod+Shift+e exit
 ----------------------------
 


### PR DESCRIPTION
Default configuration file defines reload binding as $mod+Shift+c,
documentation defines it as $mod+Shift+w.

We should probably align them to $mod+Shift+c.