### PR TITLE
drag: prevent nested mouse drag loops

### DIFF
--- a/release-notes/bugfixes/3-drag-failed-grab
+++ b/release-notes/bugfixes/3-drag-failed-grab
@@ -1,1 +1,1 @@
-abort mouse dragging when the pointer or keyboard cannot be grabbed
+abort mouse dragging when input grabs fail and prevent nested mouse drags

--- a/release-notes/bugfixes/3-drag-failed-grab
+++ b/release-notes/bugfixes/3-drag-failed-grab
@@ -1,0 +1,1 @@
+abort mouse dragging when the pointer or keyboard cannot be grabbed

--- a/src/drag.c
+++ b/src/drag.c
@@ -73,8 +73,10 @@ static bool drain_drag_events(EV_P, struct drag_x11_cb *dragloop) {
 
             case XCB_BUTTON_RELEASE: {
                 const xcb_button_release_event_t *release = (xcb_button_release_event_t *)event;
-                if (release->detail == dragloop->event->detail) {
-                    DLOG("Button %d released, ending drag\n", release->detail);
+                if (dragloop->event->detail == XCB_BUTTON_INDEX_ANY ||
+                    release->detail == dragloop->event->detail) {
+                    DLOG("Button %d released, ending drag initiated by button %d\n",
+                         release->detail, dragloop->event->detail);
                     dragloop->result = DRAG_SUCCESS;
                 } else {
                     DLOG("Ignoring button %d release during drag initiated by button %d\n",

--- a/src/drag.c
+++ b/src/drag.c
@@ -199,6 +199,12 @@ drag_result_t drag_pointer(Con *con, const xcb_button_press_event_t *event,
         return DRAG_ABORT;
     }
 
+    if (reply->status != XCB_GRAB_STATUS_SUCCESS) {
+        ELOG("Could not grab pointer (status = %d)\n", reply->status);
+        free(reply);
+        return DRAG_ABORT;
+    }
+
     free(reply);
 
     /* Grab the keyboard */
@@ -215,6 +221,13 @@ drag_result_t drag_pointer(Con *con, const xcb_button_press_event_t *event,
     if ((keyb_reply = xcb_grab_keyboard_reply(conn, keyb_cookie, &error)) == NULL) {
         ELOG("Could not grab keyboard (error_code = %d)\n", error->error_code);
         free(error);
+        xcb_ungrab_pointer(conn, XCB_CURRENT_TIME);
+        return DRAG_ABORT;
+    }
+
+    if (keyb_reply->status != XCB_GRAB_STATUS_SUCCESS) {
+        ELOG("Could not grab keyboard (status = %d)\n", keyb_reply->status);
+        free(keyb_reply);
         xcb_ungrab_pointer(conn, XCB_CURRENT_TIME);
         return DRAG_ABORT;
     }

--- a/src/drag.c
+++ b/src/drag.c
@@ -64,9 +64,24 @@ static bool drain_drag_events(EV_P, struct drag_x11_cb *dragloop) {
         int type = (event->response_type & 0x7F);
 
         switch (type) {
-            case XCB_BUTTON_RELEASE:
-                dragloop->result = DRAG_SUCCESS;
+            case XCB_BUTTON_PRESS: {
+                const xcb_button_press_event_t *press = (xcb_button_press_event_t *)event;
+                DLOG("Ignoring button %d press during drag initiated by button %d\n",
+                     press->detail, dragloop->event->detail);
                 break;
+            }
+
+            case XCB_BUTTON_RELEASE: {
+                const xcb_button_release_event_t *release = (xcb_button_release_event_t *)event;
+                if (release->detail == dragloop->event->detail) {
+                    DLOG("Button %d released, ending drag\n", release->detail);
+                    dragloop->result = DRAG_SUCCESS;
+                } else {
+                    DLOG("Ignoring button %d release during drag initiated by button %d\n",
+                         release->detail, dragloop->event->detail);
+                }
+                break;
+            }
 
             case XCB_KEY_PRESS:
                 DLOG("A key was pressed during drag, reverting changes.\n");
@@ -96,6 +111,19 @@ static bool drain_drag_events(EV_P, struct drag_x11_cb *dragloop) {
                 FREE(last_motion_notify);
                 last_motion_notify = (xcb_motion_notify_event_t *)event;
                 break;
+
+            case XCB_CLIENT_MESSAGE: {
+                const xcb_client_message_event_t *client_message = (xcb_client_message_event_t *)event;
+                if (client_message->type == A__NET_WM_MOVERESIZE) {
+                    DLOG("Ignoring _NET_WM_MOVERESIZE request during active drag "
+                         "(window = 0x%08x, direction = %d)\n",
+                         client_message->window, client_message->data.data32[2]);
+                    break;
+                }
+
+                handle_event(type, event);
+                break;
+            }
 
             default:
                 DLOG("Passing to original handler\n");
@@ -205,6 +233,7 @@ drag_result_t drag_pointer(Con *con, const xcb_button_press_event_t *event,
         return DRAG_ABORT;
     }
 
+    DLOG("Pointer grab successful\n");
     free(reply);
 
     /* Grab the keyboard */
@@ -232,6 +261,7 @@ drag_result_t drag_pointer(Con *con, const xcb_button_press_event_t *event,
         return DRAG_ABORT;
     }
 
+    DLOG("Keyboard grab successful\n");
     free(keyb_reply);
 
     /* Go into our own event loop */
@@ -253,7 +283,10 @@ drag_result_t drag_pointer(Con *con, const xcb_button_press_event_t *event,
     main_set_x11_cb(false);
     ev_prepare_start(main_loop, prepare);
 
+    DLOG("Entering drag loop (con = %p, button = %d)\n", con, event->detail);
     ev_loop(main_loop, 0);
+    DLOG("Leaving drag loop (con = %p, button = %d, result = %d)\n",
+         con, event->detail, loop.result);
 
     ev_prepare_stop(main_loop, prepare);
     main_set_x11_cb(true);

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -942,6 +942,7 @@ static void handle_client_message(xcb_client_message_event_t *event) {
         uint32_t y_root = event->data.data32[1];
         /* construct fake xcb_button_press_event_t */
         xcb_button_press_event_t fake = {
+            .detail = event->data.data32[3],
             .root_x = x_root,
             .root_y = y_root,
             .event_x = x_root - (con->rect.x),

--- a/testcases/t/316-drag-container.t
+++ b/testcases/t/316-drag-container.t
@@ -88,6 +88,33 @@ is($x->input_focus, $A->id, 'Floating window moved to the right workspace');
 is($ws2, focused_ws, 'Empty workspace focused after floating window dragged to it');
 
 ###############################################################################
+# Additional mouse buttons during a drag must not start a nested drag.
+###############################################################################
+
+$ws1 = fresh_workspace(output => 0);
+$A = open_floating_window(rect => [ 30, 30, 50, 50 ]);
+my ($initial_rect) = $A->rect;
+
+start_drag(40, 40);
+xtest_button_press(3, 100, 100);
+xtest_button_release(3, 200, 200);
+xtest_button_release(1, 250, 250);
+xtest_key_release(64); # Alt_L
+xtest_sync_with_i3;
+
+my ($dragged_rect) = $A->rect;
+is($dragged_rect->width, $initial_rect->width,
+   'Additional button did not resize floating window during drag');
+is($dragged_rect->height, $initial_rect->height,
+   'Floating window height unchanged after additional button');
+
+$x->root->warp_pointer(400, 400);
+sync_with_i3;
+my ($after_motion_rect) = $A->rect;
+is_deeply($after_motion_rect, $dragged_rect,
+          'Floating window no longer follows pointer after initiating button release');
+
+###############################################################################
 # Drag tiling container onto an empty workspace.
 ###############################################################################
 

--- a/testcases/t/316-drag-container.t
+++ b/testcases/t/316-drag-container.t
@@ -59,6 +59,28 @@ sub end_drag {
     xtest_sync_with_i3;
 }
 
+sub net_wm_moveresize {
+    my ($window, $pos_x, $pos_y, $button) = @_;
+
+    my $msg = pack "CCSLLLLLLL",
+        X11::XCB::CLIENT_MESSAGE, # response_type
+        32, # format
+        0, # sequence
+        $window->id, # window
+        $x->atom(name => '_NET_WM_MOVERESIZE')->id, # message type
+        $pos_x, # data32[0] (x_root)
+        $pos_y, # data32[1] (y_root)
+        8, # data32[2] (_NET_WM_MOVERESIZE_MOVE)
+        $button, # data32[3] (initiating button)
+        1; # data32[4] (application source)
+
+    $x->send_event(0, $x->get_root_window(),
+                   X11::XCB::EVENT_MASK_SUBSTRUCTURE_REDIRECT, $msg);
+    # Ensure the ClientMessage is queued before XTEST sends events using its
+    # separate X11 connection.
+    $x->input_focus;
+}
+
 my ($ws1, $ws2);
 my ($A, $B, $tmp);
 my ($A_id, $B_id);
@@ -113,6 +135,64 @@ sync_with_i3;
 my ($after_motion_rect) = $A->rect;
 is_deeply($after_motion_rect, $dragged_rect,
           'Floating window no longer follows pointer after initiating button release');
+
+###############################################################################
+# Client-initiated drags use the button from _NET_WM_MOVERESIZE and reject
+# repeated move requests without losing the initiating button's release.
+###############################################################################
+
+$ws1 = fresh_workspace(output => 0);
+$A = open_floating_window(rect => [ 30, 30, 50, 50 ]);
+($initial_rect) = $A->rect;
+
+$x->root->warp_pointer(40, 40);
+sync_with_i3;
+xtest_button_press(1, 40, 40);
+net_wm_moveresize($A, 40, 40, 1);
+net_wm_moveresize($A, 40, 40, 1);
+$x->root->warp_pointer(100, 100);
+sync_with_i3;
+xtest_button_press(3, 100, 100);
+xtest_button_release(3, 100, 100);
+$x->root->warp_pointer(250, 250);
+sync_with_i3;
+xtest_button_release(1, 250, 250);
+xtest_sync_with_i3;
+
+($dragged_rect) = $A->rect;
+cmp_ok($dragged_rect->x, '>', 150,
+       'Client-initiated drag ignored a different button release');
+$x->root->warp_pointer(400, 400);
+sync_with_i3;
+($after_motion_rect) = $A->rect;
+is_deeply($after_motion_rect, $dragged_rect,
+          'Client-initiated drag ends on its initiating button release');
+
+###############################################################################
+# Older or non-compliant clients may omit the _NET_WM_MOVERESIZE button.
+###############################################################################
+
+$ws1 = fresh_workspace(output => 0);
+$A = open_floating_window(rect => [ 30, 30, 50, 50 ]);
+($initial_rect) = $A->rect;
+
+$x->root->warp_pointer(40, 40);
+sync_with_i3;
+xtest_button_press(1, 40, 40);
+net_wm_moveresize($A, 40, 40, 0);
+$x->root->warp_pointer(250, 250);
+sync_with_i3;
+xtest_button_release(1, 250, 250);
+xtest_sync_with_i3;
+
+($dragged_rect) = $A->rect;
+isnt($dragged_rect->x, $initial_rect->x,
+     'Client-initiated drag with no button moved the floating window');
+$x->root->warp_pointer(400, 400);
+sync_with_i3;
+($after_motion_rect) = $A->rect;
+is_deeply($after_motion_rect, $dragged_rect,
+          'Client-initiated drag with no button ends on a button release');
 
 ###############################################################################
 # Drag tiling container onto an empty workspace.


### PR DESCRIPTION
Fixes #6609

- rejects nested drag loops
- ignores unrelated presses/releases during a drag
- ends drag when the initiating button is released
- preserves initiating EWMH button in synthetic event
- adds regression test coverage

I've been using this patched build for about a month and haven't had the "teleporting windows" issue occur since.
Another user has tested the commits on i3 4.25.1 and confirmed the issue seems resolved: https://github.com/i3/i3/issues/6609#issuecomment-5239897354

used gpt-5.6-sol to track down and fix this issue