### PR TITLE
Fix race-condition in testsuite that sometimes results in "could not kill i3: No such process"

### DIFF
--- a/testcases/lib/TestWorker.pm
+++ b/testcases/lib/TestWorker.pm
@@ -42,8 +42,8 @@ sub worker {
     if ($pid == 0) {
         close $ipc;
         undef @complete_run::CLEANUP;
-        # reap dead test children
-        $SIG{CHLD} = sub { waitpid -1, POSIX::WNOHANG };
+        # Test children are waited for synchronously in worker_wait().
+        $SIG{CHLD} = 'DEFAULT';
 
         $worker->{ipc} = $ipc_child;
 
@@ -130,12 +130,21 @@ sub worker_wait {
             do $file;
             $test->ok(undef, "$@") if $@;
 
-            # XXX hack, we need to trigger the read watcher once more
-            # to signal eof to TAP::Parser
-            print $EOF;
-
             exit 0;
         }
+
+        # Wait until the test process has exited, including all of its END
+        # blocks. In particular, i3test's END block terminates and reaps the i3
+        # process. Only signal completion afterwards so that complete-run.pl
+        # cannot start the next test on this display while the previous i3 is
+        # still running.
+        my $waited = waitpid $pid, 0;
+        die "waitpid($pid): $!" unless $waited == $pid;
+
+        # XXX hack, we need to trigger the read watcher once more
+        # to signal eof to TAP::Parser
+        syswrite($ipc, $EOF) == length($EOF)
+            or die "could not signal test completion: $!";
     }
 }
 


### PR DESCRIPTION
I noticed that the testsuite sometimes fails with "could not kill i3: No such process". Looking at the test logs in detail, one can see the error "Socket is already in use" - i3 is starting up on a (test) display where another instance is already active.

This appears to be a race-condition in TestWorker.pm . It can be forced by adding this sleep:

```diff
diff --git a/testcases/lib/TestWorker.pm b/testcases/lib/TestWorker.pm
index 9716f7f1..32f33486 100644
--- a/testcases/lib/TestWorker.pm
+++ b/testcases/lib/TestWorker.pm
@@ -134,6 +134,8 @@ sub worker_wait {
             # to signal eof to TAP::Parser
             print $EOF;
 
+            sleep(1);
+
             exit 0;
         }
     }
```

The test process signals the end of the testing by emitting $EOF, but the END block of i3test has not been triggered yet. If the next test starts up quickly enough and re-uses the display, it might run into the i3 instance that is still cleaning up.

The proposed change waits for the forked test process to exit (including its i3 process) and only then emits the "end of test" signal.

This bug was found and fixed by GPT-5.6 Sol. I reviewed and tweaked the patch.