### PR TITLE
[OBSOLETE] Enforce tracking of ignored events by 32-bit full sequence

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -124,7 +124,7 @@ static void check_crossing_screen_boundary(uint32_t x, uint32_t y) {
  * When the user moves the mouse pointer onto a window, this callback gets called.
  *
  */
-static void handle_enter_notify(xcb_enter_notify_event_t *event) {
+static void handle_enter_notify(xcb_enter_notify_event_t *event, uint32_t full_sequence) {
     Con *con;
 
     last_timestamp = event->time;
@@ -138,7 +138,7 @@ static void handle_enter_notify(xcb_enter_notify_event_t *event) {
     }
     /* Some events are not interesting, because they were not generated
      * actively by the user, but by reconfiguration of windows */
-    if (event_is_ignored(event->sequence, XCB_ENTER_NOTIFY)) {
+    if (event_is_ignored(full_sequence, XCB_ENTER_NOTIFY)) {
         DLOG("Event ignored\n");
         return;
     }
@@ -1514,7 +1514,7 @@ void handle_event(int type, xcb_generic_event_t *event) {
 
         /* Enter window = user moved their mouse over the window */
         case XCB_ENTER_NOTIFY:
-            handle_enter_notify((xcb_enter_notify_event_t *)event);
+            handle_enter_notify((xcb_enter_notify_event_t *)event, event->full_sequence);
             break;
 
         /* Client message are sent to the root window. The only interesting

--- a/testcases/t/556-workspace-keeps-focus-after-move.t
+++ b/testcases/t/556-workspace-keeps-focus-after-move.t
@@ -1,0 +1,57 @@
+#!perl
+# vim:ts=4:sw=4:expandtab
+#
+# Please read the following documents before working on tests:
+# • https://build.i3wm.org/docs/testsuite.html
+#   (or docs/testsuite)
+#
+# • https://build.i3wm.org/docs/lib-i3test.html
+#   (alternatively: perldoc ./testcases/lib/i3test.pm)
+#
+# • https://build.i3wm.org/docs/ipc.html
+#   (or docs/ipc)
+#
+# • https://i3wm.org/downloads/modern_perl_a4.pdf
+#   (unless you are already familiar with Perl)
+#
+# Tests that a workspace keeps its focus after moving even in event-heavy sessions.
+# Ticket: #6372
+# Bug still in: 4.25-24-gf7d5b898
+use i3test i3_autostart => 0;
+
+my $config = <<EOT;
+font -misc-fixed-medium-r-normal--13-120-75-75-C-70-iso10646-1
+
+fake-outputs 1024x768+0+0,1024x768+1024+0
+EOT
+
+my $pid = launch_with_config($config);
+
+cmd 'workspace ws1';
+cmd 'layout default';
+cmd 'split v';
+
+my $top = open_window;
+my $bottom = open_window;
+is($x->input_focus, $bottom->id, 'bottom window focused');
+
+for (1 .. 1000) {
+    cmd 'move up; move down';
+}
+is($x->input_focus, $bottom->id, 'bottom window still focused after some events');
+
+cmd 'move workspace to output right';
+is($x->input_focus, $bottom->id, 'bottom window still focused after some events and after workspace has been moved');
+cmd 'move workspace to output left';
+
+for (1 .. 9000) {
+    cmd 'move up; move down';
+}
+is($x->input_focus, $bottom->id, 'bottom window still focused after many events');
+
+cmd 'move workspace to output right';
+is($x->input_focus, $bottom->id, 'bottom window still focused after many events and after workspace has been moved');
+
+exit_gracefully($pid);
+
+done_testing;


### PR DESCRIPTION
This PR is a follow-up to the discussion in #6372 .

I'm not too familiar with the internals of X11, but it seems that sequence numbers are sometimes of type `uint16_t` and sometimes of type `unsigned int` or `uint32_t`. In some places XCB provides the field `full_sequence` (for example as part of `xcb_generic_event_t`), but other structs only have the 16-bit sequence. Then there is also `xcb_void_cookie_t` which has `unsigned int` for `sequence`.

The current code for tracking ignored events mixes these different data types. This works fine, as long as the sequence number doesn't overflow a `uint16_t`. Afterwards, the tracking of ignored events will fail. This appears to be the reason for #6372 and probably also #6364 . There is also the open PR https://github.com/i3/i3/pull/6559 which notes: "[...] add the sequence to the ignore list, but under some (unknown) circumstances, that does not seem to work reliably."

This problem already existed in 4.23 (and before), but only became visible in 4.24, because it seems that is was masked by using `XCB_GRAB_MODE_SYNC` when executing key bindings. This seems to mask the bug, but sending a command via `i3-msg` also triggers it in 4.23 . Commit https://github.com/i3/i3/commit/b42dc21068196dd60a0806575f0f8bb01610fd0e changed `XCB_GRAB_MODE_SYNC` to `XCB_GRAB_MODE_ASYNC` and surfaced the bug. Additionally, the commit https://github.com/i3/i3/commit/cfa4cf16 increased the number of messages being sent and sequence numbers being used, which triggers this bug more quickly than before.

The first commit in this PR introduces a test for #6372 . I found a more performant way of overflowing the uint16_t sequence number (using sync_with_i3 to create fairly cheap messages). The test runs in 1.3 seconds on my system.

The second commit fixes the problem. It defines a new data type `ignore_event_sequence_t` and a macro `ENSURE_FULL_SEQUENCE` which is then used at every call site for `add_ignore_event` and `event_is_ignored`. This way the compiler checks that a full sequence number is used everywhere. Perhaps this is over-engineered? Please let me know - I don't work much in C.

This change makes the test pass and also fixes #6372 for me in my manual testing.

Looking forward to feedback!

Disclosure of AI assistance: I used Claude Fable 5 and GPT-5.6 Sol as sparring partners, but everything here is hand-written.