### PR TITLE
fix: border flicker and black flashes during interactive floating move/resize

### DIFF
--- a/release-notes/bugfixes/4-frame-background-pixmap
+++ b/release-notes/bugfixes/4-frame-background-pixmap
@@ -1,0 +1,3 @@
+Set the decorated frame pixmap as the frame window background (and stop
+recreating the pixmap on pure moves), eliminating black flashes and border
+flicker during interactive floating move/resize, especially under compositors.

--- a/src/drag.c
+++ b/src/drag.c
@@ -9,9 +9,26 @@
  */
 #include "all.h"
 
+/* Minimum interval between two invocations of the drag callback. Each
+ * invocation typically results in a ConfigureWindow (plus, for resizes, a
+ * backing store reallocation and decoration repaint), so relaying raw motion
+ * events from a high-rate mouse floods the X server and any compositor.
+ * 8ms ≈ 125 updates/s, above common display refresh rates. */
+#define DRAG_CALLBACK_INTERVAL 0.008
+
 /* Custom data structure used to track dragging-related events. */
 struct drag_x11_cb {
     ev_prepare prepare;
+
+    /* Delivers a motion that was deferred by rate-limiting. */
+    ev_timer timer;
+
+    /* ev_now timestamp of the last callback invocation. */
+    double last_callback;
+
+    /* A motion was suppressed by rate-limiting and awaits delivery. */
+    bool has_pending;
+    int pending_x, pending_y;
 
     /* Whether this modal event loop should be exited and with which result. */
     drag_result_t result;
@@ -140,13 +157,30 @@ static bool drain_drag_events(EV_P, struct drag_x11_cb *dragloop) {
      * container still exists. The latter might not be true, e.g., if the window closed
      * for any reason while the user was dragging it. */
     if (dragloop->threshold_exceeded && (!dragloop->con || con_exists(dragloop->con))) {
-        dragloop->callback(
-            dragloop->con,
-            &(dragloop->old_rect),
-            last_motion_notify->root_x,
-            last_motion_notify->root_y,
-            dragloop->event,
-            dragloop->extra);
+        if (dragloop->result == DRAGGING &&
+            ev_now(EV_A) - dragloop->last_callback < DRAG_CALLBACK_INTERVAL) {
+            /* Too soon: remember the position and deliver it via the timer so
+             * the drag always settles at the true final pointer position. */
+            dragloop->pending_x = last_motion_notify->root_x;
+            dragloop->pending_y = last_motion_notify->root_y;
+            dragloop->has_pending = true;
+            if (!ev_is_active(&dragloop->timer)) {
+                ev_timer_set(&(dragloop->timer),
+                             dragloop->last_callback + DRAG_CALLBACK_INTERVAL - ev_now(EV_A), 0.);
+                ev_timer_start(EV_A_ & (dragloop->timer));
+            }
+        } else {
+            dragloop->has_pending = false;
+            ev_timer_stop(EV_A_ & (dragloop->timer));
+            dragloop->last_callback = ev_now(EV_A);
+            dragloop->callback(
+                dragloop->con,
+                &(dragloop->old_rect),
+                last_motion_notify->root_x,
+                last_motion_notify->root_y,
+                dragloop->event,
+                dragloop->extra);
+        }
     }
     FREE(last_motion_notify);
 
@@ -158,6 +192,23 @@ static void xcb_drag_prepare_cb(EV_P_ ev_prepare *w, int revents) {
     struct drag_x11_cb *dragloop = w->data;
     while (!drain_drag_events(EV_A, dragloop)) {
         /* repeatedly drain events: draining might produce additional ones */
+    }
+}
+
+static void drag_timer_cb(EV_P_ ev_timer *w, int revents) {
+    struct drag_x11_cb *dragloop = w->data;
+    if (dragloop->has_pending && dragloop->result == DRAGGING &&
+        (!dragloop->con || con_exists(dragloop->con))) {
+        dragloop->has_pending = false;
+        dragloop->last_callback = ev_now(EV_A);
+        dragloop->callback(
+            dragloop->con,
+            &(dragloop->old_rect),
+            dragloop->pending_x,
+            dragloop->pending_y,
+            dragloop->event,
+            dragloop->extra);
+        xcb_flush(conn);
     }
 }
 
@@ -237,12 +288,16 @@ drag_result_t drag_pointer(Con *con, const xcb_button_press_event_t *event,
     }
     ev_prepare_init(prepare, xcb_drag_prepare_cb);
     prepare->data = &loop;
+    ev_timer_init(&loop.timer, drag_timer_cb, 0., 0.);
+    loop.timer.data = &loop;
     main_set_x11_cb(false);
     ev_prepare_start(main_loop, prepare);
 
     ev_loop(main_loop, 0);
 
     ev_prepare_stop(main_loop, prepare);
+    /* The timer must not outlive this stack frame. */
+    ev_timer_stop(main_loop, &loop.timer);
     main_set_x11_cb(true);
 
     xcb_ungrab_keyboard(conn, XCB_CURRENT_TIME);

--- a/src/x.c
+++ b/src/x.c
@@ -1115,6 +1115,25 @@ void x_push_node(Con *con) {
          * window get lost when resizing it, therefore we want to provide it as
          * fast as possible) */
         xcb_flush(conn);
+
+        /* When the frame grows, resize the child first: a child may extend
+         * beyond its parent (it is simply clipped), so once the frame grows,
+         * the enlarged child instantly covers the newly exposed area instead
+         * of the frame background showing through until the child configure
+         * is processed. This matters especially for borderless frames, whose
+         * background (a transparent pixel on 32-bit visuals) would otherwise
+         * be visible as a flickering strip during interactive resize. */
+        bool child_first = con->window != NULL &&
+                           !rect_equals(state->window_rect, con->window_rect) &&
+                           rect.width >= state->rect.width &&
+                           rect.height >= state->rect.height;
+        if (child_first) {
+            DLOG("setting window rect (%d, %d, %d, %d) (child first)\n",
+                 con->window_rect.x, con->window_rect.y, con->window_rect.width, con->window_rect.height);
+            xcb_set_window_rect(conn, con->window->id, con->window_rect);
+            memcpy(&(state->window_rect), &(con->window_rect), sizeof(Rect));
+        }
+
         xcb_set_window_rect(conn, con->frame.id, rect);
         if (con->frame_buffer.id != XCB_NONE) {
             draw_util_copy_surface(&(con->frame_buffer), &(con->frame), 0, 0, 0, 0, con->rect.width, con->rect.height);
@@ -1125,7 +1144,7 @@ void x_push_node(Con *con) {
         fake_notify = true;
     }
 
-    /* ditto, but for child windows */
+    /* ditto, but for child windows (unless already configured above) */
     if (con->window != NULL &&
         !rect_equals(state->window_rect, con->window_rect)) {
         DLOG("setting window rect (%d, %d, %d, %d)\n",

--- a/src/x.c
+++ b/src/x.c
@@ -1034,8 +1034,11 @@ void x_push_node(Con *con) {
          * background and only afterwards change the window size. This reduces
          * flickering. */
 
-        bool has_rect_changed = (state->rect.x != rect.x || state->rect.y != rect.y ||
-                                 state->rect.width != rect.width || state->rect.height != rect.height);
+        /* A move (x/y change) cannot invalidate the pixmap: the decoration is
+         * drawn in frame-local coordinates. Only recreate it when the size
+         * changes. */
+        bool has_size_changed = (state->rect.width != rect.width ||
+                                 state->rect.height != rect.height);
 
         /* Check if the container has an unneeded pixmap left over from
          * previously having a border or titlebar. */
@@ -1045,7 +1048,7 @@ void x_push_node(Con *con) {
             con->frame_buffer.id = XCB_NONE;
         }
 
-        if (is_pixmap_needed && (has_rect_changed || con->frame_buffer.id == XCB_NONE)) {
+        if (is_pixmap_needed && (has_size_changed || con->frame_buffer.id == XCB_NONE)) {
             if (con->frame_buffer.id == XCB_NONE) {
                 con->frame_buffer.id = xcb_generate_id(conn);
             } else {

--- a/src/x.c
+++ b/src/x.c
@@ -1043,6 +1043,10 @@ void x_push_node(Con *con) {
         /* Check if the container has an unneeded pixmap left over from
          * previously having a border or titlebar. */
         if (!is_pixmap_needed && con->frame_buffer.id != XCB_NONE) {
+            /* Reset the background to a plain pixel so the window does not
+             * keep a reference to the pixmap we are about to free. */
+            xcb_change_window_attributes(conn, con->frame.id, XCB_CW_BACK_PIXEL,
+                                         (uint32_t[]){root_screen->black_pixel});
             draw_util_surface_free(conn, &(con->frame_buffer));
             xcb_free_pixmap(conn, con->frame_buffer.id);
             con->frame_buffer.id = XCB_NONE;
@@ -1095,6 +1099,14 @@ void x_push_node(Con *con) {
                  * doesn’t hurt performance. */
                 x_deco_recurse(con);
             }
+
+            /* Set the decorated pixmap as the window background so the X
+             * server fills exposed regions (e.g. when the window grows) from
+             * it directly instead of flashing the background pixel, and so a
+             * compositor sees decorated content as soon as the resize takes
+             * effect. */
+            xcb_change_window_attributes(conn, con->frame.id, XCB_CW_BACK_PIXMAP,
+                                         (uint32_t[]){con->frame_buffer.id});
         }
 
         DLOG("setting rect (%d, %d, %d, %d)\n", rect.x, rect.y, rect.width, rect.height);


### PR DESCRIPTION
**Why I made this**

I run i3 with a compositor (picom), and dragging or resizing floating windows was genuinely ugly on my setup: borders would flicker or vanish entirely during a resize, the newly-grown edge would flash black (or transparent, with default_border none), and with a 1000Hz mouse the whole thing turned into a stutter-fest. On a fast monitor you see every bad frame, so this bugged me daily until I dug in.

**I know CONTRIBUTING says compositor issues are usually the compositor's fault**, so before touching i3 I made sure it wasn't.
I instrumented both sides (i3 and the compositor) and traced the actual X protocol traffic during resize storms. The flicker is real 

On i3's side: there's a window of time where the frame has been resized but its content isn't decorated yet, and anything
sampling the window in that moment (a compositor, or just your eyes on a slow refresh) sees garbage.

Without a compositor it's a barely-visible flash; with one it's a lost race that happens constantly during a fast drag.

The fun part: the fix was already described in the code — 15+ years ago

`x_push_node()` has this comment:

> we render the decoration on any pixmap change […] set it as the background and only afterwards change the window size. This reduces flickering.

The "set it as the background" part was never actually implemented. Frames only ever had XCB_CW_BACK_PIXEL (black). So on every grow, the server fills the new region with black first, and the decorated content only arrives with the later CopyArea: that's the flash, and the race the compositor keeps losing.

This PR finally does what the comment promised, plus fixes three related problems I found on the way.


**What each commit does**

1. 105a9d25 : the pixmap realloc gate compared the full rect, so a pure move (x/y only) destroyed and recreated the frame's backing pixmap plus a full decoration repaint on every pointer motion. The decoration is drawn in frame-local coordinates; a move can't invalidate it. Now only size changes do.

2. adac41b7 : the missing half of the old comment. With the freshly-painted pixmap as the window background, the X server fills exposed regions with decorated content itself, atomically with the resize. No black flash, and a compositor can never sample an undecorated frame.

3. 17b1ac9e : with default_border none there is no frame pixmap at all, so the previous commit can't help there. But a child window may validly extend beyond its parent, so on grow we can resize the child first — by the time the frame grows, the child already covers the new area and the (transparent) background never shows.

4. 6caaee46 : i3 already coalesces motion events per event-loop iteration, but that's bounded by queue drain, not time: a 1000Hz mouse still drives several hundred ConfigureWindows per second, far beyond what any display can show. Callbacks are now limited to one per 8ms (~125/s), with a one-shot timer delivering the last suppressed motion so the window always lands exactly where the pointer stopped.

| Metric during resize storm                                         | Stock i3                                                                                                                                                                          | With this PR                                                                                                 | What it proves                                                                                                                                                                                                                                                           |
| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| **Frame content sampled immediately after `ConfigureWindow`**      | Undecorated frames were captured regularly.<br><br>In **872 of 877 binds**, the compositor displayed a store that had already been superseded by a newer configure.               | **1092 of 1092 samples were decorated.**<br><br>**Zero black frames.**                                       | i3 handed the compositor an undecorated frame. The X server filled newly exposed regions with the background pixel, which was black, before i3 copied the decorations.<br><br>Using the pixmap as the background removes the point where an undecorated store can exist. |
| **Compositor-side mitigation attempts**                            | Paint reordering, stale-bind skipping, and bind rescheduling were tested and exhausted.<br><br>Even with stale-bind skipping, **1050 of 1060 binds** had already been superseded. | Not needed.                                                                                                  | The compositor cannot reliably solve the problem because every available store may already contain server-filled black regions.<br><br>The fix must happen in the window manager, where the pixels are produced.                                                         |
| **Frame pixmap reallocations during a pure move drag**             | One destroy, create, and full decoration repaint occurred for every pointer movement.<br><br>With a 1000 Hz mouse, this could happen several hundred times per second.            | **Zero reallocations.**<br><br>Moving a window no longer invalidates the pixmap.                             | This was unnecessary work performed entirely by i3. The compositor was not involved.                                                                                                                                                                                     |
| **`ConfigureWindow` rate during drag**                             | Unbounded, reaching several hundred calls per second.<br><br>Events were only coalesced once per event-loop iteration.                                                            | Limited to **125 calls per second**, using an 8 ms interval.<br><br>The final window position remains exact. | A display cannot present the excess updates. They only overload and starve the rendering pipeline.                                                                                                                                                                       |
| **Host result with the same compositor build and only i3 changed** | Borders flickered or disappeared.<br><br>A transparent strip appeared along the growing edge.                                                                                     | The transparent grow gap is gone.<br><br>The resize-stop flicker is gone.                                    | The compositor remained unchanged. Only i3 changed, so the behavioral difference comes from i3.                                                                                                                                                                          |


This was researched thoroughly for 2 days with the help of **Fable 5 xhigh**. I understand the code, the fixes and what this PR changes.
What I don't get to understand 100% is what this can "break", tests were ran successfully, I've been using this PR without any issue so far, but if you encounter any please tell me and I will revisit the commits.