### PR TITLE
Fix titlebars for shaped windows

### DIFF
--- a/release-notes/bugfixes/3-fix-shape-titlebar
+++ b/release-notes/bugfixes/3-fix-shape-titlebar
@@ -1,0 +1,1 @@
+fix titlebars for shaped windows

--- a/src/x.c
+++ b/src/x.c
@@ -406,7 +406,9 @@ static void x_draw_decoration_after_title(Con *con, struct deco_render_params *p
  * number of rectangles.
  *
  */
-static size_t x_get_border_rectangles(Con *con, xcb_rectangle_t rectangles[4]) {
+static size_t x_get_border_rectangles(Con *con,
+                                      bool include_titlebar,
+                                      xcb_rectangle_t rectangles[4]) {
     size_t count = 0;
     int border_style = con_border_style(con);
 
@@ -439,7 +441,10 @@ static size_t x_get_border_rectangles(Con *con, xcb_rectangle_t rectangles[4]) {
             };
         }
         /* pixel border have an additional line at the top */
-        if (border_style == BS_PIXEL && !(borders_to_hide & ADJ_UPPER_SCREEN_EDGE)) {
+        bool add_pixel =
+            border_style == BS_PIXEL && !(borders_to_hide & ADJ_UPPER_SCREEN_EDGE);
+        bool add_titlebar = include_titlebar && con_draw_decoration_into_frame(con);
+        if (add_pixel || add_titlebar) {
             rectangles[count++] = (xcb_rectangle_t){
                 .x = br.x,
                 .y = 0,
@@ -570,7 +575,7 @@ void x_draw_decoration(Con *con) {
          * children are not freely resizable and we want their background color
          * to "shine through". */
         xcb_rectangle_t rectangles[4];
-        size_t rectangles_count = x_get_border_rectangles(con, rectangles);
+        size_t rectangles_count = x_get_border_rectangles(con, false, rectangles);
         for (size_t i = 0; i < rectangles_count; i++) {
             draw_util_rectangle(&(con->frame_buffer), p->color->child_border,
                                 rectangles[i].x,
@@ -878,7 +883,7 @@ static void x_shape_frame(Con *con, xcb_shape_sk_t shape_kind) {
                       con->window_rect.y + con->border_width,
                       con->window->id);
     xcb_rectangle_t rectangles[4];
-    size_t rectangles_count = x_get_border_rectangles(con, rectangles);
+    size_t rectangles_count = x_get_border_rectangles(con, true, rectangles);
     if (rectangles_count) {
         xcb_shape_rectangles(conn, XCB_SHAPE_SO_UNION, shape_kind,
                              XCB_CLIP_ORDERING_UNSORTED, con->frame.id,

--- a/testcases/t/301-shape.t
+++ b/testcases/t/301-shape.t
@@ -62,52 +62,94 @@ END_OF_C_CODE
 
 init_ctx($x->get_xcb_conn());
 
-my ($ws, $win1, $win1_focus, $win2, $win2_focus);
+my $ws; # set by run_test
+my ($bg_win, $bg_win_focus, $shaped_win, $shaped_win_focus); # set by the subtests
 
-################################################################################
-# Case 1: make floating window, then set shape
-################################################################################
+subtest 'normal border: make floating window, then set shape', \&run_test => sub {
+    $bg_win = open_floating_window(rect => [50, 50, 200, 200], background_color => '#ff0000');
+    $bg_win_focus = get_focused($ws);
 
-$ws = fresh_workspace;
+    $shaped_win = open_floating_window(rect => [100, 100, 100, 100], background_color => '#00ff00');
+    cmd '[id=' . $shaped_win->id . '] border normal 10px';
+    $shaped_win_focus = get_focused($ws);
+    set_shape($shaped_win->id);
+};
 
-$win1 = open_floating_window(rect => [0, 0, 100, 100], background_color => '#ff0000');
-$win1_focus = get_focused($ws);
+subtest 'normal border: set shape first, then make window floating', \&run_test, => sub {
+    $bg_win = open_window(rect => [50, 50, 200, 200], background_color => '#ff0000');
+    $bg_win_focus = get_focused($ws);
+    cmd 'floating toggle';
 
-$win2 = open_floating_window(rect => [0, 0, 100, 100], background_color => '#00ff00');
-$win2_focus = get_focused($ws);
-set_shape($win2->id);
+    $shaped_win = open_window(rect => [100, 100, 100, 100], background_color => '#00ff00');
+    cmd '[id=' . $shaped_win->id . '] border normal 10px';
+    $shaped_win_focus = get_focused($ws);
+    set_shape($shaped_win->id);
+    cmd 'floating toggle';
+};
 
-$win1->warp_pointer(75, 25);
-sync_with_i3;
-is(get_focused($ws), $win1_focus, 'focus switched to the underlying window');
+subtest 'pixel border: make floating window, then set shape', \&run_test => sub {
+    $bg_win = open_floating_window(rect => [50, 50, 200, 200], background_color => '#ff0000');
+    $bg_win_focus = get_focused($ws);
 
-$win1->warp_pointer(25, 25);
-sync_with_i3;
-is(get_focused($ws), $win2_focus, 'focus switched to the top window');
+    $shaped_win = open_floating_window(rect => [100, 100, 100, 100], background_color => '#00ff00');
+    cmd '[id=' . $shaped_win->id . '] border pixel 10px';
+    $shaped_win_focus = get_focused($ws);
+    set_shape($shaped_win->id);
+};
 
-kill_all_windows;
+subtest 'pixel border: set shape first, then make window floating', \&run_test, => sub {
+    $bg_win = open_window(rect => [50, 50, 200, 200], background_color => '#ff0000');
+    $bg_win_focus = get_focused($ws);
+    cmd 'floating toggle';
 
-################################################################################
-# Case 2: set shape first, then make window floating
-################################################################################
-
-$ws = fresh_workspace;
-
-$win1 = open_window(rect => [0, 0, 100, 100], background_color => '#ff0000');
-$win1_focus = get_focused($ws);
-cmd 'floating toggle';
-
-$win2 = open_window(rect => [0, 0, 100, 100], background_color => '#00ff00');
-$win2_focus = get_focused($ws);
-set_shape($win2->id);
-cmd 'floating toggle';
-
-$win1->warp_pointer(75, 25);
-sync_with_i3;
-is(get_focused($ws), $win1_focus, 'focus switched to the underlying window');
-
-$win1->warp_pointer(25, 25);
-sync_with_i3;
-is(get_focused($ws), $win2_focus, 'focus switched to the top window');
+    $shaped_win = open_window(rect => [100, 100, 100, 100], background_color => '#00ff00');
+    cmd '[id=' . $shaped_win->id . '] border pixel 10px';
+    $shaped_win_focus = get_focused($ws);
+    set_shape($shaped_win->id);
+    cmd 'floating toggle';
+};
 
 done_testing;
+
+sub run_test {
+    my ($setup_sub) = @_;
+    $ws = fresh_workspace;
+    $setup_sub->();
+
+    # Test the input region by observing the focus_follows_mouse behavior.
+    # The visual conunterpart (clip region) is not tested, but it uses the same
+    # code path.
+
+    # 4    5    6
+    #  ┌───┬───┐
+    #  │ 1 │ 2 │
+    # 7├───┴───┤8
+    #  │   3   │
+    #  └───────┘
+    #      9
+    my @points_table = (
+        { x =>  25, y =>  25, opaque => 1, name => '1: window zone A' },
+        { x =>  75, y =>  25, opaque => 0, name => '2: window zone B' },
+        { x =>  50, y =>  75, opaque => 0, name => '3: window zone C' },
+
+        { x =>  -5, y =>  -5, opaque => 1, name => '4: titlebar left' },
+        { x =>  50, y =>  -5, opaque => 1, name => '5: titlebar center' },
+        { x => 105, y =>  -5, opaque => 1, name => '6: titlebar right' },
+
+        { x =>  50, y => 105, opaque => 1, name => '7: border left' },
+        { x =>  -5, y =>  50, opaque => 1, name => '8: border right' },
+        { x => 105, y =>  50, opaque => 1, name => '9: border bottom' },
+    );
+
+    for my $p (@points_table) {
+        $shaped_win->warp_pointer($p->{x}, $p->{y});
+        sync_with_i3;
+        if ($p->{opaque}) {
+            is(get_focused($ws), $shaped_win_focus, "opaque      - $p->{name}");
+        } else {
+            is(get_focused($ws), $bg_win_focus,     "passthrough - $p->{name}");
+        }
+    }
+
+    kill_all_windows;
+}


### PR DESCRIPTION
This PR fixes a bug: titlebars for shaped windows are not visible since d26ddcbf.

How to reproduce: run `xeyes`, make it floating.

Actual behavior: window titlebar is not visible. 

<img width="520" height="170" alt="before" src="https://github.com/user-attachments/assets/875ba2b1-b81c-408b-9a1a-3d6207160cc2" />

After the fix:

<img width="520" height="170" alt="after" src="https://github.com/user-attachments/assets/bdc747d9-47cc-48ea-bc40-d5a49ded89fa" />

Created with help by Claude Opus 4.8.